### PR TITLE
Feature/fix 2d unsnapping

### DIFF
--- a/cmake/testing/libmmg3d_tests.cmake
+++ b/cmake/testing/libmmg3d_tests.cmake
@@ -167,7 +167,9 @@ TARGET_LINK_LIBRARIES ( test_met3d PRIVATE ${M_LIB} )
 
 IF ( MMG3D_CI AND NOT ONLY_VERY_SHORT_TESTS )
   SET ( src_test_ridge_preservation_in_ls_mode
+    ${PROJECT_SOURCE_DIR}/src/common/boulep.c
     ${PROJECT_SOURCE_DIR}/src/common/hash.c
+    ${PROJECT_SOURCE_DIR}/src/common/mmgexterns.c
     ${PROJECT_SOURCE_DIR}/src/common/mmg2.c
     ${PROJECT_SOURCE_DIR}/src/common/tools.c
     ${PROJECT_SOURCE_DIR}/src/mmg3d/bezier_3d.c

--- a/cmake/testing/mmg2d_tests.cmake
+++ b/cmake/testing/mmg2d_tests.cmake
@@ -671,3 +671,44 @@ IF ( ELAS_FOUND AND NOT USE_ELAS MATCHES OFF )
     )
 
 ENDIF()
+
+###############################################################################
+#####
+#####         Check snapping (prevision of non-manifold situations)
+#####
+###############################################################################
+#####
+SET(nmRegex "unsnap at least 1 point")
+
+ADD_TEST(NAME mmg2d_LSSnapval_manifold1
+  COMMAND ${EXECUT_MMG2D} -v 5  -ls
+  -in ${MMG2D_CI_TESTS}/LSSnapval/8elts1.mesh
+  -sol ${MMG2D_CI_TESTS}/LSSnapval/manifold.sol
+  -out ${CTEST_OUTPUT_DIR}/mmg2d_LSSnapval_manifold1.o.mesh
+  )
+
+ADD_TEST(NAME mmg2d_LSSnapval_manifold2
+  COMMAND ${EXECUT_MMG2D} -v 5  -ls
+  -in ${MMG2D_CI_TESTS}/LSSnapval/8elts2.mesh
+  -sol ${MMG2D_CI_TESTS}/LSSnapval/manifold.sol
+  -out ${CTEST_OUTPUT_DIR}/mmg2d_LSSnapval_manifold2.o.mesh
+  )
+
+SET_PROPERTY(TEST mmg2d_LSSnapval_manifold1 mmg2d_LSSnapval_manifold2
+  PROPERTY FAIL_REGULAR_EXPRESSION "${nmRegex}")
+
+ADD_TEST(NAME mmg2d_LSSnapval_non-manifold1
+  COMMAND ${EXECUT_MMG2D} -v 5  -ls
+  -in ${MMG2D_CI_TESTS}/LSSnapval/8elts1.mesh
+  -sol ${MMG2D_CI_TESTS}/LSSnapval/8elts1-nm.sol
+  -out ${CTEST_OUTPUT_DIR}/mmg2d_LSSnapval_non-manifold1.o.mesh
+  )
+
+ADD_TEST(NAME mmg2d_LSSnapval_non-manifold2
+  COMMAND ${EXECUT_MMG2D} -v 5  -ls
+  -in ${MMG2D_CI_TESTS}/LSSnapval/8elts2.mesh
+  -sol ${MMG2D_CI_TESTS}/LSSnapval/8elts2-nm.sol
+  -out ${CTEST_OUTPUT_DIR}/mmg2d_LSSnapval_non-manifold2.o.mesh
+  )
+SET_PROPERTY(TEST mmg2d_LSSnapval_non-manifold1 mmg2d_LSSnapval_non-manifold2
+  PROPERTY PASS_REGULAR_EXPRESSION "${nmRegex}")


### PR DESCRIPTION
Fix issue in the count of the edges splitted by the level-set function when checking for the creation of non-manifold situations due to value snapping in mmg2d (see `mmg2d_LSSnapval_manifold1` and  `mmg2d_LSSnapval_manifold1` continuous integration tests).