### PR TITLE
Set the np field of a freed solution to zero.

### DIFF
--- a/src/mmg2d/libmmg2d_tools.c
+++ b/src/mmg2d/libmmg2d_tools.c
@@ -523,6 +523,7 @@ void MMG2D_Free_solutions(MMG5_pMesh mesh,MMG5_pSol sol) {
   /* sol */
   if ( sol && sol->m )
     MMG5_DEL_MEM(mesh,sol->m);
-
+  
+  sol->np = 0;
   return;
 }


### PR DESCRIPTION
If a solution is freed, then also its sol->np should be zero (and maybe its other members as well, npi, size etc) so that code will not try to use it anymore.
It seems the np field is the one that is checked to see if the solution contains data.
If this function does not free the entire solution, its name is misleading.