### PR TITLE
Travis CI build and test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: required
+
+language: cpp
+
+services:
+  - docker
+
+before_install:
+  - travis_retry docker build -t mmgtools/mmg-dev .
+
+script:
+  - |
+    docker run -v $PWD:/home/travis/src --name mmg-dev mmgtools/mmg-dev bash -c \
+      "mkdir -p $HOME/src/build && \
+       cd $HOME/src/build && \
+       cmake -D CMAKE_BUILD_TYPE=Debug -D BUILD_TESTING=ON .. && \
+       make && \
+       ctest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 
 ## Optional module Scotch
 RUN apt-get install -y curl zlib1g-dev
-RUN curl -O http://gforge.inria.fr/frs/download.php/latestfile/298/scotch_6.0.4.tar.gz && \
+RUN curl -L -O http://gforge.inria.fr/frs/download.php/latestfile/298/scotch_6.0.4.tar.gz && \
     tar xzf scotch_6.0.4.tar.gz && \
     ( cd scotch_6.0.4/src && \
       ln -s Make.inc/Makefile.inc.x86-64_pc_linux2 Makefile.inc && \


### PR DESCRIPTION
Build MMG automatically on Travis using GitHub integration.

Leverage the development image defined by the existing Dockerfile, as we do with Jenkins.

*N.B. Since Travis doesn't have a Docker image cache, we need to build the development image each time. This can lead to spurious errors on Travis's platform when **apt** times out, so we use `travis_retry` to try up to three times. If this problem persists, then a public development image on Docker Hub might be useful.*