### PR TITLE
Add git_log_mmg.h as BYPRODUCT of GenerateGitHash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ IF (NOT WIN32 OR MINGW)
     COMMAND ./git_log_mmg.sh ${PROJECT_SOURCE_DIR} ${COMMON_BINARY_DIR}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/scripts/
     COMMENT "Getting git commit hash"
+    BYPRODUCTS ${COMMON_BINARY_DIR}/git_log_mmg.h
   )
 ENDIF ()
 


### PR DESCRIPTION
# Why ?

Attempting to utilize Ninja generator:

```
cmake .. -G Ninja
```

results in the following warnings:

```
CMake Warning (dev):
  Policy CMP0058 is not set: Ninja requires custom command byproducts to be
  explicit.  Run "cmake --help-policy CMP0058" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  This project specifies custom command DEPENDS on files in the build tree
  that are not specified as the OUTPUT or BYPRODUCTS of any
  add_custom_command or add_custom_target:

   src/common/git_log_mmg.h

  For compatibility with versions of CMake that did not have the BYPRODUCTS
  option, CMake is generating phony rules for such files to convince 'ninja'
  to build.

  Project authors should add the missing BYPRODUCTS or OUTPUT options to the
  custom commands that produce these files.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Furthermore, it breaks the build when including mmg via an `add_subdirectory` call because the `git_log_mmg.h` target is not found since it is never specified as a target. This PR fixes the warning and the errors I have observed.

# How to test?

Clone the PR and attempt a build with Ninja:

```
cmake .. -G Ninja
ninja
```