### PR TITLE
fix wrong index in MMGS_Get_tensorSol

### DIFF
--- a/src/mmgs/API_functions_s.c
+++ b/src/mmgs/API_functions_s.c
@@ -890,7 +890,7 @@ int MMGS_Get_tensorSol(MMG5_pSol met, double *m11,double *m12, double *m13,
   *m12 = met->m[6*met->npi+1];
   *m13 = met->m[6*met->npi+2];
   *m22 = met->m[6*met->npi+3];
-  *m13 = met->m[6*met->npi+4];
+  *m23 = met->m[6*met->npi+4];
   *m33 = met->m[6*met->npi+5];
 
   return(1);


### PR DESCRIPTION
`MMGS_Get_tensorSol` was returning wrong values for two of the return variables, 