### PR TITLE
Hotfix/mmg2dls infinite loop

### DIFF
--- a/src/mmg2d/mmg2d6.c
+++ b/src/mmg2d/mmg2d6.c
@@ -255,7 +255,16 @@ int MMG2D_ismaniball(MMG5_pMesh mesh, MMG5_pSol sol, int start, int8_t istart) {
       smsgn = (fabs(v1) < MMG5_EPS) || ( (fabs(v2) > MMG5_EPS) && MG_SMSGN(v1,v2) ) ? 1 : 0;
     // smsgn =  MG_SMSGN(v1,v2) ? 1 : 0;
   }
-  while ( smsgn );
+  while ( smsgn && (k != start) );
+
+  if ( k==start ) {
+    /* Complete ball has been travelled without crossing a boundary or finding a
+     * sign change: we are in the special case where v1 = v2 = v[istart] = 0 in
+     * tria start. In this case, test MG_SMSGN(v1,v2) returns 0 while smsgn is
+     * computed to 1, which is non consistent.  */
+    assert ( smsgn );
+    return 0;
+  }
 
   end1 = k;
   k = start;
@@ -284,7 +293,9 @@ int MMG2D_ismaniball(MMG5_pMesh mesh, MMG5_pSol sol, int start, int8_t istart) {
       smsgn = (fabs(v2) < MMG5_EPS) || ( (fabs(v1) > MMG5_EPS) && MG_SMSGN(v1,v2) ) ? 1 : 0;
     // smsgn = MG_SMSGN(v1,v2) ? 1 : 0;
   }
-  while ( smsgn );
+  while ( smsgn && (k != start) );
+
+  assert ( k!=start );
 
   /* If first stop was due to an external boundary, the second one must too;
      else, the final triangle for the first travel must be that of the second one */

--- a/src/mmg2d/mmg2d6.c
+++ b/src/mmg2d/mmg2d6.c
@@ -247,6 +247,11 @@ int MMG2D_ismaniball(MMG5_pMesh mesh, MMG5_pSol sol, int start, int8_t istart) {
     v1 = sol->m[ip1];
     v2 = sol->m[ip2];
 
+    if ( (fabs(v1) < MMG5_EPS) && (fabs(v2) < MMG5_EPS) ) {
+      /* Do not authorize a snap that leads to a triangle with only 0 vertices */
+      return 0;
+    }
+
     /* Authorize change of references only provided the boundary reference is MG_ISO */
     if ( pt->ref != refstart && pt->edg[i1] != MG_ISO ) {
       smsgn = 0;
@@ -285,6 +290,11 @@ int MMG2D_ismaniball(MMG5_pMesh mesh, MMG5_pSol sol, int start, int8_t istart) {
 
     v1 = sol->m[ip1];
     v2 = sol->m[ip2];
+
+    if ( (fabs(v1) < MMG5_EPS) && (fabs(v2) < MMG5_EPS) ) {
+      /* Do not authorize a snap that leads to a triangle with only 0 vertices */
+      return 0;
+    }
 
     if ( pt->ref != refstart && pt->edg[i1] != MG_ISO ) {
       smsgn = 0;


### PR DESCRIPTION
This PR is an attempt to solve the infinite loop which occurs in level-set discretization of mmg2d when checking that the snap of the isovalues doesn't lead to a non-manifold situation (see [MMG2D_ismaniball](https://github.com/MmgTools/mmg/blob/bd9fcb0a6f226165fb1a5bfe8ce644b0d3329703/src/mmg2d/mmg2d6.c#L234-L258)).

# Error overview
The infinite loop is due to the unconsistency between:
  - the test [`!MG_SMSGN(v1,v2)`](https://github.com/MmgTools/mmg/blob/bd9fcb0a6f226165fb1a5bfe8ce644b0d3329703/src/mmg2d/mmg2d6.c#L356), where v1 and v2 are considered with different signs if v1 = v2 = 0;
   - and the test [`fabs(v1) < MMG5_EPS) || ( (fabs(v2) > MMG5_EPS) && MG_SMSGN(v1,v2) `](https://github.com/MmgTools/mmg/blob/bd9fcb0a6f226165fb1a5bfe8ce644b0d3329703/src/mmg2d/mmg2d6.c#L255), where v1 and v2 are considered with same signs if v1 = v2 = 0.

# Minimal reproducer
The infinite loop occurs if an internal point has been snapped and if all the points of its ball have level-set values lower than `MMG5_EPS` (1e-0.6). See the attached figure where checking the snap of point 5 leads to loop indefinitely.
 
![Capture d’écran 2022-02-21 à 15 06 49](https://user-images.githubusercontent.com/11232703/154974067-d5f9a211-a8d7-4372-8d83-1c2f58bde6e6.png)

# PR contents 
The PR contains the following corrections:
  - Commit [ebe963e](https://github.com/MmgTools/mmg/commit/ebe963e9471b82082d925527084e0e752069e1c9) checks that the loop doesn't get back to the starting triangle without a change of sign;
  - Commit [cc7126](https://github.com/MmgTools/mmg/commit/cc7126742f5b2f9114a31dc149bda53db73ecb60) refuse to snap a value if it creates at least one triangle whose all vertices have values lower than `MMG5_EPS`.

# Proposition of future feature
Previous issue can logically occur along degenerated triangles very close to the level-set (linked issue) but also if the input level-set has a small scale range (provided example). In the second case, computing the max range of the level-set to scale the accuracy of the `0` value should help (`MMG5_EPS` should be replaced by `max_range * MMG5_EPS`). 