### PR TITLE
Fix header copy and generalize cmake macro.

### DIFF
--- a/cmake/modules/macros.cmake
+++ b/cmake/modules/macros.cmake
@@ -32,7 +32,7 @@ ENDMACRO ( )
 #####         Copy an automatically generated header file to another place
 #####
 ###############################################################################
-MACRO ( COPY_FORTRAN_HEADER
+MACRO ( COPY_HEADER
     in_dir in_file out_dir out_file
     file_dependencies
     target_name
@@ -60,26 +60,41 @@ ENDMACRO ( )
 #####         and create the associated target
 #####
 ###############################################################################
-MACRO ( COPY_FORTRAN_HEADER_AND_CREATE_TARGET
-    binary_dir include_dir target_identifier )
+MACRO ( COPY_HEADERS_AND_CREATE_TARGET
+    source_dir binary_dir include_dir target_identifier )
 
-  COPY_FORTRAN_HEADER (
+  ADD_CUSTOM_TARGET(mmg${target_identifier}types_header ALL
+    DEPENDS
+    ${COMMON_SOURCE_DIR}/libmmgtypes.h )
+
+  ADD_CUSTOM_TARGET(mmg${target_identifier}_header ALL
+    DEPENDS
+    ${source_dir}/libmmg${target_identifier}.h )
+
+  COPY_HEADER (
+    ${COMMON_SOURCE_DIR} libmmgtypes.h
+    ${include_dir} libmmgtypes.h
+    mmg${target_identifier}types_header copy${target_identifier}_libmmgtypes )
+
+  COPY_HEADER (
+    ${source_dir} libmmg${target_identifier}.h
+    ${include_dir} libmmg${target_identifier}.h
+    mmg${target_identifier}_header copy_libmmg${target_identifier} )
+
+  COPY_HEADER (
     ${COMMON_BINARY_DIR} libmmgtypesf.h
     ${include_dir} libmmgtypesf.h
     mmg_fortran_header copy${target_identifier}_libmmgtypesf )
 
-  COPY_FORTRAN_HEADER (
-    ${binary_dir}
-    libmmg${target_identifier}f.h ${include_dir}
-    libmmg${target_identifier}f.h
-    mmg${target_identifier}_fortran_header copy_libmmg${target_identifier}f
-    )
+  COPY_HEADER (
+    ${binary_dir} libmmg${target_identifier}f.h
+    ${include_dir} libmmg${target_identifier}f.h
+    mmg${target_identifier}_fortran_header copy_libmmg${target_identifier}f )
 
   ADD_CUSTOM_TARGET(copy_${target_identifier}_headers ALL
     DEPENDS
     copy_libmmg${target_identifier}f copy${target_identifier}_libmmgtypesf
-    ${include_dir}/libmmg${target_identifier}.h
-    ${include_dir}/libmmgtypes.h )
+    copy_libmmg${target_identifier} copy${target_identifier}_libmmgtypes )
 
 ENDMACRO ( )
 

--- a/cmake/modules/mmg2d.cmake
+++ b/cmake/modules/mmg2d.cmake
@@ -123,12 +123,8 @@ SET( mmg2d_headers
 # Install header files in /usr/local or equivalent
 INSTALL(FILES ${mmg2d_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mmg/mmg2d COMPONENT headers )
 
-COPY_FORTRAN_HEADER_AND_CREATE_TARGET ( ${MMG2D_BINARY_DIR} ${MMG2D_INCLUDE} 2d )
-
-# Copy header files in project directory at configuration step
-# (generated file don't exists yet or are outdated)
-FILE(INSTALL  ${mmg2d_headers} DESTINATION ${MMG2D_INCLUDE}
-  PATTERN "libmmg*f.h"  EXCLUDE)
+# Copy header files in project directory at build step
+COPY_HEADERS_AND_CREATE_TARGET ( ${MMG2D_SOURCE_DIR} ${MMG2D_BINARY_DIR} ${MMG2D_INCLUDE} 2d )
 
 ############################################################################
 #####

--- a/cmake/modules/mmg3d.cmake
+++ b/cmake/modules/mmg3d.cmake
@@ -138,12 +138,8 @@ SET( mmg3d_headers
 # Install header files in /usr/local or equivalent
 INSTALL(FILES ${mmg3d_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mmg/mmg3d COMPONENT headers)
 
-COPY_FORTRAN_HEADER_AND_CREATE_TARGET ( ${MMG3D_BINARY_DIR} ${MMG3D_INCLUDE} 3d )
-
-# Copy header files in project directory at configuration step
-# (generated file don't exists yet or are outdated)
-FILE(INSTALL  ${mmg3d_headers} DESTINATION ${MMG3D_INCLUDE}
-  PATTERN "libmmg*f.h"  EXCLUDE)
+# Copy header files in project directory at build step
+COPY_HEADERS_AND_CREATE_TARGET ( ${MMG3D_SOURCE_DIR} ${MMG3D_BINARY_DIR} ${MMG3D_INCLUDE} 3d )
 
 ############################################################################
 #####

--- a/cmake/modules/mmgs.cmake
+++ b/cmake/modules/mmgs.cmake
@@ -103,12 +103,8 @@ SET( mmgs_headers
 # Install header files in /usr/local or equivalent
 INSTALL(FILES ${mmgs_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mmg/mmgs COMPONENT headers)
 
-COPY_FORTRAN_HEADER_AND_CREATE_TARGET ( ${MMGS_BINARY_DIR} ${MMGS_INCLUDE} s )
-
-# Copy header files in project directory at configuration step
-# (generated file don't exists yet or are outdated)
-FILE(INSTALL  ${mmgs_headers} DESTINATION ${MMGS_INCLUDE}
-  PATTERN "libmmg*f.h"  EXCLUDE)
+# Copy header files in project directory at build step
+COPY_HEADERS_AND_CREATE_TARGET ( ${MMGS_SOURCE_DIR} ${MMGS_BINARY_DIR} ${MMGS_INCLUDE} s )
 
 ############################################################################
 #####


### PR DESCRIPTION
Copy the libmmg*.h header files in the build/include/* folder at every build (not only at configuration).