### PR TITLE
Jenkinsfile for pipeline builds in a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Customize the official Debian container to allow Pipeline building of MMG
+# David Sherman 2017-02-07
+
+FROM debian
+
+USER root
+
+## Standard build tools
+RUN apt-get update && \
+    apt-get install -y sudo build-essential git cmake doxygen
+
+## Optional module Scotch
+RUN apt-get install -y curl zlib1g-dev
+RUN curl -O http://gforge.inria.fr/frs/download.php/latestfile/298/scotch_6.0.4.tar.gz && \
+    tar xzf scotch_6.0.4.tar.gz && \
+    ( cd scotch_6.0.4/src && \
+      ln -s Make.inc/Makefile.inc.x86-64_pc_linux2 Makefile.inc && \
+      make scotch prefix=/usr && make install ) && \
+    rm -rf scotch_6.0.4.tar.gz scotch_6.0.4
+
+## Optional module LinearElasticity
+RUN git clone https://github.com/ICStoolbox/Commons.git && \
+    mkdir -p Commons/build && \
+    ( cd Commons/build && HOME=/usr cmake .. && make && make install ) && \
+    git clone https://github.com/ICStoolbox/LinearElasticity.git && \
+    mkdir -p LinearElasticity/build && \
+    ( cd LinearElasticity/build && HOME=/usr cmake .. && make && make install ) && \
+    rm -rf Commons LinearElasticity

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,46 @@
+#!groovy
+
+// Jenkinsfile for compiling, testing, and packaging MMG
+
+
+pipeline {
+    agent {
+        dockerfile true
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+                sh 'mkdir -p build local'
+            }
+        }
+        stage('Compile') {
+            steps {
+                sh '''
+                	cd build &&
+                	cmake -D CMAKE_BUILD_TYPE=Debug -D BUILD_TESTING=ON .. &&
+                	make
+                '''
+            }
+        }
+        stage('Test') {
+            steps {
+                sh '''
+                	cd build &&
+                	ctest
+                '''
+            }
+        }
+        stage('Package') {
+            steps {
+                sh '''
+                	cd build &&
+                	cmake -D CMAKE_BUILD_TYPE=Release -D BUILD_TESTING=OFF -D CMAKE_INSTALL_PREFIX:PATH=$PWD/../local ..
+                	make
+                	make install
+                '''
+								archiveArtifacts artifacts: 'local/**', fingerprint: true, onlyIfSuccessful: true
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `Jenkinsfile` for automated [Jenkins 2 Pipeline](https://jenkins.io/solutions/pipeline/) builds. It uses the [Declarative Pipeline](https://jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline) syntax for clarity. A Docker container is used to provide MMG's prerequisites, including the optional Scotch and Elastic modules. Jenkins will build the Docker image if necessary using the provided `Dockerfile`.

The only requirements of the Jenkins installation are that it be running Jenkins 2 with the [pipeline-model-definition](https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin) plugin  and have a Docker host build agent.

If the repository containing MMG is configured in Jenkins as a [GitHub Organization Folder](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Organization+Folder+Plugin) (see [demo](https://hub.docker.com/r/jenkinsci/pipeline-as-code-github-demo/)), then new branches and pull requests can be automatically detected and run as a separate Jenkins jobs. The results of these jobs will be sent back to GitHub and will appear as badges.

A successful pipeline run looks like this:

![mmg stage view](https://cloud.githubusercontent.com/assets/9472510/22717690/d53f9cf4-ed9c-11e6-8c49-430d72e4d2b4.png)