### PR TITLE
CMake: Fix compilation with Mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ GENERATE_FORTRAN_HEADER ( mmg
 ###############################################################################
 
 # Libraries
-IF ( NOT WIN32 OR MINGW )
+IF ( NOT WIN32 )
 
   IF(NOT DEFINED M_LIB)
     MESSAGE(STATUS "M_LIB not defined. Searching it")


### PR DESCRIPTION
* The NOT operator was not applied to MINGW so libm was wrongly search.
* Testing for MINGW here because when building with MINGW, WIN32 is set.