### PR TITLE
Feature/parmmg

### DIFF
--- a/src/mmg3d/analys_3d.c
+++ b/src/mmg3d/analys_3d.c
@@ -147,6 +147,7 @@ int MMG5_setadj(MMG5_pMesh mesh){
         tag = MG_GEO;
         if ( mesh->info.opnbdy ) tag += MG_OPNBDY;
         if ( !adja[i] ) {
+          tag += MG_NOM;
           pt->tag[i] |= tag;
           mesh->point[ip1].tag |= tag;
           mesh->point[ip2].tag |= tag;

--- a/src/mmg3d/analys_3d.c
+++ b/src/mmg3d/analys_3d.c
@@ -691,7 +691,7 @@ int MMG3D_nmgeom(MMG5_pMesh mesh){
         ip = MMG5_idir[i][j];
         p0 = &mesh->point[pt->v[ip]];
         if ( p0->flag == base )  continue;
-        else if ( !(p0->tag & MG_NOM) )  continue;
+        else if ( !(p0->tag & MG_NOM) || (p0->tag & MG_PARBDY) )  continue;
 
         p0->flag = base;
         ier = MMG5_boulenm(mesh,k,ip,i,n,t);
@@ -728,7 +728,8 @@ int MMG3D_nmgeom(MMG5_pMesh mesh){
     
     for (i=0; i<4; i++) {
       p0 = &mesh->point[pt->v[i]];
-      if ( p0->tag & MG_REQ || !(p0->tag & MG_NOM) || p0->xp ) continue;
+      if ( p0->tag & MG_REQ || !(p0->tag & MG_NOM) ||
+           p0->xp || (p0->tag & MG_PARBDY) ) continue;
       ier = MMG5_boulenmInt(mesh,k,i,t);
       if ( ier ) {
         ++mesh->xp;

--- a/src/mmg3d/hash_3d.c
+++ b/src/mmg3d/hash_3d.c
@@ -537,8 +537,8 @@ int MMG5_setEdgeNmTag(MMG5_pMesh mesh, MMG5_Hash *hash) {
 
     for (l=0; l<3; l++) {
 
-      /* Skip edges at the intersection of a parallel interface */
-      if ( ptt->tag[l] & MG_BDY ) continue;
+      /* Skip parallel edges */
+      if ( ptt->tag[l] & MG_PARBDY ) continue;
 
       if ( ptt->tag[l] & MG_NOM ) {
         i1 = MMG5_inxt2[l];

--- a/src/mmg3d/hash_3d.c
+++ b/src/mmg3d/hash_3d.c
@@ -538,7 +538,7 @@ int MMG5_setEdgeNmTag(MMG5_pMesh mesh, MMG5_Hash *hash) {
     for (l=0; l<3; l++) {
 
       /* Skip parallel edges */
-      if ( ptt->tag[l] & MG_PARBDY ) continue;
+      if ( (ptt->tag[l] & MG_PARBDY) || (ptt->tag[l] & MG_BDY) ) continue;
 
       if ( ptt->tag[l] & MG_NOM ) {
         i1 = MMG5_inxt2[l];

--- a/src/mmg3d/mmg3d1.c
+++ b/src/mmg3d/mmg3d1.c
@@ -2027,7 +2027,7 @@ MMG3D_anatets_iso(MMG5_pMesh mesh,MMG5_pSol met,int8_t typchk) {
     for (i=0; i<4; i++) {
       /* virtual triangle */
       memset(&ptt,0,sizeof(MMG5_Tria));
-      if ( pt->xt && pxt->ftag[i] ) {
+      if ( pt->xt && pxt->ftag[i] && pxt->ftag[i] != MG_OLDPARBDY ) {
         MMG5_tet2tri(mesh,k,i,&ptt);
       }
 

--- a/src/mmg3d/mmg3d1.c
+++ b/src/mmg3d/mmg3d1.c
@@ -1472,7 +1472,7 @@ int MMG3D_splsurfedge( MMG5_pMesh mesh,MMG5_pSol met,int k,
   p0  = &mesh->point[ip1];
   p1  = &mesh->point[ip2];
 
-  if ( (p0->tag & MG_PARBDY) && (p1->tag & MG_PARBDY) ) continue;
+  if ( (p0->tag & MG_PARBDY) && (p1->tag & MG_PARBDY) ) return 0;
 
   ref = pxt->edg[imax];
   tag = pxt->tag[imax];

--- a/src/mmg3d/mmg3d1.c
+++ b/src/mmg3d/mmg3d1.c
@@ -1472,6 +1472,8 @@ int MMG3D_splsurfedge( MMG5_pMesh mesh,MMG5_pSol met,int k,
   p0  = &mesh->point[ip1];
   p1  = &mesh->point[ip2];
 
+  if ( (p0->tag & MG_PARBDY) && (p1->tag & MG_PARBDY) ) continue;
+
   ref = pxt->edg[imax];
   tag = pxt->tag[imax];
 

--- a/src/mmg3d/mmg3d1_delone.c
+++ b/src/mmg3d/mmg3d1_delone.c
@@ -198,6 +198,15 @@ MMG5_boucle_for(MMG5_pMesh mesh, MMG5_pSol met,MMG3D_pPROctree *PROctree,int ne,
         else if ( tag & MG_REF ) {
           if ( !MMG5_BezierRef(mesh,ip1,ip2,0.5,o,no1,to) )
             goto collapse;
+          if ( MG_SIN(p0->tag) && MG_SIN(p1->tag) ) {
+            MMG5_tet2tri(mesh,k,i,&ptt);
+            MMG5_nortri(mesh,&ptt,no1);
+            if ( !MG_GET(pxt->ori,i) ) {
+              no1[0] *= -1.0;
+              no1[1] *= -1.0;
+              no1[2] *= -1.0;
+            }
+          }
         }
         else {
           if ( !MMG5_norface(mesh,k,i,v) )  goto collapse;
@@ -557,6 +566,15 @@ MMG5_boucle_for(MMG5_pMesh mesh, MMG5_pSol met,MMG3D_pPROctree *PROctree,int ne,
           else if ( tag & MG_REF ) {
             if ( !MMG5_BezierRef(mesh,ip1,ip2,0.5,o,no1,to) )
               goto collapse2;
+            if ( MG_SIN(p0->tag) && MG_SIN(p1->tag) ) {
+              MMG5_tet2tri(mesh,k,i,&ptt);
+              MMG5_nortri(mesh,&ptt,no1);
+              if ( !MG_GET(pxt->ori,i) ) {
+                no1[0] *= -1.0;
+                no1[1] *= -1.0;
+                no1[2] *= -1.0;
+              }
+            }
           }
           else {
             if ( !MMG5_norface(mesh,k,i,v) )  goto collapse2;

--- a/src/mmg3d/mmg3d1_delone.c
+++ b/src/mmg3d/mmg3d1_delone.c
@@ -156,6 +156,7 @@ MMG5_boucle_for(MMG5_pMesh mesh, MMG5_pSol met,MMG3D_pPROctree *PROctree,int ne,
 
       /* Case of a boundary face */
       if ( pt->xt && (pxt->ftag[i] & MG_BDY) ) {
+        if ( (p0->tag & MG_PARBDY) && (p1->tag & MG_PARBDY) ) continue;
         if ( !(MG_GET(pxt->ori,i)) ) continue;
         ref = pxt->edg[MMG5_iarf[i][j]];
         tag = pxt->tag[MMG5_iarf[i][j]];
@@ -524,6 +525,7 @@ MMG5_boucle_for(MMG5_pMesh mesh, MMG5_pSol met,MMG3D_pPROctree *PROctree,int ne,
 
         /* Case of a boundary face */
         if ( pt->xt && (pxt->ftag[i] & MG_BDY) ) {
+          if ( (p0->tag & MG_PARBDY) && (p1->tag & MG_PARBDY) ) continue;
           if ( !(MG_GET(pxt->ori,i)) ) continue;
           ref = pxt->edg[MMG5_iarf[i][j]];
           tag = pxt->tag[MMG5_iarf[i][j]];


### PR DESCRIPTION
Fix some tags to operate in parallel.
1. Skip parallel edges and points for non-manifold analysis.
2. Skip old parallel entities when trying to compute normals (these entities are not always on the geometric boundary, so it is wrong to assume they are MG_BDY --  similar issues could be present elsewhere in the code).
3. Avoid splitting edges with parallel extremities. (Maybe this could be removed in a new version of ParMmg)
4. Put MG_NOM tag on the boundary of an open surface.