### PR TITLE
Feature/2d local param consistency

### DIFF
--- a/src/common/mettools.c
+++ b/src/common/mettools.c
@@ -535,7 +535,7 @@ int MMG5_test_eigenvmatsym3d(MMG5_pMesh mesh,double *mex,double lambdaex[],
 int MMG5_test_eigenvmatnonsym3d(MMG5_pMesh mesh,double *mex,double lambdaex[],
                                 double vpex[][3],double ivpex[][3]) {
   double mnum[9],lambdanum[3],vpnum[3][3]; /* Numerical quantities */
-  double swap[3],maxerr,err;
+  double swap[3],maxerr;
   int8_t perm[3] = {0,1,2}; /* eigenvalues permutation array */
 
 
@@ -912,7 +912,7 @@ int MMG5_intersecmet22(MMG5_pMesh mesh, double *m,double *n,double *mr) {
 int MMG5_intersecmet33(MMG5_pMesh mesh, double *m,double *n,double *mr) {
   double  vp[3][3],dm[3],dn[3],d[3],ivp[3][3];
   double  isqhmin,isqhmax;
-  int8_t  i,j,k,ij;
+  int8_t  i;
 
   isqhmin  = 1.0 / (mesh->info.hmin*mesh->info.hmin);
   isqhmax  = 1.0 / (mesh->info.hmax*mesh->info.hmax);

--- a/src/common/tools.c
+++ b/src/common/tools.c
@@ -65,7 +65,6 @@ inline void MMG5_nsort(int n,double *val,int8_t *perm){
  *
  */
 inline void MMG5_nperm(int8_t n,int8_t shift,int8_t stride,double *val,double *oldval,int8_t *perm) {
-  double tmp;
   int8_t i,k;
 
   for( i = 0; i < n; i++ )

--- a/src/mmg2d/bezier_2d.c
+++ b/src/mmg2d/bezier_2d.c
@@ -28,12 +28,79 @@
 int MMG2D_chkedg(MMG5_pMesh mesh, int k) {
   MMG5_pTria        pt;
   MMG5_pPoint       p1,p2;
-  double            hausd,hmax,ps,cosn,ux,uy,ll,li,t1[2],t2[2];
-  int8_t            i,i1,i2;
+  MMG5_pPar         par;
+  double            hausd[3],hmax[3],ps,cosn,ux,uy,ll,li,t1[2],t2[2];
+  int               l;
+  int8_t            i,i1,i2,fill;
 
   pt = &mesh->tria[k];
-  hausd = mesh->info.hausd;
-  hmax = mesh->info.hmax;
+  hausd[0] = hausd[1] = hausd[2] = mesh->info.hausd;
+  hmax[0]  = hmax[1]  = hmax[2]  = mesh->info.hmax;
+
+  /* Local parameters for pt and k */
+  int8_t isloc = 0;
+
+  if ( mesh->info.parTyp & MG_Tria ) {
+    for ( l=0; l<mesh->info.npar; ++l ) {
+      par = &mesh->info.par[l];
+
+      if ( par->elt != MMG5_Triangle )  continue;
+      if ( par->ref != pt->ref ) continue;
+
+      hmax[0]  = hmax[1]  = hmax[2]  = par->hmax;
+      hausd[0] = hausd[1] = hausd[2] = par->hausd;
+      isloc = 1;
+      break;
+    }
+  }
+
+  fill = 0;
+  if ( mesh->info.parTyp & MG_Edge ) {
+    if ( isloc ) {
+      for ( l=0; l<mesh->info.npar; ++l ) {
+        par = &mesh->info.par[l];
+
+        if ( par->elt != MMG5_Edg )  continue;
+
+        for (i=0; i<3; i++) {
+          if ( par->ref != pt->edg[i] ) continue;
+
+          hmax[i]  = MG_MIN(hmax[i],par->hmax);
+          hausd[i] = MG_MIN(hausd[i],par->hausd);
+
+          MG_SET(fill,i);
+        }
+
+        /* Stop the loop over local parameters if all edges have been found */
+        if ( fill == 7 ) {
+          break;
+        }
+
+      }
+    }
+    else {
+      for ( l=0; l<mesh->info.npar; ++l ) {
+        par = &mesh->info.par[l];
+
+        if ( par->elt != MMG5_Edg )  continue;
+
+        for (i=0; i<3; i++) {
+          if ( par->ref != pt->edg[i] ) continue;
+
+          hmax[i]  = par->hmax;
+          hausd[i] = par->hausd;
+
+          MG_SET(fill,i);
+        }
+
+        /* Stop the loop over local parameters if all edges have been found */
+        if ( fill == 7 ) {
+          break;
+        }
+      }
+    }
+  }
+
 
   /* Analyze the three edges of k */
   for (i=0; i<3; i++) {
@@ -49,7 +116,7 @@ int MMG2D_chkedg(MMG5_pMesh mesh, int k) {
     ll = ux*ux + uy*uy;
 
     /* Long edges should be split */
-    if ( ll > hmax*hmax ) {
+    if ( ll > hmax[i]*hmax[i] ) {
       MG_SET(pt->flag,i);
       continue;
     }
@@ -93,7 +160,7 @@ int MMG2D_chkedg(MMG5_pMesh mesh, int k) {
     cosn = ps/ll ;
     cosn *= (1.0-cosn);
     cosn *= ll;
-    if ( cosn > 9.0*hausd*hausd ) {   // Not so sure about that 9.0
+    if ( cosn > 9.0*hausd[i]*hausd[i] ) {   // Not so sure about that 9.0
       MG_SET(pt->flag,i);
       continue;
     }
@@ -103,7 +170,7 @@ int MMG2D_chkedg(MMG5_pMesh mesh, int k) {
     cosn = ps/ll ;
     cosn *= (1.0-cosn);
     cosn *= ll;
-    if ( cosn > 9.0*hausd*hausd ) {
+    if ( cosn > 9.0*hausd[i]*hausd[i] ) {
       MG_SET(pt->flag,i);
       continue;
     }


### PR DESCRIPTION
Attempt to fix the non-consistency of local and global hmax values in mmg2d by considering local hmax in the first wave of adaptation. A priori the same issue can't happen with hmin (because a too fine mesh is not a problem).