### PR TITLE
Hide stdout in quiet mode.

### DIFF
--- a/src/mmg3d/quality_3d.c
+++ b/src/mmg3d/quality_3d.c
@@ -358,9 +358,11 @@ static int _MMG3D_printquaLES(MMG5_pMesh mesh,MMG5_pSol met) {
 
   }
 
-  fprintf(stdout,"\n  -- MESH QUALITY");
-  fprintf(stdout," (LES)");
-  fprintf(stdout,"  %d\n",mesh->ne - nex);
+  if ( mesh->info.imprim > 0 ) {
+    fprintf(stdout,"\n  -- MESH QUALITY");
+    fprintf(stdout," (LES)");
+    fprintf(stdout,"  %d\n",mesh->ne - nex);
+  }
 
 #ifndef DEBUG
   fprintf(stdout,"     BEST   %8.6f  AVRG.   %8.6f  WRST.   %8.6f (%d)\n",
@@ -460,18 +462,20 @@ int _MMG3D_inqua(MMG5_pMesh mesh,MMG5_pSol met) {
     his[ir] += 1;
   }
 
-  fprintf(stdout,"\n  -- MESH QUALITY");
-  fprintf(stdout,"  %d\n",mesh->ne - nex);
+  if ( mesh->info.imprim > 0 ) {
+    fprintf(stdout,"\n  -- MESH QUALITY");
+    fprintf(stdout,"  %d\n",mesh->ne - nex);
 
 #ifndef DEBUG
-  fprintf(stdout,"     BEST   %8.6f  AVRG.   %8.6f  WRST.   %8.6f (%d)\n",
-          rapmax,rapavg / (mesh->ne-nex),rapmin,iel);
+    fprintf(stdout,"     BEST   %8.6f  AVRG.   %8.6f  WRST.   %8.6f (%d)\n",
+           rapmax,rapavg / (mesh->ne-nex),rapmin,iel);
 #else
-  fprintf(stdout,"     BEST   %e  AVRG.   %e  WRST.   %e (%d)\n => %d %d %d %d\n",
-          rapmax,rapavg / (mesh->ne-nex),rapmin,iel,
-          _MMG3D_indPt(mesh,mesh->tetra[iel].v[0]),_MMG3D_indPt(mesh,mesh->tetra[iel].v[1]),
-          _MMG3D_indPt(mesh,mesh->tetra[iel].v[2]),_MMG3D_indPt(mesh,mesh->tetra[iel].v[3]));
+    fprintf(stdout,"     BEST   %e  AVRG.   %e  WRST.   %e (%d)\n => %d %d %d %d\n",
+            rapmax,rapavg / (mesh->ne-nex),rapmin,iel,
+            _MMG3D_indPt(mesh,mesh->tetra[iel].v[0]),_MMG3D_indPt(mesh,mesh->tetra[iel].v[1]),
+            _MMG3D_indPt(mesh,mesh->tetra[iel].v[2]),_MMG3D_indPt(mesh,mesh->tetra[iel].v[3]));
 #endif
+  }
 
   if ( mesh->info.imprim >= 3 ) {
     /* print histo */
@@ -561,18 +565,20 @@ int _MMG3D_outqua(MMG5_pMesh mesh,MMG5_pSol met) {
     his[ir] += 1;
   }
 
-  fprintf(stdout,"\n  -- MESH QUALITY");
-  fprintf(stdout,"  %d\n",mesh->ne - nex);
+  if ( mesh->info.imprim > 0 ) {
+    fprintf(stdout,"\n  -- MESH QUALITY");
+    fprintf(stdout,"  %d\n",mesh->ne - nex);
 
 #ifndef DEBUG
-  fprintf(stdout,"     BEST   %8.6f  AVRG.   %8.6f  WRST.   %8.6f (%d)\n",
-          rapmax,rapavg / (mesh->ne-nex),rapmin,iel);
+    fprintf(stdout,"     BEST   %8.6f  AVRG.   %8.6f  WRST.   %8.6f (%d)\n",
+            rapmax,rapavg / (mesh->ne-nex),rapmin,iel);
 #else
-  fprintf(stdout,"     BEST   %e  AVRG.   %e  WRST.   %e (%d)\n => %d %d %d %d\n",
-          rapmax,rapavg / (mesh->ne-nex),rapmin,iel,
-          _MMG3D_indPt(mesh,mesh->tetra[iel].v[0]),_MMG3D_indPt(mesh,mesh->tetra[iel].v[1]),
-          _MMG3D_indPt(mesh,mesh->tetra[iel].v[2]),_MMG3D_indPt(mesh,mesh->tetra[iel].v[3]));
+    fprintf(stdout,"     BEST   %e  AVRG.   %e  WRST.   %e (%d)\n => %d %d %d %d\n",
+            rapmax,rapavg / (mesh->ne-nex),rapmin,iel,
+           _MMG3D_indPt(mesh,mesh->tetra[iel].v[0]),_MMG3D_indPt(mesh,mesh->tetra[iel].v[1]),
+           _MMG3D_indPt(mesh,mesh->tetra[iel].v[2]),_MMG3D_indPt(mesh,mesh->tetra[iel].v[3]));
 #endif
+  }
 
   if ( abs(mesh->info.imprim) >= 3 ){
 

--- a/src/mmgs/libmmgs.c
+++ b/src/mmgs/libmmgs.c
@@ -250,9 +250,11 @@ int MMGS_mmgsls(MMG5_pMesh mesh,MMG5_pSol met)
   mytime    ctim[TIMEMAX];
   char      stim[32];
 
-  fprintf(stdout,"  -- MMGS, Release %s (%s) \n",MG_VER,MG_REL);
-  fprintf(stdout,"     %s\n",MG_CPY);
-  fprintf(stdout,"     %s %s\n",__DATE__,__TIME__);
+  if ( mesh->info.imprim ) {
+    fprintf(stdout,"  -- MMGS, Release %s (%s) \n",MG_VER,MG_REL);
+    fprintf(stdout,"     %s\n",MG_CPY);
+    fprintf(stdout,"     %s %s\n",__DATE__,__TIME__);
+  }
 
   _MMGS_Set_commonFunc();
 
@@ -402,9 +404,11 @@ int MMGS_mmgslib(MMG5_pMesh mesh,MMG5_pSol met)
   mytime    ctim[TIMEMAX];
   char      stim[32];
 
-  fprintf(stdout,"  -- MMGS, Release %s (%s) \n",MG_VER,MG_REL);
-  fprintf(stdout,"     %s\n",MG_CPY);
-  fprintf(stdout,"     %s %s\n",__DATE__,__TIME__);
+  if ( mesh->info.imprim ) {
+    fprintf(stdout,"  -- MMGS, Release %s (%s) \n",MG_VER,MG_REL);
+    fprintf(stdout,"     %s\n",MG_CPY);
+    fprintf(stdout,"     %s %s\n",__DATE__,__TIME__);
+  }
 
   _MMGS_Set_commonFunc();
 

--- a/src/mmgs/quality_s.c
+++ b/src/mmgs/quality_s.c
@@ -422,9 +422,11 @@ int _MMGS_inqua(MMG5_pMesh mesh,MMG5_pSol met) {
     his[ir] += 1;
   }
 
-  fprintf(stdout,"\n  -- MESH QUALITY   %d\n",mesh->nt - nex);
-  fprintf(stdout,"     BEST   %8.6f  AVRG.   %8.6f  WRST.   %8.6f (%d)\n",
-          rapmax,rapavg / (mesh->nt-nex),rapmin,iel);
+  if ( mesh->info.imprim > 0 ) {
+    fprintf(stdout,"\n  -- MESH QUALITY   %d\n",mesh->nt - nex);
+    fprintf(stdout,"     BEST   %8.6f  AVRG.   %8.6f  WRST.   %8.6f (%d)\n",
+            rapmax,rapavg / (mesh->nt-nex),rapmin,iel);
+  }
 
   if ( abs(mesh->info.imprim) >= 3 ){
 
@@ -484,9 +486,11 @@ int _MMGS_outqua(MMG5_pMesh mesh,MMG5_pSol met) {
     his[ir] += 1;
   }
 
-  fprintf(stdout,"\n  -- MESH QUALITY   %d\n",mesh->nt - nex);
-  fprintf(stdout,"     BEST   %8.6f  AVRG.   %8.6f  WRST.   %8.6f (%d)\n",
-          rapmax,rapavg / (mesh->nt-nex),rapmin,iel);
+  if ( mesh->info.imprim > 0 ) {
+    fprintf(stdout,"\n  -- MESH QUALITY   %d\n",mesh->nt - nex);
+    fprintf(stdout,"     BEST   %8.6f  AVRG.   %8.6f  WRST.   %8.6f (%d)\n",
+            rapmax,rapavg / (mesh->nt-nex),rapmin,iel);
+  }
 
   if ( abs(mesh->info.imprim) >= 3 ){
     /* print histo */


### PR DESCRIPTION
Mmg is still a bit verbose even when called with the `-v 0`. This PR fixes that for `mmgs` and `mmg3d`, but I admittedly haven't looked at `mmg2d`.