### PR TITLE
Add extern declarations as necessary

### DIFF
--- a/src/common/mmgcommon.h.in
+++ b/src/common/mmgcommon.h.in
@@ -625,20 +625,20 @@ void MMG5_gradEigenvreq(double *dm,double *dn,double,int8_t,int8_t *);
 int  MMG5_updatemetreq_ani(double *n,double dn[2],double vp[2][2]);
 
 /* function pointers */
-int    (*MMG5_chkmsh)(MMG5_pMesh,int,int);
-int    (*MMG5_bezierCP)(MMG5_pMesh ,MMG5_Tria *,MMG5_pBezier ,char );
-double (*MMG5_lenSurfEdg)(MMG5_pMesh mesh,MMG5_pSol sol ,int ,int, char );
-int    (*MMG5_grad2met_ani)(MMG5_pMesh,MMG5_pSol,MMG5_pTria,int,int);
-int    (*MMG5_grad2metreq_ani)(MMG5_pMesh,MMG5_pSol,MMG5_pTria,int,int);
-int    (*MMG5_compute_meanMetricAtMarkedPoints)( MMG5_pMesh,MMG5_pSol);
+extern int    (*MMG5_chkmsh)(MMG5_pMesh,int,int);
+extern int    (*MMG5_bezierCP)(MMG5_pMesh ,MMG5_Tria *,MMG5_pBezier ,char );
+extern double (*MMG5_lenSurfEdg)(MMG5_pMesh mesh,MMG5_pSol sol ,int ,int, char );
+extern int    (*MMG5_grad2met_ani)(MMG5_pMesh,MMG5_pSol,MMG5_pTria,int,int);
+extern int    (*MMG5_grad2metreq_ani)(MMG5_pMesh,MMG5_pSol,MMG5_pTria,int,int);
+extern int    (*MMG5_compute_meanMetricAtMarkedPoints)( MMG5_pMesh,MMG5_pSol);
 
 
 /* useful functions to debug */
-int  (*MMG5_indElt)(MMG5_pMesh mesh,int kel);
-int  (*MMG5_indPt)(MMG5_pMesh mesh,int kp);
+extern int  (*MMG5_indElt)(MMG5_pMesh mesh,int kel);
+extern int  (*MMG5_indPt)(MMG5_pMesh mesh,int kp);
 
 #ifdef USE_SCOTCH
-int    (*MMG5_renumbering)(int vertBoxNbr, MMG5_pMesh mesh, MMG5_pSol sol);
+extern int    (*MMG5_renumbering)(int vertBoxNbr, MMG5_pMesh mesh, MMG5_pSol sol);
 #endif
 
 void   MMG5_Set_commonFunc();

--- a/src/common/mmgexterns.c
+++ b/src/common/mmgexterns.c
@@ -1,0 +1,37 @@
+/* =============================================================================
+**  This file is part of the mmg software package for the tetrahedral
+**  mesh modification.
+**  Copyright (c) Bx INP/Inria/UBordeaux/UPMC, 2004- .
+**
+**  mmg is free software: you can redistribute it and/or modify it
+**  under the terms of the GNU Lesser General Public License as published
+**  by the Free Software Foundation, either version 3 of the License, or
+**  (at your option) any later version.
+**
+**  mmg is distributed in the hope that it will be useful, but WITHOUT
+**  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+**  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+**  License for more details.
+**
+**  You should have received a copy of the GNU Lesser General Public
+**  License and of the GNU General Public License along with mmg (in
+**  files COPYING.LESSER and COPYING). If not, see
+**  <http://www.gnu.org/licenses/>. Please read their terms carefully and
+**  use this copy of the mmg distribution only if you accept them.
+** =============================================================================
+*/
+
+#include "mmgcommon.h"
+
+
+int  (*MMG5_chkmsh)(MMG5_pMesh,int,int);
+int  (*MMG5_bezierCP)(MMG5_pMesh ,MMG5_Tria *,MMG5_pBezier ,char );
+double (*MMG5_lenSurfEdg)(MMG5_pMesh mesh,MMG5_pSol sol ,int ,int, char );
+int  (*MMG5_indElt)(MMG5_pMesh mesh,int kel);
+int  (*MMG5_indPt)(MMG5_pMesh mesh,int kp);
+int  (*MMG5_grad2met_ani)(MMG5_pMesh,MMG5_pSol,MMG5_pTria,int,int);
+int  (*MMG5_grad2metreq_ani)(MMG5_pMesh,MMG5_pSol,MMG5_pTria,int,int);
+int    (*MMG5_compute_meanMetricAtMarkedPoints)( MMG5_pMesh,MMG5_pSol);
+#ifdef USE_SCOTCH
+int  (*MMG5_renumbering)(int vertBoxNbr, MMG5_pMesh mesh, MMG5_pSol sol);
+#endif

--- a/src/mmg2d/mmg2d.c
+++ b/src/mmg2d/mmg2d.c
@@ -24,6 +24,12 @@
 
 mytime   MMG5_ctim[TIMEMAX];
 
+int    (*MMG2D_defsiz)(MMG5_pMesh ,MMG5_pSol );
+int    (*MMG2D_intmet)(MMG5_pMesh ,MMG5_pSol ,int ,char ,int ,double );
+double (*MMG2D_lencurv)(MMG5_pMesh ,MMG5_pSol ,int ,int );
+int    (*MMG2D_gradsizreq)(MMG5_pMesh ,MMG5_pSol );
+double (*MMG2D_caltri)(MMG5_pMesh ,MMG5_pSol ,MMG5_pTria );
+int    (*MMG2D_gradsiz)(MMG5_pMesh ,MMG5_pSol );
 
 /**
  * Print elapsed time at end of process.

--- a/src/mmg2d/mmg2d.h
+++ b/src/mmg2d/mmg2d.h
@@ -356,13 +356,13 @@ int    lissmet_ani(MMG5_pMesh mesh,MMG5_pSol sol);
 int    MMG2D_sum_reqEdgeLengthsAtPoint(MMG5_pMesh,MMG5_pSol,MMG5_pTria,char);
 int    MMG2D_set_metricAtPointsOnReqEdges(MMG5_pMesh,MMG5_pSol);
 
-double (*MMG2D_lencurv)(MMG5_pMesh ,MMG5_pSol ,int ,int );
-double (*MMG2D_caltri)(MMG5_pMesh ,MMG5_pSol ,MMG5_pTria );
-int    (*MMG2D_optlen)(MMG5_pMesh ,MMG5_pSol ,double ,int );
-int    (*MMG2D_intmet)(MMG5_pMesh ,MMG5_pSol ,int ,char ,int ,double );
-int    (*MMG2D_gradsiz)(MMG5_pMesh ,MMG5_pSol );
-int    (*MMG2D_gradsizreq)(MMG5_pMesh ,MMG5_pSol );
-int    (*MMG2D_defsiz)(MMG5_pMesh ,MMG5_pSol );
+extern double (*MMG2D_lencurv)(MMG5_pMesh ,MMG5_pSol ,int ,int );
+extern double (*MMG2D_caltri)(MMG5_pMesh ,MMG5_pSol ,MMG5_pTria );
+extern int    (*MMG2D_optlen)(MMG5_pMesh ,MMG5_pSol ,double ,int );
+extern int    (*MMG2D_intmet)(MMG5_pMesh ,MMG5_pSol ,int ,char ,int ,double );
+extern int    (*MMG2D_gradsiz)(MMG5_pMesh ,MMG5_pSol );
+extern int    (*MMG2D_gradsizreq)(MMG5_pMesh ,MMG5_pSol );
+extern int    (*MMG2D_defsiz)(MMG5_pMesh ,MMG5_pSol );
 
 /* init structures */
 void  MMG2D_Init_parameters(MMG5_pMesh mesh);

--- a/src/mmg3d/mmg3d.c
+++ b/src/mmg3d/mmg3d.c
@@ -36,6 +36,22 @@
 
 mytime         MMG5_ctim[TIMEMAX];
 
+double (*MMG5_lenedg)(MMG5_pMesh ,MMG5_pSol ,int, MMG5_pTetra );
+double (*MMG5_lenedgspl)(MMG5_pMesh ,MMG5_pSol ,int, MMG5_pTetra );
+double (*MMG5_caltet)(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pTetra pt);
+double (*MMG5_caltri)(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pTria ptt);
+int    (*MMG3D_defsiz)(MMG5_pMesh ,MMG5_pSol );
+int    (*MMG3D_gradsiz)(MMG5_pMesh ,MMG5_pSol );
+int    (*MMG3D_gradsizreq)(MMG5_pMesh ,MMG5_pSol );
+int    (*MMG5_intmet)(MMG5_pMesh,MMG5_pSol,int,char,int, double);
+int    (*MMG5_interp4bar)(MMG5_pMesh,MMG5_pSol,int,int,double *);
+int    (*MMG5_movintpt)(MMG5_pMesh ,MMG5_pSol, MMG3D_pPROctree ,int *, int , int );
+int    (*MMG5_movbdyregpt)(MMG5_pMesh, MMG5_pSol, MMG3D_pPROctree ,int*, int, int*, int, int ,int);
+int    (*MMG5_movbdyrefpt)(MMG5_pMesh, MMG5_pSol, MMG3D_pPROctree ,int*, int, int*, int ,int);
+int    (*MMG5_movbdynompt)(MMG5_pMesh, MMG5_pSol, MMG3D_pPROctree ,int*, int, int*, int ,int);
+int    (*MMG5_movbdyridpt)(MMG5_pMesh, MMG5_pSol, MMG3D_pPROctree ,int*, int, int*, int ,int);
+int    (*MMG5_cavity)(MMG5_pMesh ,MMG5_pSol ,int ,int ,int *,int ,double);
+int    (*MMG3D_PROctreein)(MMG5_pMesh ,MMG5_pSol ,MMG3D_pPROctree ,int,double );
 
 /**
  * Print elapsed time at end of process.

--- a/src/mmg3d/mmg3d.h
+++ b/src/mmg3d/mmg3d.h
@@ -503,22 +503,22 @@ extern int MMG5_moymet(MMG5_pMesh ,MMG5_pSol ,MMG5_pTetra ,double *);
 int    MMG3D_set_metricAtPointsOnReqEdges (MMG5_pMesh,MMG5_pSol);
 void MMG3D_mark_pointsOnReqEdge_fromTetra (  MMG5_pMesh mesh );
 
-double (*MMG5_lenedg)(MMG5_pMesh ,MMG5_pSol ,int, MMG5_pTetra );
-double (*MMG5_lenedgspl)(MMG5_pMesh ,MMG5_pSol ,int, MMG5_pTetra );
-double (*MMG5_caltet)(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pTetra pt);
-double (*MMG5_caltri)(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pTria ptt);
-int    (*MMG3D_defsiz)(MMG5_pMesh ,MMG5_pSol );
-int    (*MMG3D_gradsiz)(MMG5_pMesh ,MMG5_pSol );
-int    (*MMG3D_gradsizreq)(MMG5_pMesh ,MMG5_pSol );
-int    (*MMG5_intmet)(MMG5_pMesh,MMG5_pSol,int,char,int, double);
-int    (*MMG5_interp4bar)(MMG5_pMesh,MMG5_pSol,int,int,double *);
-int    (*MMG5_movintpt)(MMG5_pMesh ,MMG5_pSol, MMG3D_pPROctree ,int *, int , int );
-int    (*MMG5_movbdyregpt)(MMG5_pMesh, MMG5_pSol, MMG3D_pPROctree ,int*, int, int*, int, int ,int);
-int    (*MMG5_movbdyrefpt)(MMG5_pMesh, MMG5_pSol, MMG3D_pPROctree ,int*, int, int*, int ,int);
-int    (*MMG5_movbdynompt)(MMG5_pMesh, MMG5_pSol, MMG3D_pPROctree ,int*, int, int*, int ,int);
-int    (*MMG5_movbdyridpt)(MMG5_pMesh, MMG5_pSol, MMG3D_pPROctree ,int*, int, int*, int ,int);
-int    (*MMG5_cavity)(MMG5_pMesh ,MMG5_pSol ,int ,int ,int *,int ,double);
-int    (*MMG3D_PROctreein)(MMG5_pMesh ,MMG5_pSol ,MMG3D_pPROctree ,int,double );
+extern double (*MMG5_lenedg)(MMG5_pMesh ,MMG5_pSol ,int, MMG5_pTetra );
+extern double (*MMG5_lenedgspl)(MMG5_pMesh ,MMG5_pSol ,int, MMG5_pTetra );
+extern double (*MMG5_caltet)(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pTetra pt);
+extern double (*MMG5_caltri)(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pTria ptt);
+extern int    (*MMG3D_defsiz)(MMG5_pMesh ,MMG5_pSol );
+extern int    (*MMG3D_gradsiz)(MMG5_pMesh ,MMG5_pSol );
+extern int    (*MMG3D_gradsizreq)(MMG5_pMesh ,MMG5_pSol );
+extern int    (*MMG5_intmet)(MMG5_pMesh,MMG5_pSol,int,char,int, double);
+extern int    (*MMG5_interp4bar)(MMG5_pMesh,MMG5_pSol,int,int,double *);
+extern int    (*MMG5_movintpt)(MMG5_pMesh ,MMG5_pSol, MMG3D_pPROctree ,int *, int , int );
+extern int    (*MMG5_movbdyregpt)(MMG5_pMesh, MMG5_pSol, MMG3D_pPROctree ,int*, int, int*, int, int ,int);
+extern int    (*MMG5_movbdyrefpt)(MMG5_pMesh, MMG5_pSol, MMG3D_pPROctree ,int*, int, int*, int ,int);
+extern int    (*MMG5_movbdynompt)(MMG5_pMesh, MMG5_pSol, MMG3D_pPROctree ,int*, int, int*, int ,int);
+extern int    (*MMG5_movbdyridpt)(MMG5_pMesh, MMG5_pSol, MMG3D_pPROctree ,int*, int, int*, int ,int);
+extern int    (*MMG5_cavity)(MMG5_pMesh ,MMG5_pSol ,int ,int ,int *,int ,double);
+extern int    (*MMG3D_PROctreein)(MMG5_pMesh ,MMG5_pSol ,MMG3D_pPROctree ,int,double );
 
 /**
  * \param mesh pointer toward the mesh structure.

--- a/src/mmg3d/mmg3d1.c
+++ b/src/mmg3d/mmg3d1.c
@@ -38,7 +38,7 @@
 
 #include "inlined_functions_3d.h"
 
-char  ddb;
+extern char  ddb;
 
 /**
  * \param mesh pointer toward the mesh structure.

--- a/src/mmgs/mmgs.c
+++ b/src/mmgs/mmgs.c
@@ -38,6 +38,13 @@
 
 mytime         MMG5_ctim[TIMEMAX];
 
+int    (*movintpt)(MMG5_pMesh mesh,MMG5_pSol met,int *list,int ilist);
+int    (*MMGS_defsiz)(MMG5_pMesh mesh,MMG5_pSol met);
+double (*MMG5_calelt)(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pTria ptt);
+int    (*MMGS_gradsiz)(MMG5_pMesh mesh,MMG5_pSol met);
+int    (*MMGS_gradsizreq)(MMG5_pMesh mesh,MMG5_pSol met);
+int    (*intmet)(MMG5_pMesh mesh,MMG5_pSol met,int k,char i,int ip,double s);
+int    (*movridpt)(MMG5_pMesh mesh,MMG5_pSol met,int *list,int ilist);
 
 /**
  * Print elapsed time at end of process.

--- a/src/mmgs/mmgs.h
+++ b/src/mmgs/mmgs.h
@@ -202,13 +202,13 @@ int    movintpt_ani(MMG5_pMesh mesh,MMG5_pSol met,int *list,int ilist);
 int    MMGS_prilen(MMG5_pMesh mesh,MMG5_pSol met,int);
 int    MMGS_set_metricAtPointsOnReqEdges ( MMG5_pMesh,MMG5_pSol );
 
-double (*MMG5_calelt)(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pTria ptt);
-int    (*MMGS_defsiz)(MMG5_pMesh mesh,MMG5_pSol met);
-int    (*MMGS_gradsiz)(MMG5_pMesh mesh,MMG5_pSol met);
-int    (*MMGS_gradsizreq)(MMG5_pMesh mesh,MMG5_pSol met);
-int    (*intmet)(MMG5_pMesh mesh,MMG5_pSol met,int k,char i,int ip,double s);
-int    (*movridpt)(MMG5_pMesh mesh,MMG5_pSol met,int *list,int ilist);
-int    (*movintpt)(MMG5_pMesh mesh,MMG5_pSol met,int *list,int ilist);
+extern double (*MMG5_calelt)(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pTria ptt);
+extern int    (*MMGS_defsiz)(MMG5_pMesh mesh,MMG5_pSol met);
+extern int    (*MMGS_gradsiz)(MMG5_pMesh mesh,MMG5_pSol met);
+extern int    (*MMGS_gradsizreq)(MMG5_pMesh mesh,MMG5_pSol met);
+extern int    (*intmet)(MMG5_pMesh mesh,MMG5_pSol met,int k,char i,int ip,double s);
+extern int    (*movridpt)(MMG5_pMesh mesh,MMG5_pSol met,int *list,int ilist);
+extern int    (*movintpt)(MMG5_pMesh mesh,MMG5_pSol met,int *list,int ilist);
 
 /**
  * Set common pointer functions between mmgs and mmg3d to the matching mmgs

--- a/src/mmgs/mmgs1.c
+++ b/src/mmgs/mmgs1.c
@@ -35,7 +35,7 @@
 #include "mmgs.h"
 
 
-char ddb;
+extern char ddb;
 
 /**
  * \param mesh pointer toward the mesh structure.


### PR DESCRIPTION
This is needed for GCC10 which now defaults to -fno-common, see https://gcc.gnu.org/gcc-10/porting_to.html