### PR TITLE
fixed a bug in indexing that causes infinite loop

### DIFF
--- a/src/mmg2d/API_functions_2d.c
+++ b/src/mmg2d/API_functions_2d.c
@@ -754,8 +754,8 @@ int  MMG2D_Set_triangles(MMG5_pMesh mesh, int *tria, int *refs) {
     mesh->point[ptt->v[1]].tag &= ~MG_NUL;
     mesh->point[ptt->v[2]].tag &= ~MG_NUL;
 
-    for(i=0 ; i<3 ; i++)
-      ptt->edg[i] = 0;
+    for(j=0 ; j<3 ; j++)
+      ptt->edg[j] = 0;
 
     vol = MMG2D_quickarea(mesh->point[ptt->v[0]].c,mesh->point[ptt->v[1]].c,
                          mesh->point[ptt->v[2]].c);


### PR DESCRIPTION
A bug fix is suggested for MMG2D_Set_triangles(), one of the mmg2d's API functions.

The bug is that the redundant use of index 'i' within the main loop in MMG2D_Set_triangles() causes the loop to be never-ending.

The suggested fix is to use a different index for the nested loop.
