### PR TITLE
Cleaning of exec name generation and [skip output comparison] option in GitHub Action

### DIFF
--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -160,6 +160,12 @@ jobs:
         env:
           NJOBS: "2"
 
+      - name: Set environment variables for output comparison
+        if: "! contains(github.event.head_commit.message, '[skip output comparison]')"
+        run: |
+          echo "C_FLG=\"-DCMAKE_C_FLAGS=-DMMG_COMPARABLE_OUTPUT\"" >> "$GITHUB_ENV"
+          echo "MMG_ERROR_RULE=\"COMMAND_ERROR_IS_FATAL ANY\"" >> "$GITHUB_ENV"
+
       - name: Install VTK
         # Download vtk only if used
         if: matrix.vtk == 'on'
@@ -222,6 +228,7 @@ jobs:
       - name: Test compilation with shared libs linkage
         run: |
           cmake -Smmg -Bbuild_shared \
+          ${{ env.C_FLG }} \
           ${{ env.FORT_FLG }} \
             -DCI_CONTEXT=ON \
             -DBUILD_TESTING=ON \
@@ -243,6 +250,7 @@ jobs:
       - name: Test compilation without library linkage
         run: |
           cmake -Smmg -Bbuild_nolibs \
+          ${{ env.C_FLG }} \
           ${{ env.FORT_FLG }} \
             -DCI_CONTEXT=ON \
             -DBUILD_TESTING=ON \
@@ -263,6 +271,7 @@ jobs:
       - name: Configure Mmg with static libs (default behaviour)
         run: |
           cmake -Smmg -Bbuild \
+          ${{ env.C_FLG }} \
           ${{ env.FORT_FLG }} \
             -DCI_CONTEXT=ON \
             -DBUILD_TESTING=ON \
@@ -302,3 +311,11 @@ jobs:
         run: |
           cd build
           ctest -R "msh|vtk" -VV -C ${{ inputs.cmake_build_type }} -j ${{ env.NJOBS }}
+
+      - name: Archive production artifacts for tests
+        if: success() || failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Mmg-tests
+          path: |
+            build/TEST_OUTPUTS

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -312,10 +312,10 @@ jobs:
           cd build
           ctest -R "msh|vtk" -VV -C ${{ inputs.cmake_build_type }} -j ${{ env.NJOBS }}
 
-      - name: Archive production artifacts for tests
-        if: success() || failure()
-        uses: actions/upload-artifact@v2
-        with:
-          name: Mmg-tests
-          path: |
-            build/TEST_OUTPUTS
+      # - name: Archive production artifacts for tests
+      #  if: success() || failure()
+      #  uses: actions/upload-artifact@v2
+      #  with:
+      #    name: Mmg-tests
+      #    path: |
+      #      build/TEST_OUTPUTS

--- a/cmake/modules/macros.cmake
+++ b/cmake/modules/macros.cmake
@@ -313,36 +313,6 @@ ENDMACRO ( )
 
 ###############################################################################
 #####
-#####         Add Executable that must be tested by ci
-#####
-###############################################################################
-
-MACRO ( ADD_EXEC_TO_CI_TESTS exec_name list_name )
-
-  IF(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-    SET(EXECUT ${EXECUTABLE_OUTPUT_PATH}/${exec_name}_debug)
-    SET(BUILDNAME ${BUILDNAME}_debug CACHE STRING "build name variable")
-  ELSEIF(${CMAKE_BUILD_TYPE} MATCHES "Release")
-    SET(EXECUT ${EXECUTABLE_OUTPUT_PATH}/${exec_name}_O3)
-    SET(BUILDNAME ${BUILDNAME}_O3 CACHE STRING "build name variable")
-  ELSEIF(${CMAKE_BUILD_TYPE} MATCHES "RelWithDebInfo")
-    SET(EXECUT ${EXECUTABLE_OUTPUT_PATH}/${exec_name}_O3d)
-    SET(BUILDNAME ${BUILDNAME}_O3d CACHE STRING "build name variable")
-  ELSEIF(${CMAKE_BUILD_TYPE} MATCHES "MinSizeRel")
-    SET(EXECUT ${EXECUTABLE_OUTPUT_PATH}/${exec_name}_Os)
-    SET(BUILDNAME ${BUILDNAME}_Os CACHE STRING "build name variable")
-  ELSE()
-    SET(EXECUT ${EXECUTABLE_OUTPUT_PATH}/${exec_name})
-    SET(BUILDNAME ${BUILDNAME} CACHE STRING "build name variable")
-  ENDIF()
-
-  SET ( ${list_name} ${EXECUT} )
-
-ENDMACRO ( )
-
-
-###############################################################################
-#####
 #####         Add a library test
 #####
 ###############################################################################

--- a/cmake/modules/mmg2d.cmake
+++ b/cmake/modules/mmg2d.cmake
@@ -184,7 +184,7 @@ IF ( BUILD_TESTING )
   # Add runtime that we want to test for mmg2d
   IF ( MMG2D_CI )
 
-    ADD_EXEC_TO_CI_TESTS ( ${PROJECT_NAME}2d EXECUT_MMG2D )
+    SET ( EXECUT_MMG2D      $<TARGET_NAME:${PROJECT_NAME}2d> )
 
     IF ( ONLY_VERY_SHORT_TESTS )
       # Add tests that doesn't require to download meshes

--- a/cmake/modules/mmg2d.cmake
+++ b/cmake/modules/mmg2d.cmake
@@ -184,7 +184,7 @@ IF ( BUILD_TESTING )
   # Add runtime that we want to test for mmg2d
   IF ( MMG2D_CI )
 
-    SET ( EXECUT_MMG2D      $<TARGET_NAME:${PROJECT_NAME}2d> )
+    SET ( EXECUT_MMG2D      $<TARGET_FILE:${PROJECT_NAME}2d> )
 
     IF ( ONLY_VERY_SHORT_TESTS )
       # Add tests that doesn't require to download meshes

--- a/cmake/modules/mmg3d.cmake
+++ b/cmake/modules/mmg3d.cmake
@@ -206,8 +206,8 @@ IF ( BUILD_TESTING )
       SET ( RUN_AGAIN OFF )
     ENDIF ( )
 
-    ADD_EXEC_TO_CI_TESTS ( ${PROJECT_NAME}3d EXECUT_MMG3D )
-    SET ( LISTEXEC_MMG ${EXECUT_MMG3D} )
+    SET ( EXECUT_MMG3D      $<TARGET_FILE:${PROJECT_NAME}3d> )
+    SET ( SHRT_EXECUT_MMG3D ${PROJECT_NAME}3d )
 
     IF ( ONLY_VERY_SHORT_TESTS )
       # Add tests that doesn't require to download meshes

--- a/cmake/modules/mmgs.cmake
+++ b/cmake/modules/mmgs.cmake
@@ -164,8 +164,8 @@ IF ( BUILD_TESTING )
   # Add runtime that we want to test for mmgs
   IF( MMGS_CI )
 
-    ADD_EXEC_TO_CI_TESTS ( ${PROJECT_NAME}s EXECUT_MMGS )
-    SET ( LISTEXEC_MMG ${EXECUT_MMGS} )
+    SET ( EXECUT_MMGS      $<TARGET_FILE:${PROJECT_NAME}s> )
+    SET ( SHRT_EXECUT_MMGS ${PROJECT_NAME}s)
 
     IF ( ONLY_VERY_SHORT_TESTS )
       # Add tests that doesn't require to download meshes

--- a/cmake/testing/mmg3d_tests.cmake
+++ b/cmake/testing/mmg3d_tests.cmake
@@ -20,8 +20,6 @@
 ##  use this copy of the mmg distribution only if you accept them.
 ## =============================================================================
 
-GET_FILENAME_COMPONENT ( SHRT_EXECUT_MMG3D ${EXECUT_MMG3D} NAME )
-
 ##############################################################################
 #####
 #####         Tests that may be run twice

--- a/cmake/testing/mmg_tests.cmake
+++ b/cmake/testing/mmg_tests.cmake
@@ -24,6 +24,7 @@
 # executable is in EXECUT_MMG3D (filled by mmg3d.cmake) and the mmgs executable
 # is in EXECUTE_MMGS (filled by mmgs.cmake))
 SET(EXECUT_MMG ${EXECUT_MMGS} ${EXECUT_MMG3D})
+SET(SHRT_EXECUT_MMG ${SHRT_EXECUT_MMGS} ${SHRT_EXECUT_MMG3D})
 
 # Make some files not openable
 IF ( EXISTS ${CTEST_OUTPUT_DIR}/unwrittable7.meshb
@@ -43,8 +44,7 @@ IF ( NOT EXISTS ${CTEST_OUTPUT_DIR}/unwrittable8.sol)
 ENDIF()
 
 # Lists of tests that are common to mmgs and mmg3d
-FOREACH(EXEC ${EXECUT_MMG})
-  GET_FILENAME_COMPONENT ( SHRT_EXEC ${EXEC} NAME )
+FOREACH(EXEC SHRT_EXEC IN ZIP_LISTS EXECUT_MMG SHRT_EXECUT_MMG)
 
   ###############################################################################
   #####
@@ -391,4 +391,4 @@ ADD_TEST(NAME mmg_CommandLineAni_${SHRT_EXEC}
 
 
 
-ENDFOREACH(EXEC)
+ENDFOREACH()

--- a/cmake/testing/mmgs_tests.cmake
+++ b/cmake/testing/mmgs_tests.cmake
@@ -20,8 +20,6 @@
 ##  use this copy of the Mmg distribution only if you accept them.
 ## =============================================================================
 
-GET_FILENAME_COMPONENT ( SHRT_EXECUT_MMGS ${EXECUT_MMGS} NAME )
-
 ###############################################################################
 #####
 #####         Continuous Integration


### PR DESCRIPTION
This PR contains commits from the branch `feature/improve-ci` that may be useful:
  - the generation of the executable names using CMake generator expression (cmake cleaning)
  - the possibility to add the pattern `[skip output comparison]` to add the `MMG_COMPARABLE_OUTPUT` precompilation flag.  This flag allows to reduce diff between two Mmg runs by: 
     1. disabling Mmg timers
     2. disabling the print of Mmg release and commit
     
The limitation is that diff between ctest runs are still not easily comparable as ctests adds its own timers at the end of each test.     