### PR TITLE
add support to preserve users refs when discretizing an implicit function

### DIFF
--- a/src/common/hash.c
+++ b/src/common/hash.c
@@ -116,7 +116,7 @@ int _MMG5_mmgHashTria(MMG5_pMesh mesh, int *adjt, _MMG5_Hash *hash, int chkISO) 
           }
           /* non-manifold case */
           else if ( adja[i] != 3*jel+j ) {
-            if ( chkISO && ( (pt->ref == MG_ISO) || (pt->ref < 0)) ) {
+            if ( chkISO && ( isMG_ISO(pt->ref) || (pt->ref < 0)) ) {
               lel = adjt[3*(jel-1)+1+j]/3;
               l   = adjt[3*(jel-1)+1+j]%3;
               adjt[3*(lel-1)+1+l] = 0;

--- a/src/common/inout.c
+++ b/src/common/inout.c
@@ -577,7 +577,7 @@ int MMG5_loadMshMesh_part2(MMG5_pMesh mesh,MMG5_pSol sol,FILE **inm,
           pa->tag |= MG_REF;
         }
         else {
-          if ( abs(ref)!= MG_ISO ) {
+          if ( !isMG_ISO(abs(ref))  ) {
             pa = &mesh->edge[++na];
             fscanf((*inm),"%d %d ",&pa->a,&pa->b);
             pa->ref = abs(ref);
@@ -599,7 +599,7 @@ int MMG5_loadMshMesh_part2(MMG5_pMesh mesh,MMG5_pSol sol,FILE **inm,
           ptt->ref = abs(ref);
         }
         else {
-          if ( abs(ref)!= MG_ISO ) {
+          if ( !isMG_ISO(abs(ref))  ) {
             ptt = &mesh->tria[++nt];
             fscanf((*inm),"%d %d %d",&ptt->v[0],&ptt->v[1],&ptt->v[2]);
             ptt->ref = abs(ref);
@@ -709,7 +709,7 @@ int MMG5_loadMshMesh_part2(MMG5_pMesh mesh,MMG5_pSol sol,FILE **inm,
             pa->tag |= MG_REF;
           }
           else {
-            if( abs(ref)!= MG_ISO ) {
+            if( !isMG_ISO(abs(ref))   ) {
               pa = &mesh->edge[++na];
               fread(&pa->a,sw,1,(*inm));
               fread(&pa->b,sw,1,(*inm));
@@ -768,7 +768,7 @@ int MMG5_loadMshMesh_part2(MMG5_pMesh mesh,MMG5_pSol sol,FILE **inm,
             ptt->ref = abs(ref);
           }
           else {
-            if( abs(ref)!= MG_ISO ) {
+            if( !isMG_ISO(abs(ref)) ) {
               ptt = &mesh->tria[++nt];
               for ( i=0; i<3 ; ++i ) {
                 fread(&l,sw,1,(*inm));
@@ -1041,7 +1041,7 @@ int MMG5_loadMshMesh_part2(MMG5_pMesh mesh,MMG5_pSol sol,FILE **inm,
         }
 
         /* Set the elements references to 0 in iso mode */
-        if ( mesh->info.iso )  pt->ref = 0;
+        //if ( mesh->info.iso )  pt->ref = 0;
 
         /* Possibly switch 2 vertices number so that each tet is positively oriented */
         if ( _MMG5_orvol(mesh->point,pt->v) < 0.0 ) {

--- a/src/common/libmmgtypes.h
+++ b/src/common/libmmgtypes.h
@@ -57,7 +57,25 @@
  * Implicite domain ref in iso mode
  *
  */
-#define MG_ISO    10
+#define MG_ISO_    8
+
+static inline char isMG_ISO(const unsigned ref ){
+  
+  const char b0 = ref % 2;
+  const char b1 = (ref/2) % 2;
+  const char b2 = (ref/4) % 2;
+  const char b3 = (ref/8) % 2;
+  if( b3) return 1;
+  return 0;
+};
+
+static inline char setMG_ISO(unsigned* ref ){
+  
+  if( isMG_ISO(*ref)) return ;
+  *ref += MG_ISO_;
+};
+
+
 
 #include <stdarg.h>
 

--- a/src/common/mmgcommon.h.in
+++ b/src/common/mmgcommon.h.in
@@ -70,8 +70,45 @@ extern "C" {
 #define _MMG5_MEMMAX  800
 
 /* Domain refs in iso mode */
-#define MG_PLUS    2
-#define MG_MINUS   3
+#define MG_PLUS_    2
+#define MG_MINUS_   4
+
+static inline char isMG_PLUS(const unsigned ref ){
+  
+  const char b0 = ref % 2;
+  const char b1 = (ref/2) % 2;
+  if( b1) return 1;
+  return 0;
+};
+
+
+
+static inline char isMG_MINUS(const unsigned ref ){
+  
+  const char b0 = ref % 2;
+  const char b1 = (ref/2) % 2;
+  const char b2 = (ref/4) % 2;
+  if( b2) return 1;
+  return 0;
+};
+
+static inline void setMG_PLUS(unsigned* ref){
+  if (isMG_PLUS(*ref)) return;
+  if (isMG_MINUS(*ref)){
+    *ref -= MG_MINUS_;
+  };
+  *ref += MG_PLUS_;
+};
+
+static inline void setMG_MINUS(unsigned* ref){
+  if (isMG_MINUS(*ref)) return;
+  if (isMG_PLUS(*ref)){
+    *ref -= MG_PLUS_;
+  };
+  *ref += MG_MINUS_;
+};
+
+
 
 /* numerical accuracy */
 #define _MMG5_ANGEDG    0.707106781186548   /*0.573576436351046 */

--- a/src/mmg3d/API_functions_3d.c
+++ b/src/mmg3d/API_functions_3d.c
@@ -1545,20 +1545,20 @@ int _MMG3D_skipIso(MMG5_pMesh mesh) {
   int    k;
 
   if ( (mesh->info.imprim > 5) || mesh->info.ddebug )
-    fprintf(stdout,"  ## Warning: skip of all entites with %d reference.\n",MG_ISO);
+    fprintf(stdout,"  ## Warning: skip of all entites with %d reference.\n", MG_ISO_);
 
   /* Skip triangles with MG_ISO refs */
   k = 1;
   do {
     ptt = &mesh->tria[k];
-    if ( abs(ptt->ref) != MG_ISO ) continue;
+    if ( !isMG_ISO(abs(ptt->ref))  ) continue;
     /* here ptt is the first tri of mesh->tria that we want to delete */
     do {
       ptt1 = &mesh->tria[mesh->nti];
     }
-    while( (abs(ptt1->ref) == MG_ISO) && (k <= --mesh->nti) );
+    while( isMG_ISO(abs(ptt1->ref)) && (k <= --mesh->nti) );
 
-    if ( abs(ptt1->ref) != MG_ISO )
+    if ( !isMG_ISO(abs(ptt1->ref))  )
       /* ptt1 is the last tri of mesh->tria that we want to keep */
       memcpy(ptt,ptt1,sizeof(MMG5_Tria));
   } while( ++k <= mesh->nti );
@@ -1577,7 +1577,7 @@ int _MMG3D_skipIso(MMG5_pMesh mesh) {
   k = 1;
   do {
     pa = &mesh->edge[k];
-    if ( abs(pa->ref) != MG_ISO ) {
+    if ( !isMG_ISO(abs(pa->ref))  ) {
       pa->ref = abs(pa->ref);
       continue;
     }
@@ -1585,9 +1585,9 @@ int _MMG3D_skipIso(MMG5_pMesh mesh) {
     do {
       pa1 = &mesh->edge[mesh->nai];
     }
-    while( (abs(pa1->ref) == MG_ISO) && (k <= --mesh->nai) );
+    while( isMG_ISO(abs(pa1->ref) ) && (k <= --mesh->nai) );
 
-    if ( abs(pa1->ref) != MG_ISO ) {
+    if ( !isMG_ISO(abs(pa1->ref))  ) {
       /* pa1 is the last edge of mesh->edge that we want to keep */
       memcpy(pa,pa1,sizeof(MMG5_Edge));
       pa1->ref = abs(pa1->ref);

--- a/src/mmg3d/analys_3d.c
+++ b/src/mmg3d/analys_3d.c
@@ -579,7 +579,7 @@ static void _MMG5_nmgeom(MMG5_pMesh mesh){
           if ( p0->ref != 0 )
             p0->ref = -abs(p0->ref);
           else
-            p0->ref = MG_ISO;
+            setMG_ISO(&(p0->ref));
         }
         else {
           if ( !p0->xp ) {

--- a/src/mmg3d/colver_3d.c
+++ b/src/mmg3d/colver_3d.c
@@ -469,8 +469,8 @@ int _MMG5_chkcol_bdy(MMG5_pMesh mesh,MMG5_pSol met,int k,char iface,
     ipp = listv[l] % 4;
     pt  = &mesh->tetra[iel];
 
-    if ( pt->ref == MG_MINUS ) isminp = 1;
-    else if ( pt->ref == MG_PLUS ) isplp = 1;
+    if ( isMG_MINUS(pt->ref)   ) isminp = 1;
+    else if ( isMG_PLUS(pt->ref) ) isplp = 1;
 
     /* Topological test for tetras of the shell */
     for (iq=0; iq<4; iq++)
@@ -511,9 +511,9 @@ int _MMG5_chkcol_bdy(MMG5_pMesh mesh,MMG5_pSol met,int k,char iface,
 
     /* Volume test for tetras outside the shell */
     if ( mesh->info.iso ) {
-      if ( !ndepmin && pt->ref == MG_MINUS )
+      if ( !ndepmin && isMG_MINUS(pt->ref)   )
         ndepmin = iel;
-      else if ( !ndepplus && pt->ref == MG_PLUS )
+      else if ( !ndepplus && isMG_PLUS(pt->ref)   )
         ndepplus = iel;
     }
 

--- a/src/mmg3d/hash_3d.c
+++ b/src/mmg3d/hash_3d.c
@@ -1134,7 +1134,11 @@ int _MMG5_hGeom(MMG5_pMesh mesh) {
         if ( !kk || pt->tag[i] & MG_NOM ) {
           if ( pt->tag[i] & MG_NOM ) {
             if ( mesh->info.iso )
-              pt->edg[i] = ( pt->edg[i] != 0 ) ?  -abs(pt->edg[i]) : MG_ISO;
+	      if ( pt->edg[i] != 0 && !isMG_ISO(pt->ref) ){
+		pt->edg[i] =  -abs(pt->edg[i]) ;
+	      }else {
+		setMG_ISO(&(pt->edg[i]));
+	      }
           }
           _MMG5_hEdge(mesh,pt->v[i1],pt->v[i2],pt->edg[i],pt->tag[i]);
         }
@@ -1238,7 +1242,7 @@ int _MMG5_bdryTria(MMG5_pMesh mesh, int ntmesh) {
           if ( pxt->tag[_MMG5_iarf[i][2]] )  ptt->tag[2] = pxt->tag[_MMG5_iarf[i][2]];
         }
         if ( adj ) {
-          if ( mesh->info.iso ) ptt->ref = MG_ISO;
+          if ( mesh->info.iso  && ( isMG_PLUS(pt->ref) != isMG_PLUS(pt1->ref) ) ) setMG_ISO(&(ptt->ref));
           /* useful only when saving mesh */
           else ptt->ref  = pxt ? pxt->ref[i] : MG_MIN(pt->ref,pt1->ref);
         }
@@ -1326,7 +1330,7 @@ int _MMG5_bdryTria(MMG5_pMesh mesh, int ntmesh) {
           if ( pxpr->tag[_MMG5_iarf_pr[i][2]] )  ptt->tag[2] = pxpr->tag[_MMG5_iarf_pr[i][2]];
         }
         if ( adj ) {
-          if ( mesh->info.iso ) ptt->ref = MG_ISO;
+          if ( mesh->info.iso ) setMG_ISO(&(ptt->ref));
           /* useful only when saving mesh */
           else ptt->ref  = pxpr ? pxpr->ref[i] : 0;
         }
@@ -1692,7 +1696,7 @@ int _MMG5_bdrySet(MMG5_pMesh mesh) {
       else  MG_SET(pxt->ori,i);
       /* Set edge tag */
       if ( pxt->ftag[i] ) {
-        if ( adj && (pt->ref <= pt1->ref || (pt->ref == MG_PLUS)) ) {
+        if ( adj && (pt->ref <= pt1->ref || (isMG_PLUS(pt->ref)  )) ) {
           continue;
         }
         else {
@@ -1891,7 +1895,7 @@ int _MMG5_bdryPerm(MMG5_pMesh mesh) {
     for (i=0; i<4; i++) {
       adj = adja[i] / 4;
       pt1 = &mesh->tetra[adj];
-      if ( adj && (pt->ref <= pt1->ref || pt->ref == MG_PLUS) )
+      if ( adj && (pt->ref <= pt1->ref || isMG_PLUS(pt->ref)  ) )
         continue;
       ia = pt->v[_MMG5_idir[i][0]];
       ib = pt->v[_MMG5_idir[i][1]];

--- a/src/mmg3d/inout_3d.c
+++ b/src/mmg3d/inout_3d.c
@@ -513,7 +513,7 @@ int MMG3D_loadMesh(MMG5_pMesh mesh,const char *filename) {
           fread(&ref,sw,1,inm);
           if(iswp) ref=_MMG5_swapbin(ref);
         }
-        if( abs(ref) != MG_ISO ) {
+        if( !isMG_ISO(abs(ref))  ) {
           pt1 = &mesh->tria[++mesh->nt];
           pt1->v[0] = v[0];
           pt1->v[1] = v[1];
@@ -653,7 +653,7 @@ int MMG3D_loadMesh(MMG5_pMesh mesh,const char *filename) {
       }
       pa->tag |= MG_REF;
       if ( mesh->info.iso ) {
-        if( abs(pa->ref) != MG_ISO ) {
+        if( !isMG_ISO(abs(pa->ref)) ) {
           ++mesh->na;
           pa->ref = abs(pa->ref);
           memmove(&mesh->edge[mesh->na],&mesh->edge[k],sizeof(MMG5_Edge));
@@ -761,7 +761,7 @@ int MMG3D_loadMesh(MMG5_pMesh mesh,const char *filename) {
       ppt->tag &= ~MG_NUL;
     }
 
-    if ( mesh->info.iso )  pt->ref = 0;
+    //if ( mesh->info.iso )  pt->ref = 0;
 
     /* Possibly switch 2 vertices number so that each tet is positively oriented */
     if ( _MMG5_orvol(mesh->point,pt->v) < 0.0 ) {

--- a/src/mmg3d/mmg3d2.c
+++ b/src/mmg3d/mmg3d2.c
@@ -619,11 +619,13 @@ static int _MMG3D_setref_ls(MMG5_pMesh mesh, MMG5_pSol sol) {
     assert(nz < 4);
     if ( npls ) {
       assert(!nmns);
-      pt->ref = MG_PLUS;
+      //pt->ref = MG_PLUS;
+      setMG_PLUS(&(pt->ref)) ;
     }
     else {
       assert(nmns);
-      pt->ref = MG_MINUS;
+      //pt->ref = MG_MINUS;
+      setMG_MINUS(&(pt->ref)) ;
     }
   }
   return(1);
@@ -895,8 +897,8 @@ int _MMG5_chkmanicoll(MMG5_pMesh mesh,int k,int iface,int iedg,int ndepmin,int n
     assert( ilist < MMG3D_LMAX+2 );
     pt->flag = base;
 
-    if ( pt->ref == MG_MINUS ) isminq = 1;
-    else if ( pt->ref == MG_PLUS ) isplq = 1;
+    if ( isMG_MINUS(pt->ref) ) isminq = 1;
+    else if ( isMG_PLUS(pt->ref)  ) isplq = 1;
 
     cur = 0;
     while( cur < ilist ) {
@@ -912,8 +914,8 @@ int _MMG5_chkmanicoll(MMG5_pMesh mesh,int k,int iface,int iedg,int ndepmin,int n
         jel /= 4;
         pt1 = &mesh->tetra[jel];
 
-        if ( pt1->ref == MG_MINUS ) isminq = 1;
-        else if ( pt1->ref == MG_PLUS ) isplq = 1;
+        if ( isMG_MINUS(pt1->ref)  ) isminq = 1;
+        else if ( isMG_PLUS(pt1->ref)  ) isplq = 1;
 
         if ( pt1->flag == base ) continue;
         pt1->flag = base;
@@ -927,12 +929,12 @@ int _MMG5_chkmanicoll(MMG5_pMesh mesh,int k,int iface,int iedg,int ndepmin,int n
         ilist++;
 
         /* check if jel is an available starting tetra for further enumeration */
-        if ( !ndeppq && pt1->ref == MG_PLUS ) {
+        if ( !ndeppq && isMG_PLUS(pt1->ref)  ) {
           for(ip=0; ip<4; ip++)
             if ( pt1->v[ip] == nump ) break;
           if( ip == 4 ) ndeppq = jel;
         }
-        if( !ndepmq && pt1->ref == MG_MINUS ) {
+        if( !ndepmq && isMG_MINUS(pt1->ref)  ) {
           for(ip=0; ip<4; ip++)
             if ( pt1->v[ip] == nump ) break;
           if( ip == 4 ) ndepmq = jel;

--- a/src/mmg3d/swap_3d.c
+++ b/src/mmg3d/swap_3d.c
@@ -88,7 +88,7 @@ int _MMG5_chkswpbdy(MMG5_pMesh mesh, MMG5_pSol met, int *list,int ilist,
     for (k=0; k<ilist; k++) {
       iel = list[k] / 6;
       pt = &mesh->tetra[iel];
-      if ( pt->ref == MG_MINUS )
+      if ( isMG_MINUS(pt->ref) )
         nminus++;
       else
         nplus++;

--- a/src/mmgs/inout_s.c
+++ b/src/mmgs/inout_s.c
@@ -506,7 +506,7 @@ int MMGS_loadMesh(MMG5_pMesh mesh, const char *filename) {
           fread(&ref,sw,1,inm);
           if(iswp) ref=swapbin(ref);
         }
-        if ( abs(ref) != MG_ISO ) {
+        if (  !isMG_ISO(abs(ref)) ) {
           ped = &mesh->edge[++mesh->na];
           ped->a   = a;
           ped->b   = b;

--- a/src/mmgs/mmgs2.c
+++ b/src/mmgs/mmgs2.c
@@ -224,7 +224,7 @@ int _MMGS_chkmaniball(MMG5_pMesh mesh, int start, char istart) {
   i = istart;
 
   i1 = _MMG5_iprv2[i];
-  assert( MG_EDG(pt->tag[i1]) && (pt->edg[i1]==MG_ISO) );
+  assert( MG_EDG(pt->tag[i1]) && ( isMG_ISO(pt->edg[i1]) ) );
 
   /* First travel, while another part of the implicit boundary is not met */
   do {
@@ -234,7 +234,7 @@ int _MMGS_chkmaniball(MMG5_pMesh mesh, int start, char istart) {
     k = adja[i1] / 3;
     i = adja[i1] % 3;
 
-    if ( !k || mesh->tria[k].edg[i]==MG_ISO ) break;
+    if ( !k ||  isMG_ISO(mesh->tria[k].edg[i]) ) break;
 
     i = _MMG5_inxt2[i];
   }
@@ -265,7 +265,7 @@ int _MMGS_chkmaniball(MMG5_pMesh mesh, int start, char istart) {
       k = adja[i1] / 3;
       i = adja[i1] % 3;
 
-      if ( (!k) || mesh->tria[k].edg[i]==MG_ISO ) break;
+      if ( (!k) || isMG_ISO(mesh->tria[k].edg[i]) ) break;
 
       i = _MMG5_iprv2[i];
     }
@@ -285,7 +285,7 @@ int _MMGS_chkmaniball(MMG5_pMesh mesh, int start, char istart) {
     k = adja[i1] / 3;
     i = adja[i1] % 3;
 
-    if ( (!k) || mesh->tria[k].edg[i]==MG_ISO ) break;
+    if ( (!k) || isMG_ISO(mesh->tria[k].edg[i]) ) break;
 
     i = _MMG5_inxt2[i];
   }
@@ -327,7 +327,7 @@ int _MMGS_chkmanimesh(MMG5_pMesh mesh) {
         continue;
       }
       else {
-        if ( pt->edg[i] == MG_ISO ) cnt++;
+        if ( isMG_ISO(pt->edg[i]) ) cnt++;
       }
     }
     if( cnt == 3 ) {
@@ -347,7 +347,7 @@ int _MMGS_chkmanimesh(MMG5_pMesh mesh) {
       adja = &mesh->adja[3*(k-1)+1];
       iel = adja[i] / 3;
 
-      if ( (!iel) || (pt->edg[i] != MG_ISO) ) continue;
+      if ( (!iel) || !isMG_ISO(pt->edg[i] ) ) continue;
 
       i1 = _MMG5_inxt2[i];
       if ( !_MMGS_chkmaniball(mesh,k,i1) )
@@ -532,11 +532,11 @@ static int _MMGS_setref_ls(MMG5_pMesh mesh, MMG5_pSol sol) {
       /* Keep the initial triangle references of the mesh */
       if ( npls ) {
         assert(!nmns);
-        pt->ref = MG_PLUS;
+        setMG_PLUS(&(pt->ref));
       }
       else {
         assert(nmns);
-        pt->ref = MG_MINUS;
+        setMG_MINUS(&(pt->ref));
       }
     }
 
@@ -548,7 +548,7 @@ static int _MMGS_setref_ls(MMG5_pMesh mesh, MMG5_pSol sol) {
         v   = sol->m[ip] -mesh->info.ls;
         v1  = sol->m[ip1]-mesh->info.ls;
         if ( v == 0.0 && v1 == 0.0) {
-          pt->edg[i]  = MG_ISO;
+          setMG_ISO(&(pt->edg[i]));
           pt->tag[i] |= MG_REF;
         }
       }


### PR DESCRIPTION
Two main changes:

change name of  MG_ISO to MG_ISO_ (so no more use of the old variable is possible)
same thing for  MG_PLUS_ and MG_MINUS

then define function on/off the correct bit of the refs.

the user ref must be multiplied by 16 before using this patch.
In this way the user refs are preserved when  discretizing an implicit function .

 