### PR TITLE
Feature/mmgs algo with user met

### DIFF
--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: [ubuntu-20.04,macos-10.15]
+            os: [ubuntu-20.04,macos-12]
             pattern: [on,off]
             pointmap: [off]
             scotch: [on,off]

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -41,7 +41,7 @@ jobs:
                 scotch: off
                 vtk: on
 
-              - os: macos-10.15
+              - os: macos-12
                 pattern: off
                 pointmap: off
                 scotch: off
@@ -54,7 +54,7 @@ jobs:
                 scotch: on
                 vtk: off
 
-              - os: macos-10.15
+              - os: macos-12
                 pattern: off
                 pointmap: on
                 scotch: on

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -815,7 +815,7 @@ EXAMPLE_RECURSIVE      = YES
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             = .
+IMAGE_PATH             =  @CMAKE_CURRENT_SOURCE_DIR@/doc/doxygen/images
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program
@@ -863,7 +863,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = README.md
+USE_MDFILE_AS_MAINPAGE = @CMAKE_CURRENT_SOURCE_DIR@/README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/src/common/intmet.c
+++ b/src/common/intmet.c
@@ -176,6 +176,11 @@ int MMG5_intridmet(MMG5_pMesh mesh,MMG5_pSol met,int ip1, int ip2,double s,
   if ( (MG_SIN(p1->tag) || (p1->tag & MG_NOM)) &&
        (MG_SIN(p2->tag) || (p2->tag & MG_NOM)) ) {
     /* m1 and m2 are isotropic metrics */
+    /* Remark (Algiane): Perspective of improvement can be:
+       - 1. to not force isotropy at singular point
+       - 2. to not force the metric to be along tangent and normal dir at ridge point
+    */
+
     dd  = (1-s)*sqrt(m2[0]) + s*sqrt(m1[0]);
     dd *= dd;
     if ( dd < MMG5_EPSD ) {

--- a/src/common/mettools.c
+++ b/src/common/mettools.c
@@ -1121,7 +1121,7 @@ int MMG5_test_intersecmet33(MMG5_pMesh mesh) {
  *
  * Intersect the surface metric held in np (supported in tangent plane of \a np)
  * with 3*3 physical metric in \a me. For ridge points, this function fill the
- * \f$ p_0->m[3]\f$ and \f$ p_0->m[4]\f$ fields that contains respectively the
+ * \f$ p_0 \rightarrow m[3]\f$ and \f$ p_0 \rightarrow m[4]\f$ fields that contains respectively the
  * specific sizes in the \f$n_1\f$ and \f$n_2\f$ directions.
  *
  */
@@ -1142,11 +1142,30 @@ int MMG5_mmgIntextmet(MMG5_pMesh mesh,MMG5_pSol met,int np,double me[6],
   p0 = &mesh->point[np];
   m  = &met->m[6*np];
 
-  /* Case of a singular point : since MMG5_defmetsin() computes an isotropic
+  /** Case of a singular point : since MMG5_defmetsin() computes an isotropic
    * metric, scale it by the physical metric while keeping it isotropic */
   if ( MG_SIN(p0->tag) || (p0->tag & MG_NOM) ) {
 
-    /* Compute minimum size in physical metric */
+    /** 1. Compute minimum size in physical metric.
+     * Note that, if we enforce an isotropic metric at singular points, we have
+     *  2 direct choices:
+     *   - use the maximal size to make the physical metric iso. In a first
+     * guess it seems to be a good idea to limit the impact of singular points
+     * over the mesh but in practice it leads to collapse too much. See the
+     * following pictures of adaptation over a constant aniso metric with mmgs
+     * without gradation and with gradation.
+     * \image html mmgs-max-on-sin-nograd.png "Max siz on sin points, no gradation" width=30%
+     * \image html mmgs-max-on-sin-grad.png "Max siz on sin points, with gradation" width=15%
+     *   - use the minimal size to make the physical metric iso. Adaptation
+     * over a constant aniso metric with mmgs without gradation
+     * shows the creation of a small element at each corner.
+     * The computed iso size correspond to the size imposed on the
+     * top surface. With gradation, the gradation removes the anisotropy everywhere
+     * so the metric at corners has no effect).
+     * \image html mmgs-min-on-sin-nograd.png "Max siz on sin points, no gradation" width=30%
+     * \image html mmgs-min-on-sin-grad.png "Max siz on sin points, with gradation" width=15%
+     *
+     */
     order = MMG5_eigenv3d(1,me,lambda,vp);
     if ( !order ) {
       if ( !mmgWarn ) {
@@ -1162,16 +1181,16 @@ int MMG5_mmgIntextmet(MMG5_pMesh mesh,MMG5_pSol met,int np,double me[6],
       hu = MG_MAX(hu,lambda[i]);
     }
 
-    /* Truncate physical size with respect to mesh constraints */
+    /** 2. Truncate physical size with respect to mesh constraints */
     hu = MG_MIN(isqhmin,hu);
     hu = MG_MAX(isqhmax,hu);
 
-    /* Overwrite diagonal metric if physical metric prescribes smaller sizes */
+    /** 3. Overwrite diagonal metric if physical metric prescribes smaller sizes */
     if( hu > m[0] )
       m[0] = m[3] = m[5] = hu;
 
   }
-  /* Case of a ridge point : take sizes in 3 directions t,n1,u */
+  /** Case of a ridge point : take sizes in 3 directions t,n1,u */
   else if ( p0->tag & MG_GEO ) {
     /* Size prescribed by metric me in direction t */
     t = n;
@@ -1182,7 +1201,7 @@ int MMG5_mmgIntextmet(MMG5_pMesh mesh,MMG5_pSol met,int np,double me[6],
     hu = MG_MAX(isqhmax,hu);
     m[0] = MG_MAX(m[0],hu);
 
-    /* Size prescribed by metric me in direction u1 = n1 ^ t */
+    /** 1. Size prescribed by metric me in direction u1 = n1 ^ t */
     assert ( p0->xp );
     go = &mesh->xpoint[p0->xp];
     n1 = &go->n1[0];
@@ -1206,7 +1225,7 @@ int MMG5_mmgIntextmet(MMG5_pMesh mesh,MMG5_pSol met,int np,double me[6],
       hu = MG_MAX(isqhmax,hu);
       m[1] = MG_MAX(m[1],hu);
     }
-    /* Size prescribed by metric me in direction u2 = n2 ^ t */
+    /** 2. Size prescribed by metric me in direction u2 = n2 ^ t */
     u[0] = n2[1]*t[2] - n2[2]*t[1];
     u[1] = n2[2]*t[0] - n2[0]*t[2];
     u[2] = n2[0]*t[1] - n2[1]*t[0];
@@ -1226,7 +1245,7 @@ int MMG5_mmgIntextmet(MMG5_pMesh mesh,MMG5_pSol met,int np,double me[6],
       m[2] = MG_MAX(m[2],hu);
     }
 
-    /* Size prescribed by metric me in direction n1 */
+    /** 3. Size prescribed by metric me in direction n1 */
     hu = me[0]*n1[0]*n1[0] + me[3]*n1[1]*n1[1] + me[5]*n1[2]*n1[2]
       + 2.0*me[1]*n1[0]*n1[1] + 2.0*me[2]*n1[0]*n1[2] + 2.0*me[4]*n1[1]*n1[2];
 
@@ -1234,7 +1253,7 @@ int MMG5_mmgIntextmet(MMG5_pMesh mesh,MMG5_pSol met,int np,double me[6],
     hu = MG_MAX(isqhmax,hu);
     m[3] = hu;
 
-    /* Size prescribed by metric me in direction n2 */
+    /** 4. Size prescribed by metric me in direction n2 */
     hu = me[0]*n2[0]*n2[0] + me[3]*n2[1]*n2[1] + me[5]*n2[2]*n2[2]
       + 2.0*me[1]*n2[0]*n2[1] + 2.0*me[2]*n2[0]*n2[2] + 2.0*me[4]*n2[1]*n2[2];
 
@@ -1242,11 +1261,11 @@ int MMG5_mmgIntextmet(MMG5_pMesh mesh,MMG5_pSol met,int np,double me[6],
     hu = MG_MAX(isqhmax,hu);
     m[4] = hu;
   }
-  /* Case of a ref, or regular point : intersect metrics in tangent plane */
+  /** Case of a ref, or regular point : intersect metrics in tangent plane */
   else {
     MMG5_rotmatrix(n,r);
 
-    /* Expression of both metrics in tangent plane */
+    /** 1. Expression of both metrics in tangent plane */
     MMG5_rmtr(r,m,mrot);
     mtan[0] = mrot[0];
     mtan[1] = mrot[1];
@@ -1258,7 +1277,7 @@ int MMG5_mmgIntextmet(MMG5_pMesh mesh,MMG5_pSol met,int np,double me[6],
     metan[1] = mrot[1];
     metan[2] = mrot[3];
 
-    /* Intersection of metrics in the tangent plane */
+    /** 2. Intersection of metrics in the tangent plane */
     if ( !MMG5_intersecmet22(mesh,mtan,metan,mr) ) {
       if ( !mmgWarn1 ) {
         fprintf(stderr,"\n  ## Warning: %s: impossible metric intersection:"
@@ -1275,7 +1294,7 @@ int MMG5_mmgIntextmet(MMG5_pMesh mesh,MMG5_pSol met,int np,double me[6],
       return 0;
     }
 
-    /* Back to the canonical basis of \mathbb{R}^3 : me = ^tR*mr*R : mtan and
+    /** 3. Back to the canonical basis of \mathbb{R}^3 : me = ^tR*mr*R : mtan and
      * metan are reused */
     mtan[0]  = mr[0]*r[0][0] + mr[1]*r[1][0];
     mtan[1]  = mr[0]*r[0][1] + mr[1]*r[1][1];
@@ -1295,7 +1314,7 @@ int MMG5_mmgIntextmet(MMG5_pMesh mesh,MMG5_pSol met,int np,double me[6],
     m[4] = r[0][1] * mtan[2] + r[1][1] * metan[2] + r[2][1]*alpha3;
     m[5] = r[0][2] * mtan[2] + r[1][2] * metan[2] + r[2][2]*alpha3;
 
-    /* Truncate the metric in the third direction (because me was not
+    /** 4. Truncate the metric in the third direction (because me was not
      * truncated) */
     order = MMG5_eigenv3d(1,m,lambda,vp);
     if ( !order ) {

--- a/src/mmgs/anisosiz_s.c
+++ b/src/mmgs/anisosiz_s.c
@@ -155,15 +155,18 @@ static int MMG5_defmetsin(MMG5_pMesh mesh,MMG5_pSol met,int it,int ip) {
  *
  * Compute metric tensor associated to a ridge point : convention is a bit weird
  * here :
- *  - p->m[0] is the specific size in direction \a t,
- *  - p->m[1] is the specific size in direction \f$u_1 = n_1^{}t\f$,
- *  - p->m[2] is the specific size in direction \f$u_2 = n_2^{}t\f$,
- *  - p->m[3] is the specific size in direction \f$n_1\f$
+ *   - p->m[0] is the specific size in direction \a t,
+ *   - p->m[1] is the specific size in direction \f$ u_1 = n_1 \wedge t \f$ ,
+ *   - p->m[2] is the specific size in direction \f$ u_2 = n_2 \wedge t \f$ ,
+ *   - p->m[3] is the specific size in direction \f$ n_1 \f$
+ *     (computed by the \a MMG5_intextmet function),
+ *   - p->m[4] is the specific size in direction \f$n_2\f$ ,
  *    (computed by the \a MMG5_intextmet function),
- *  - p->m[4] is the specific size in direction \f$n_2\f$,
- *   (computed by the \a MMG5_intextmet function),
  * and at each time, metric tensor has to be recomputed, depending on the side.
  *
+ * \warning As it is implemented, the interpolation at ridge point from 2
+ * singular points leads to an isotropic metric of size m[0] (even if the metric
+ * at singular points is not enforced to be isotropic).
  */
 static int MMG5_defmetrid(MMG5_pMesh mesh,MMG5_pSol met,int it,int ip) {
   MMG5_pTria     pt;
@@ -704,6 +707,13 @@ int MMGS_intextmet(MMG5_pMesh mesh,MMG5_pSol met,int np,double me[6]) {
  *
  * Define size at points by intersecting the surfacic metric and the
  * physical metric.
+ *
+ * The output metric is:
+ *   - at singular points: isotropic
+ *   - at ridge points: anisotropic in the orthonormal basis defined by the
+ * tangent at the ridge and the normal at each portion of surface.
+ *   - at surface boundary points: anisotropic in an orthonormal basis difined
+ * in the tangent plane and the direction normal to this plane.
  *
  */
 int MMGS_defsiz_ani(MMG5_pMesh mesh,MMG5_pSol met) {

--- a/src/mmgs/libmmgs_private.h
+++ b/src/mmgs/libmmgs_private.h
@@ -151,12 +151,16 @@ int  MMGS_split1(MMG5_pMesh mesh,MMG5_pSol met,int k,int i,int *vx);
 int  MMGS_split2(MMG5_pMesh mesh,MMG5_pSol met,int k,int *vx);
 int  MMGS_split3(MMG5_pMesh mesh,MMG5_pSol met,int k,int *vx);
 int  split1b(MMG5_pMesh mesh,int k,int8_t i,int ip);
-int  chkcol(MMG5_pMesh mesh,MMG5_pSol met,int k,int8_t i,int *list,int8_t typchk);
+int  chkcol(MMG5_pMesh mesh,MMG5_pSol met,int k,int8_t i,int *list,int8_t typchk,
+            double (*MMGS_lenEdg)(MMG5_pMesh,MMG5_pSol,int ,int,int8_t),
+            double (*MMGS_caltri)(MMG5_pMesh,MMG5_pSol,MMG5_pTria));
 int  colver(MMG5_pMesh mesh,int *list,int ilist);
 int  colver3(MMG5_pMesh mesh,int*list);
 int  colver2(MMG5_pMesh mesh,int *ilist);
 int  swapar(MMG5_pMesh mesh,int k,int i);
-int  chkswp(MMG5_pMesh mesh,MMG5_pSol met,int k,int i,int8_t typchk);
+int  chkswp(MMG5_pMesh mesh,MMG5_pSol met,int k,int i,int8_t typchk,
+            double (*MMGS_lenEdg)(MMG5_pMesh,MMG5_pSol,int ,int,int8_t),
+            double (*MMGS_caltri)(MMG5_pMesh,MMG5_pSol,MMG5_pTria));
 int  swpedg(MMG5_pMesh mesh,MMG5_pSol met,int *list,int ilist,int8_t typchk);
 int8_t typelt(MMG5_pPoint p[3],int8_t *ia);
 int  litswp(MMG5_pMesh mesh,int k,int8_t i,double kal);

--- a/src/mmgs/swapar_s.c
+++ b/src/mmgs/swapar_s.c
@@ -35,9 +35,28 @@
 
 #include "libmmgs_private.h"
 #include "mmgexterns.h"
+#include "inlined_functions.h"
 
-/* Check whether edge i of triangle k should be swapped for geometric approximation purposes */
-int chkswp(MMG5_pMesh mesh,MMG5_pSol met,int k,int i,int8_t typchk) {
+/**
+ * \param mesh pointer toward the mesh
+ * \param met pointer toward the metric
+ * \param k index of the element in wich we perform the edge swap
+ * \param i index of the edge to swap
+ * \param typchk type of check to perform
+ * \param MMGS_lenEdg pointer toward the suitable fct to compute edge lengths
+ * depending on presence of input metric, metric type (iso/aniso) and \a typchk
+ * value (i.e. stage of adaptation)
+ * \param MMGS_caltri pointer toward the suitable fct to compute tria quality
+ * depending on presence of input metric, metric type (iso/aniso) and \a typchk
+ * value (i.e. stage of adaptation)
+ *
+ * Check whether edge i of triangle k should be swapped for geometric
+ * approximation purposes
+ *
+ */
+int chkswp(MMG5_pMesh mesh,MMG5_pSol met,int k,int i,int8_t typchk,
+           double (*MMGS_lenEdg)(MMG5_pMesh,MMG5_pSol,int ,int,int8_t),
+           double (*MMGS_caltri)(MMG5_pMesh,MMG5_pSol,MMG5_pTria)) {
   MMG5_pTria    pt,pt0,pt1;
   MMG5_pPoint   p[3],q;
   MMG5_pPar      par;
@@ -94,9 +113,9 @@ int chkswp(MMG5_pMesh mesh,MMG5_pSol met,int k,int i,int8_t typchk) {
   }
 
   /* check length */
-  if ( typchk == 2 && met->m ) {
-    loni = MMG5_lenSurfEdg(mesh,met,ip1,ip2,0);
-    lona = MMG5_lenSurfEdg(mesh,met,ip0,iq,0);
+  if ( MMGS_lenEdg ) {
+    loni = MMGS_lenEdg(mesh,met,ip1,ip2,0);
+    lona = MMGS_lenEdg(mesh,met,ip0,iq,0);
     if ( loni > 1.0 )  loni = MG_MIN(1.0 / loni,MMGS_LSHRT);
     if ( lona > 1.0 )  lona = 1.0 / lona;
     if ( lona < loni || !loni )  return 0;
@@ -263,14 +282,14 @@ int chkswp(MMG5_pMesh mesh,MMG5_pSol met,int k,int i,int8_t typchk) {
   }
   else {
     pt0->v[0]= ip0;  pt0->v[1]= ip1;  pt0->v[2]= ip2;
-    cal1 = MMG5_caltri_iso(mesh,NULL,pt0);
+    cal1 = MMGS_caltri(mesh,met,pt0);
     pt0->v[0]= ip1;  pt0->v[1]= iq;   pt0->v[2]= ip2;
-    cal2 = MMG5_caltri_iso(mesh,NULL,pt0);
+    cal2 = MMGS_caltri(mesh,met,pt0);
     calnat = MG_MIN(cal1,cal2);
     pt0->v[0]= ip0;  pt0->v[1]= ip1;  pt0->v[2]= iq;
-    cal1 = MMG5_caltri_iso(mesh,NULL,pt0);
+    cal1 = MMGS_caltri(mesh,met,pt0);
     pt0->v[0]= ip0;  pt0->v[1]= iq;   pt0->v[2]= ip2;
-    cal2 = MMG5_caltri_iso(mesh,NULL,pt0);
+    cal2 = MMGS_caltri(mesh,met,pt0);
     calchg = MG_MIN(cal1,cal2);
   }
 
@@ -368,80 +387,4 @@ int swapar(MMG5_pMesh mesh,int k,int i) {
   mesh->adja[3*(adj-1)+1+j]   = 3*k11+v11;
 
   return 1;
-}
-
-
-/* flip edge i of tria k for isotropic mesh*/
-int litswp(MMG5_pMesh mesh,int k,int8_t i,double kali) {
-  MMG5_pTria    pt,pt0,pt1;
-  double        kalf,kalt,ps,n1[3],n2[3];
-  int          *adja,ia,ib,ic,id,kk;
-  int8_t        ii,i1,i2;
-
-  pt0 = &mesh->tria[0];
-  pt  = &mesh->tria[k];
-  if ( !MG_EOK(pt) || MG_EDG(pt->tag[i]) )  return 0;
-
-  i1 = MMG5_inxt2[i];
-  i2 = MMG5_iprv2[i];
-  ia = pt->v[i];
-  ib = pt->v[i1];
-  ic = pt->v[i2];
-
-  adja = &mesh->adja[3*(k-1)+1];
-  kk  = adja[i] / 3;
-  ii  = adja[i] % 3;
-  pt1 = &mesh->tria[kk];
-  if ( MS_SIN(pt1->tag[ii]) )  return 0;
-  id = pt1->v[ii];
-
-  /* check non convexity */
-  MMG5_norpts(mesh,ia,ib,id,n1);
-  MMG5_norpts(mesh,ia,id,ic,n2);
-  ps = n1[0]*n2[0] + n1[1]*n2[1] + n1[2]*n2[2];
-  if ( ps < MMG5_ANGEDG )  return 0;
-
-  /* check quality */
-  pt0->v[0] = id;  pt0->v[1] = ic;  pt0->v[2] = ib;
-  kalt = MMG5_calelt(mesh,NULL,pt0);
-  kali = MG_MIN(kali,kalt);
-  pt0->v[0] = ia;  pt0->v[1] = id;  pt0->v[2] = ic;
-  kalt = MMG5_calelt(mesh,NULL,pt0);
-  pt0->v[0] = ia;  pt0->v[1] = ib;  pt0->v[2] = id;
-  kalf = MMG5_calelt(mesh,NULL,pt0);
-  kalf = MG_MIN(kalf,kalt);
-  if ( kalf > 1.02 * kali ) {
-    swapar(mesh,k,i);
-    return 1;
-  }
-  return 0;
-}
-
-
-/**
- * attempt to swap any edge below quality value
- * list goes from 0 to ilist-1.
- *
- * \warning not used
- *
- */
-int swpedg(MMG5_pMesh mesh,MMG5_pSol met,int *list,int ilist,int8_t typchk) {
-  int      k,ns,iel;
-  int8_t   i,i1;
-
-  k  = 0;
-  ns = 0;
-  do {
-    iel = list[k] / 3;
-    i   = list[k] % 3;
-    i1  = MMG5_inxt2[i];
-    if ( chkswp(mesh,met,iel,i1,typchk) ) {
-      ns += swapar(mesh,iel,i1);
-      k++;
-    }
-    k++;
-  }
-  while ( k < ilist );
-
-  return ns;
 }


### PR DESCRIPTION
Modifications of mmgs algo to take into account the metric in the first wave of adapatation (`anatri(typchk=1)`).

Now, edge lengths and qualities of first wave are computed using the input metric to have a better convergency.
Comparision of meshes after the call to anatet 1 for original algo (left) and new one (right):
![Capture d’écran 2022-07-21 à 14 47 52](https://user-images.githubusercontent.com/11232703/180222962-033e587f-76c8-447f-8372-64ac21d11b08.png)

Final meshes (run with disabled gradation) are similar:
![Capture d’écran 2022-07-21 à 15 09 29](https://user-images.githubusercontent.com/11232703/180223675-6021f7b6-5b35-499a-885d-d2dea1894852.png)

Terminal outputs are attached.
[old-algo.txt](https://github.com/MmgTools/mmg/files/9159674/old-algo.txt)
[new-algo.txt](https://github.com/MmgTools/mmg/files/9159677/new-algo.txt)

