### PR TITLE
[Windows] __attribute__ does not compile

### DIFF
--- a/src/mmg2d/velextls_2d.c
+++ b/src/mmg2d/velextls_2d.c
@@ -382,8 +382,14 @@ int _MMG2_velextLS(MMG5_pMesh mesh,MMG5_pSol disp) {
  * Hack to avoid to have an empty translation unit (forbidden by ISO C)
  *
  */
+#ifdef _WIN32
+void MMG2D_unused_function(void) {
+  return;
+}
+#else
 void __attribute__((unused)) MMG2D_unused_function(void) {
   return;
 }
+#endif
 
 #endif

--- a/src/mmg3d/velextls_3d.c
+++ b/src/mmg3d/velextls_3d.c
@@ -433,8 +433,14 @@ int _MMG5_velextLS(MMG5_pMesh mesh,MMG5_pSol disp) {
  * Hack to avoid to have an empty translation unit (forbidden by ISO C)
  *
  */
-static void __attribute__((unused))MMG3D_unused_function(void) {
+#ifdef _WIN32
+void MMG3D_unused_function(void) {
   return;
 }
+#else
+void __attribute__((unused)) MMG3D_unused_function(void) {
+  return;
+}
+#endif
 
 #endif


### PR DESCRIPTION
Hi,

We're using the develop branch for Linux, Mac and Windows compilation. Since few days (and this commit https://github.com/MmgTools/mmg/commit/aae3963263db68aca982a2bcd5a2a753be7780d8 ) we can't compile on Windows.

I found a way to compile, and here is the patch. It can be interesting for you, and it's easier for us also.

If you see a better way to code this debug, do not hesitate :)

The MUSIC team (Inria - IHU Liryc)