### PR TITLE
Fix linking error.

### DIFF
--- a/src/mmg3d/libmmg3d.c
+++ b/src/mmg3d/libmmg3d.c
@@ -41,6 +41,9 @@
 
 #include "inlined_functions_3d.h"
 
+/* Declared in the header, but need to define in at most one compilation unit */
+double (*MMG3D_lenedgCoor)(double *ca,double *cb,double *sa,double *sb);
+
 /**
  * Pack the mesh \a mesh and its associated metric \a met and return \a val.
  */

--- a/src/mmg3d/libmmg3d.h
+++ b/src/mmg3d/libmmg3d.h
@@ -1973,7 +1973,7 @@ int MMG3D_Get_adjaTet(MMG5_pMesh mesh,int kel, int listet[4]);
  * >   END SUBROUTINE\n
  *
  */
-double (*MMG3D_lenedgCoor)(double *ca,double *cb,double *sa,double *sb);
+extern double (*MMG3D_lenedgCoor)(double *ca,double *cb,double *sa,double *sb);
 
 /**
  * \param mesh pointer toward the mesh structure.


### PR DESCRIPTION
This is related to [this thread](https://forum.mmgtools.org/t/multiple-definition-error-linking/200).

To reproduce the problem, create a minimal project with 2 different files including mmg:

#### `foo.cpp`
```cpp
#include <mmg/libmmg.h>
```

#### `main.cpp`
```cpp
#include <mmg/libmmg.h>

int main(void) {
	return 0;
}
```

#### `CMakeLists.txt`
```cpp
cmake_minimum_required(VERSION 3.1)
project(example)

add_subdirectory(mmg)

add_executable(example foo.cpp main.cpp)
target_link_libraries(example libmmg3d_a)
```

Will produce the following linking error:
```
/usr/bin/ld: CMakeFiles/example.dir/main.cpp.o:(.bss+0x0): multiple definition of `MMG3D_lenedgCoor'; CMakeFiles/example.dir/foo.cpp.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/example.dir/build.make:101: example] Error 1
make[1]: *** [CMakeFiles/Makefile2:73: CMakeFiles/example.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```