### PR TITLE
Fix issue with usage of private headers of Mmg in other codes (ParMmg for example)

### DIFF
--- a/cmake/modules/mmg.cmake
+++ b/cmake/modules/mmg.cmake
@@ -52,6 +52,11 @@ LIST(REMOVE_ITEM mmg_library_files
   ${MMGS_SOURCE_DIR}/mmgs.c
   ${MMG3D_SOURCE_DIR}/mmg3d.c
   ${REMOVE_FILE} )
+FILE(
+  GLOB
+  mmg_header_files
+  ${COMMON_SOURCE_DIR}/*.h
+  )
 
 IF ( VTK_FOUND )
   LIST(APPEND  mmg_library_files
@@ -99,6 +104,9 @@ IF ( LIBMMG_STATIC OR LIBMMG_SHARED )
   SET( mmg_headers
     ${PROJECT_SOURCE_DIR}/src/mmg/libmmg.h
     ${PROJECT_SOURCE_DIR}/src/mmg/libmmgf.h
+    ${COMMON_BINARY_DIR}/mmgcmakedefines.h
+    ${COMMON_BINARY_DIR}/mmgversion.h
+    ${mmg_header_files}
     )
   SET(MMG2D_INCLUDE ${PROJECT_BINARY_DIR}/include/mmg/mmg2d )
   SET(MMGS_INCLUDE ${PROJECT_BINARY_DIR}/include/mmg/mmgs )

--- a/cmake/modules/mmg3d.cmake
+++ b/cmake/modules/mmg3d.cmake
@@ -130,6 +130,8 @@ ENDIF()
 # mmg3d header files needed for library
 SET( mmg3d_headers
   ${MMG3D_SOURCE_DIR}/libmmg3d.h
+  ${MMG3D_SOURCE_DIR}/mmg3d.h
+  ${MMG3D_SOURCE_DIR}/inlined_functions_3d.h
   ${MMG3D_BINARY_DIR}/libmmg3df.h
   ${COMMON_SOURCE_DIR}/libmmgtypes.h
   ${COMMON_BINARY_DIR}/libmmgtypesf.h
@@ -138,6 +140,10 @@ SET( mmg3d_headers
   )
 IF (NOT WIN32 OR MINGW)
   LIST(APPEND mmg3d_headers  ${COMMON_BINARY_DIR}/git_log_mmg.h )
+  IF (LIBMMG_STATIC OR LIBMMG_SHARED)
+    SET(mmg3d_git_header  ${COMMON_BINARY_DIR}/git_log_mmg.h)
+    INSTALL(FILES ${mmg3d_git_header} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mmg/ COMPONENT headers)
+  ENDIF()
 ENDIF()
 
 


### PR DESCRIPTION
### ⚠️ NOT TO MERGE RIGHT NOW ⚠️

🚧 Need to be reviewed and maybe fixed (implementation may have to be completed...) 🚧

This branch is probably linked (to check) with the branch  `Feature/compilation simplification` and [PR #69 ](https://github.com/MmgTools/ParMmg/pull/69) of ParMmg.

ParMmg uses private Mmg headers that for now are searched in the build directory of Mmg (because they are not installed by Mmg). What we would like to do is to allow installation of this private headers but only in a specific mode (for advanced users) because we do not not guarantee not to modify the prototype of private functions and we do not ensure the support on these functions.
Note that this solution will not work on windows because symbols have to be explicitly exported (but ParMmg has not been ported on windows).

Current branch probably adress this issue.
