### PR TITLE
Feature/vtk io robustification

### DIFF
--- a/src/common/inout.c
+++ b/src/common/inout.c
@@ -1178,6 +1178,7 @@ int MMG5_loadMshMesh_part2(MMG5_pMesh mesh,MMG5_pSol *sol,FILE **inm,
 
       psl->ver = mesh->ver;
       psl->dim = mesh->dim;
+      psl->entities = MMG5_Vertex;
       psl->type = 1;
 
       /* String tags: The first one stores the solution name */
@@ -2598,15 +2599,29 @@ int MMG5_saveSolAtTetrahedraHeader( MMG5_pMesh mesh,
 /**
  * \param mesh pointer toward the mesh structure.
  * \param type type of the metric
+ * \param entities entities on which the metric applies (should be MMG5_Vertex)
  * \param inm metric file
  * \return 1 if success, -1 if fail
  *
- * Check if the type of the metric is compatible with the remeshing mode.  If
- * not, close the metric file (note that if type is an allocated array, you must
- * unallocate it outside).
+ * Check metric data:
+ *   1. check that the metric applies on vertices;
+ *   2. check that the type of the metric is compatible with the remeshing mode.
+ * If not, close the metric file (note that if type is an allocated array, you
+ * must unallocate it outside).
  *
  */
-int MMG5_chkMetricType(MMG5_pMesh mesh,int *type, FILE *inm) {
+int MMG5_chkMetricType(MMG5_pMesh mesh,int *type, int *entities, FILE *inm) {
+
+  /* Metric can be provided only on vertices */
+  if ( (*entities != MMG5_Vertex) && (*entities != MMG5_Noentity) ) {
+    fprintf(stderr,"  ## Error: %s: Metric should apply on vertices.\n"
+            " If your input file is at a non Medit"
+            " file format, please ensure to remove non metric fields from your"
+            " file and that the metric field"
+            " contains the \":metric\" string.\n",__FILE__);
+    if ( inm ) fclose(inm);
+    return -1;
+  }
 
   /* 1: scalar solution (isotropic metric or ls function,
      2: vector field (displacement in Lagrangian mode),

--- a/src/common/mmgcommon.h
+++ b/src/common/mmgcommon.h
@@ -674,7 +674,7 @@ int             MMG5_saveMshMesh(MMG5_pMesh,MMG5_pSol*,const char*, int);
 int             MMG5_saveDisp(MMG5_pMesh ,MMG5_pSol );
 int             MMG5_loadSolHeader(const char*,int,FILE**,int*,int*,int*,int*,
                                    int*,int*,int**,long*,int);
-int             MMG5_chkMetricType(MMG5_pMesh mesh,int *type, FILE *inm);
+int             MMG5_chkMetricType(MMG5_pMesh mesh,int *type,int*, FILE *inm);
 int             MMG5_readFloatSol3D(MMG5_pSol,FILE*,int,int,int);
 int             MMG5_readDoubleSol3D(MMG5_pSol,FILE*,int,int,int);
 int             MMG5_saveSolHeader( MMG5_pMesh,const char*,FILE**,int,int*,int*,int,

--- a/src/common/vtkparser.cpp
+++ b/src/common/vtkparser.cpp
@@ -81,6 +81,7 @@ vtkDataSet *MMG5_load_vtkXMLFile(const char*fileName)
 /// @param eltMeditRef index of a cell data field that contains references
 /// (field named medit:ref), -1 if no references
 /// @param nsols number of point data (except the medit:ref ones)
+/// @param metricData 1 if file contains a metric data highlighted by the :metric name
 ///
 /// @return 1 if success, -1 otherwise
 ///
@@ -97,7 +98,8 @@ vtkDataSet *MMG5_load_vtkXMLFile(const char*fileName)
 ///
 static
 int MMG5_count_vtkEntities ( vtkDataSet *dataset, MMG5_pMesh mesh,
-                             int8_t *ptMeditRef, int8_t *eltMeditRef, int *nsols ) {
+                             int8_t *ptMeditRef, int8_t *eltMeditRef,
+                             int *nsols, int8_t *metricData ) {
 
   static int8_t mmgWarn0 = 0;
   static int8_t mmgWarn1 = 0;
@@ -205,7 +207,8 @@ int MMG5_count_vtkEntities ( vtkDataSet *dataset, MMG5_pMesh mesh,
             " Ignored.\n",__func__ );
   }
 
-  *nsols = npointData + ncellData - npointRef - ncellRef;
+  *nsols      = npointData + ncellData - npointRef - ncellRef;
+  *metricData = ( nmetricField > 0 );
 
   return 1;
 }
@@ -218,13 +221,15 @@ int MMG5_count_vtkEntities ( vtkDataSet *dataset, MMG5_pMesh mesh,
 /// @param eltMeditRef index of a cell data field that contains references
 /// (field named medit:ref), -1 if no references
 /// @param nsols number of point data (except the medit:ref ones)
+/// @param metricData 1 if file contains a metric data highlighted by the :metric name
 ///
 /// @return 1 if success, 0 if fail to open/load the file, -1 otherwise;
 ///
 /// I/O at Vtp VTK file format.
 ///
 int MMG5_loadVtpMesh_part1(MMG5_pMesh mesh,const char *filename,vtkDataSet **dataset,
-                           int8_t *ptMeditRef,int8_t *eltMeditRef,int *nsols) {
+                           int8_t *ptMeditRef,int8_t *eltMeditRef,int *nsols,
+                           int8_t *metricData) {
 
   (*nsols) = 0;
   (*ptMeditRef) = (*eltMeditRef) = -1;
@@ -238,7 +243,8 @@ int MMG5_loadVtpMesh_part1(MMG5_pMesh mesh,const char *filename,vtkDataSet **dat
   }
 
   // count the number of entities of each type
-  int ier = MMG5_count_vtkEntities ( (*dataset),mesh,ptMeditRef,eltMeditRef,nsols );
+  int ier = MMG5_count_vtkEntities ( (*dataset),mesh,ptMeditRef,eltMeditRef,
+                                     nsols,metricData );
 
   if ( ier != 1 ) {
     return -1;
@@ -254,13 +260,15 @@ int MMG5_loadVtpMesh_part1(MMG5_pMesh mesh,const char *filename,vtkDataSet **dat
 /// @param eltMeditRef index of a cell data field that contains references
 /// (field named medit:ref), -1 if no references
 /// @param nsols number of point data (except the medit:ref ones)
+/// @param metricData 1 if file contains a metric data highlighted by the :metric name
 ///
 /// @return 1 if success, 0 if fail to open/load the file, -1 otherwise;
 ///
 /// I/O at Vtk VTK file format.
 ///
 int MMG5_loadVtkMesh_part1(MMG5_pMesh mesh,const char *filename,vtkDataSet **dataset,
-                           int8_t *ptMeditRef,int8_t *eltMeditRef,int *nsols) {
+                           int8_t *ptMeditRef,int8_t *eltMeditRef,int *nsols,
+                           int8_t *metricData ) {
 
   (*nsols) = 0;
   (*ptMeditRef) = (*eltMeditRef) = -1;
@@ -274,7 +282,8 @@ int MMG5_loadVtkMesh_part1(MMG5_pMesh mesh,const char *filename,vtkDataSet **dat
   }
 
   // count the number of entities of each type
-  int ier = MMG5_count_vtkEntities ( (*dataset),mesh,ptMeditRef,eltMeditRef,nsols );
+  int ier = MMG5_count_vtkEntities ( (*dataset),mesh,ptMeditRef,eltMeditRef,
+                                     nsols,metricData );
 
   if ( ier != 1 ) {
     return -1;
@@ -290,16 +299,19 @@ int MMG5_loadVtkMesh_part1(MMG5_pMesh mesh,const char *filename,vtkDataSet **dat
 /// @param eltMeditRef index of a cell data field that contains references
 /// (field named medit:ref), -1 if no references
 /// @param nsols number of point data (except the medit:ref ones)
+/// @param metricData 1 if file contains a metric data highlighted by the :metric name
 ///
 /// @return 1 if success, 0 if fail to open/load the file, -1 other errors;
 ///
 /// I/O at Vtu VTK file format, part 1: file reading + count of the number of entities.
 ///
 int MMG5_loadVtuMesh_part1(MMG5_pMesh mesh,const char *filename,vtkDataSet **dataset,
-                           int8_t *ptMeditRef,int8_t *eltMeditRef,int *nsols) {
+                           int8_t *ptMeditRef,int8_t *eltMeditRef,int *nsols,
+                           int8_t *metricData) {
 
   (*nsols) = 0;
   (*ptMeditRef) = (*eltMeditRef) = -1;
+  (*metricData) = 0;
 
   // Read all the data from the file
   try {
@@ -310,7 +322,8 @@ int MMG5_loadVtuMesh_part1(MMG5_pMesh mesh,const char *filename,vtkDataSet **dat
   }
 
   // count the number of entities of each type
-  int ier = MMG5_count_vtkEntities ( (*dataset),mesh,ptMeditRef,eltMeditRef,nsols );
+  int ier = MMG5_count_vtkEntities ( (*dataset),mesh,ptMeditRef,eltMeditRef,
+                                     nsols,metricData );
 
   if ( ier != 1 ) {
     return -1;
@@ -779,7 +792,7 @@ int MMG5_loadVtkMesh_part2(MMG5_pMesh mesh,MMG5_pSol *sol,vtkDataSet **dataset,
           auto ar = cd->GetArray(j);
 
           psl->np = ar->GetNumberOfTuples();
-          if ( nc != psl->np ) {
+          if ( numCells != psl->np ) {
             fprintf(stderr,"  ** MISMATCHES DATA: THE NUMBER OF ELEMENTS IN "
                     "THE MESH (%d) DIFFERS FROM THE NUMBER OF CELLS DATA IN "
                     "THE SOLUTION (%d) \n",mesh->ne,psl->np);

--- a/src/common/vtkparser.cpp
+++ b/src/common/vtkparser.cpp
@@ -779,7 +779,7 @@ int MMG5_loadVtkMesh_part2(MMG5_pMesh mesh,MMG5_pSol *sol,vtkDataSet **dataset,
           auto ar = cd->GetArray(j);
 
           psl->np = ar->GetNumberOfTuples();
-          if ( mesh->ne != psl->np ) {
+          if ( nc != psl->np ) {
             fprintf(stderr,"  ** MISMATCHES DATA: THE NUMBER OF ELEMENTS IN "
                     "THE MESH (%d) DIFFERS FROM THE NUMBER OF CELLS DATA IN "
                     "THE SOLUTION (%d) \n",mesh->ne,psl->np);

--- a/src/common/vtkparser.hpp
+++ b/src/common/vtkparser.hpp
@@ -60,9 +60,9 @@
 #include <vtkCellArray.h>
 #include <typeinfo>
 
-int MMG5_loadVtpMesh_part1(MMG5_pMesh,const char*,vtkDataSet**,int8_t*,int8_t*,int*);
-int MMG5_loadVtuMesh_part1(MMG5_pMesh,const char*,vtkDataSet**,int8_t*,int8_t*,int*);
-int MMG5_loadVtkMesh_part1(MMG5_pMesh,const char*,vtkDataSet**,int8_t*,int8_t*,int*);
+int MMG5_loadVtpMesh_part1(MMG5_pMesh,const char*,vtkDataSet**,int8_t*,int8_t*,int*,int8_t*);
+int MMG5_loadVtuMesh_part1(MMG5_pMesh,const char*,vtkDataSet**,int8_t*,int8_t*,int*,int8_t*);
+int MMG5_loadVtkMesh_part1(MMG5_pMesh,const char*,vtkDataSet**,int8_t*,int8_t*,int*,int8_t*);
 
 int MMG5_loadVtkMesh_part2(MMG5_pMesh,MMG5_pSol*,vtkDataSet**,int8_t,int8_t,int);
 

--- a/src/mmg2d/inout_2d.c
+++ b/src/mmg2d/inout_2d.c
@@ -746,7 +746,7 @@ int MMG2D_loadMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
   if ( sol ) {
     /* Check the metric type */
-    ier = MMG5_chkMetricType(mesh,&sol->type,inm);
+    ier = MMG5_chkMetricType(mesh,&sol->type,&sol->entities,inm);
     if ( ier <1 ) {
       fprintf(stderr,"  ** ERROR WHEN PARSING THE INPUT FILE\n");
       return ier;
@@ -928,7 +928,10 @@ int MMG2D_loadSol(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
     return -1;
   }
 
-  ier = MMG5_chkMetricType(mesh,type,inm);
+  /* #MMG5_loadSolHeader function reads only solution at vertices so we don't
+      have to check the entites on which the metric applies */
+  int entities = MMG5_Vertex;
+  ier = MMG5_chkMetricType(mesh,type,&entities,inm);
   if ( ier < 1 ) {
     MMG5_SAFE_FREE(type);
     return ier;

--- a/src/mmg2d/inoutcpp_2d.cpp
+++ b/src/mmg2d/inoutcpp_2d.cpp
@@ -88,17 +88,18 @@ int MMG2D_loadVtpMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 2;
 
-  ier = MMG5_loadVtpMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtpMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
-  /* Check element count */
-  if ( nsols>1 ) {
-    fprintf(stderr,"Error: SEVERAL SOLUTIONS FOUND (%d)\n",nsols);
+  /* Check data fields */
+  if ( nsols > metricData ) {
+    fprintf(stderr,"Error: %d UNEXPECTED DATA FIELD(S)\n",nsols);
     return -1;
   }
 
@@ -111,7 +112,7 @@ int MMG2D_loadVtpMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
   if ( sol ) {
     /* Check the metric type */
-    ier = MMG5_chkMetricType(mesh,&sol->type,NULL);
+    ier = MMG5_chkMetricType(mesh,&sol->type,&sol->entities,NULL);
     if ( ier <1 ) {
       fprintf(stderr,"  ** UNEXPECTED METRIC TYPE\n");
       return ier;
@@ -130,12 +131,13 @@ int MMG2D_loadVtpMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *fil
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 2;
 
-  ier = MMG5_loadVtpMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtpMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
   mesh->nsols = nsols;
@@ -161,17 +163,18 @@ int MMG2D_loadVtkMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 2;
 
-  ier = MMG5_loadVtkMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtkMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
-  /* Check element count */
-  if ( nsols>1 ) {
-    fprintf(stderr,"Error: SEVERAL SOLUTIONS FOUND (%d)\n",nsols);
+  /* Check data fields */
+  if ( nsols > metricData ) {
+    fprintf(stderr,"Error: %d UNEXPECTED DATA FIELD(S)\n",nsols);
     return -1;
   }
 
@@ -184,7 +187,7 @@ int MMG2D_loadVtkMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
   if ( sol ) {
     /* Check the metric type */
-    ier = MMG5_chkMetricType(mesh,&sol->type,NULL);
+    ier = MMG5_chkMetricType(mesh,&sol->type,&sol->entities,NULL);
     if ( ier <1 ) {
       fprintf(stderr,"  ** UNEXPECTED METRIC TYPE\n");
       return ier;
@@ -203,12 +206,13 @@ int MMG2D_loadVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *fil
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 2;
 
-  ier = MMG5_loadVtkMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtkMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
   mesh->nsols = nsols;
@@ -234,17 +238,18 @@ int MMG2D_loadVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 2;
 
-  ier = MMG5_loadVtuMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtuMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
-  /* Check element count */
-  if ( nsols>1 ) {
-    fprintf(stderr,"Error: SEVERAL SOLUTIONS FOUND (%d)\n",nsols);
+  /* Check data fields */
+  if ( nsols > metricData ) {
+    fprintf(stderr,"Error: %d UNEXPECTED DATA FIELD(S)\n",nsols);
     return -1;
   }
 
@@ -257,7 +262,7 @@ int MMG2D_loadVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
   if ( sol ) {
     /* Check the metric type */
-    ier = MMG5_chkMetricType(mesh,&sol->type,NULL);
+    ier = MMG5_chkMetricType(mesh,&sol->type,&sol->entities,NULL);
     if ( ier <1 ) {
       fprintf(stderr,"  ** UNEXPECTED METRIC TYPE\n");
       return ier;
@@ -277,12 +282,13 @@ int MMG2D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *fil
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 2;
 
-  ier = MMG5_loadVtuMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtuMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
   /* Check element count */

--- a/src/mmg3d/inout_3d.c
+++ b/src/mmg3d/inout_3d.c
@@ -1251,7 +1251,7 @@ int MMG3D_loadMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
   /* Check the metric type */
   if ( sol ) {
-    ier = MMG5_chkMetricType(mesh,&sol->type,inm);
+    ier = MMG5_chkMetricType(mesh,&sol->type,&sol->entities,inm);
   }
 
   return ier;
@@ -2274,7 +2274,10 @@ int MMG3D_loadSol(MMG5_pMesh mesh,MMG5_pSol met, const char *filename) {
     return -1;
   }
 
-  ier = MMG5_chkMetricType(mesh,type,inm);
+  /* #MMG5_loadSolHeader function reads only solution at vertices so we don't
+      have to check the entites on which the metric applies */
+  int entities = MMG5_Vertex;
+  ier = MMG5_chkMetricType(mesh,type,&entities,inm);
 
   if ( ier < 1 ) {
     MMG5_SAFE_FREE(type);

--- a/src/mmg3d/inoutcpp_3d.cpp
+++ b/src/mmg3d/inoutcpp_3d.cpp
@@ -79,17 +79,18 @@ int MMG3D_loadVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 3;
 
-  ier = MMG5_loadVtuMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtuMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
-  /* Check element count */
-  if ( nsols>1 ) {
-    fprintf(stderr,"Error: SEVERAL SOLUTIONS FOUND (%d)\n",nsols);
+  /* Check data fields */
+  if ( nsols > metricData ) {
+    fprintf(stderr,"Error: %d UNEXPECTED DATA FIELD(S)\n",nsols);
     return -1;
   }
 
@@ -102,7 +103,7 @@ int MMG3D_loadVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
   if ( sol ) {
     /* Check the metric type */
-    ier = MMG5_chkMetricType(mesh,&sol->type,NULL);
+    ier = MMG5_chkMetricType(mesh,&sol->type,&sol->entities,NULL);
   }
 
   return ier;
@@ -118,12 +119,13 @@ int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *fil
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 3;
 
-  ier = MMG5_loadVtuMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtuMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
   mesh->nsols = nsols;
@@ -150,17 +152,18 @@ int MMG3D_loadVtkMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 3;
 
-  ier = MMG5_loadVtkMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtkMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
-  // Check solutions number
-  if ( nsols>1 ) {
-    fprintf(stderr,"Error: SEVERAL SOLUTIONS FOUND (%d)\n",nsols);
+  /* Check data fields */
+  if ( nsols > metricData ) {
+    fprintf(stderr,"Error: %d UNEXPECTED DATA FIELD(S)\n",nsols);
     return -1;
   }
 
@@ -173,7 +176,7 @@ int MMG3D_loadVtkMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
   if ( sol ) {
     /* Check the metric type */
-    ier = MMG5_chkMetricType(mesh,&sol->type,NULL);
+    ier = MMG5_chkMetricType(mesh,&sol->type,&sol->entities,NULL);
   }
 
   return ier;
@@ -189,12 +192,13 @@ int MMG3D_loadVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *fil
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 3;
 
-  ier = MMG5_loadVtkMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtkMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
   mesh->nsols = nsols;

--- a/src/mmgs/inout_s.c
+++ b/src/mmgs/inout_s.c
@@ -758,7 +758,7 @@ int MMGS_loadMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
   if ( sol ) {
     /* Check the metric type */
-    ier = MMG5_chkMetricType(mesh,&sol->type,inm);
+    ier = MMG5_chkMetricType(mesh,&sol->type,&sol->entities,inm);
   }
 
   return ier;
@@ -1398,7 +1398,10 @@ int MMGS_loadSol(MMG5_pMesh mesh,MMG5_pSol met,const char* filename) {
     return -1;
   }
 
-  ier = MMG5_chkMetricType(mesh,type,inm);
+  /* #MMG5_loadSolHeader function reads only solution at vertices so we don't
+      have to check the entites on which the metric applies */
+  int entities = MMG5_Vertex;
+  ier = MMG5_chkMetricType(mesh,type,&entities,inm);
   if ( ier < 1 ) {
     MMG5_SAFE_FREE(type);
     return ier;

--- a/src/mmgs/inoutcpp_s.cpp
+++ b/src/mmgs/inoutcpp_s.cpp
@@ -80,17 +80,18 @@ int MMGS_loadVtpMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 3;
 
-  ier = MMG5_loadVtpMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtpMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
-  /* Check element count */
-  if ( nsols>1 ) {
-    fprintf(stderr,"Error: SEVERAL SOLUTIONS FOUND (%d)\n",nsols);
+  /* Check data fields */
+  if ( nsols > metricData ) {
+    fprintf(stderr,"Error: %d UNEXPECTED DATA FIELD(S)\n",nsols);
     return -1;
   }
 
@@ -103,7 +104,7 @@ int MMGS_loadVtpMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
   if ( sol ) {
     /* Check the metric type */
-    ier = MMG5_chkMetricType(mesh,&sol->type,NULL);
+    ier = MMG5_chkMetricType(mesh,&sol->type,&sol->entities,NULL);
   }
 
   return ier;
@@ -119,12 +120,13 @@ int MMGS_loadVtpMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *file
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 3;
 
-  ier = MMG5_loadVtpMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtpMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
   mesh->nsols = nsols;
@@ -150,17 +152,18 @@ int MMGS_loadVtkMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet *dataset;
 
   mesh->dim = 3;
 
-  ier = MMG5_loadVtkMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtkMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
-  /* Check element count */
-  if ( nsols>1 ) {
-    fprintf(stderr,"Error: SEVERAL SOLUTIONS FOUND (%d)\n",nsols);
+  /* Check data fields */
+  if ( nsols > metricData ) {
+    fprintf(stderr,"Error: %d UNEXPECTED DATA FIELD(S)\n",nsols);
     return -1;
   }
 
@@ -173,7 +176,7 @@ int MMGS_loadVtkMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
   if ( sol ) {
     /* Check the metric type */
-    ier = MMG5_chkMetricType(mesh,&sol->type,NULL);
+    ier = MMG5_chkMetricType(mesh,&sol->type,&sol->entities,NULL);
   }
 
   return ier;
@@ -189,12 +192,13 @@ int MMGS_loadVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *file
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet *dataset;
 
   mesh->dim = 3;
 
-  ier = MMG5_loadVtkMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtkMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
   mesh->nsols = nsols;
@@ -220,17 +224,18 @@ int MMGS_loadVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 3;
 
-  ier = MMG5_loadVtuMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtuMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
-  /* Check element count */
-  if ( nsols>1 ) {
-    fprintf(stderr,"Error: SEVERAL SOLUTIONS FOUND (%d)\n",nsols);
+  /* Check data fields */
+  if ( nsols > metricData ) {
+    fprintf(stderr,"Error: %d UNEXPECTED DATA FIELD(S)\n",nsols);
     return -1;
   }
 
@@ -243,7 +248,7 @@ int MMGS_loadVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
   if ( sol ) {
     /* Check the metric type */
-    ier = MMG5_chkMetricType(mesh,&sol->type,NULL);
+    ier = MMG5_chkMetricType(mesh,&sol->type,&sol->entities,NULL);
   }
 
   return ier;
@@ -259,12 +264,13 @@ int MMGS_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *file
 
 #else
   int         ier,nsols;
-  int8_t      ptMeditRef,eltMeditRef;
+  int8_t      ptMeditRef,eltMeditRef,metricData;
   vtkDataSet  *dataset;
 
   mesh->dim = 3;
 
-  ier = MMG5_loadVtuMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,&nsols);
+  ier = MMG5_loadVtuMesh_part1(mesh,filename,&dataset,&ptMeditRef,&eltMeditRef,
+                               &nsols,&metricData);
   if ( ier < 1 ) return ier;
 
   mesh->nsols = nsols;


### PR DESCRIPTION
Fail if input VTK file contains a solution field (previously, without metric, the solution field was interpreted as the metric, even if defined on elements and not on vertices).