### PR TITLE
Feature/ls bijective map

### DIFF
--- a/src/common/mmg2.c
+++ b/src/common/mmg2.c
@@ -109,11 +109,14 @@ static int MMG5_InvMat_check(MMG5_pInvMat pim,int key) {
  * lookup table.
  */
 static void MMG5_InvMat_error(MMG5_pInvMat pim,int ref,int k) {
-  fprintf(stderr,"\n   ## Error: Trying to overwrite material reference %d"
+  fprintf(stderr,"\n   ## Warning: Overwrite material reference %d"
     " (from LSReferences line %d) with another entry from LSReferences line %d."
     ,ref,MMG5_InvMat_getIndex(pim,ref)+1,k+1);
-  fprintf(stderr,"\n             Check your LSReferences table: each material"
-    " reference should be unique!\n");
+  fprintf(stderr,"\n               Check your LSReferences table: if possible,"
+          " each material reference should be unique,\n"
+          "                if not possible, you may"
+          " encounter unexpected issues (wrong domain mapping or erroneous"
+          " detection of non-manifold level-set)!\n");
 }
 
 /**
@@ -132,12 +135,10 @@ static int MMG5_InvMat_set(MMG5_pMesh mesh,MMG5_pInvMat pim,int k) {
 
   /** Store the dosplit attribute of the parent material */
   key = MMG5_InvMat_key(pim,pm->ref);
-  if( MMG5_InvMat_check(pim,key) ) {
-    pim->lookup[key] = MMG5_InvMat_code(k,pm->dospl);
-  } else {
+  if( !MMG5_InvMat_check(pim,key) ) {
     MMG5_InvMat_error(pim,pm->ref,k);
-    return 0;
   }
+  pim->lookup[key] = MMG5_InvMat_code(k,pm->dospl);
 
   /** Store the child material sign with the parent material index (in the
    *  lookup table).
@@ -148,19 +149,16 @@ static int MMG5_InvMat_set(MMG5_pMesh mesh,MMG5_pInvMat pim,int k) {
    *     and this must have already been checked. */
   if( pm->dospl ) {
     key = MMG5_InvMat_key(pim,pm->rin);
-    if( MMG5_InvMat_check(pim,key) ) {
-      pim->lookup[key] = MMG5_InvMat_code(k,MG_MINUS);
-    } else {
+    if( !MMG5_InvMat_check(pim,key) ) {
       MMG5_InvMat_error(pim,pm->rin,k);
-      return 0;
     }
+    pim->lookup[key] = MMG5_InvMat_code(k,MG_MINUS);
+
     key = MMG5_InvMat_key(pim,pm->rex);
-    if( MMG5_InvMat_check(pim,key) ) {
-      pim->lookup[key] = MMG5_InvMat_code(k,MG_PLUS);
-    } else {
+    if( !MMG5_InvMat_check(pim,key) ) {
       MMG5_InvMat_error(pim,pm->rex,k);
-      return 0;
     }
+    pim->lookup[key] = MMG5_InvMat_code(k,MG_PLUS);
   }
 
   return 1;


### PR DESCRIPTION
## Warning instead of error in case of non bijective multi-material input map

Non-bijective multimaterial maps can be useful to merge external (resp. internal) parts of multiple materials after level-set discretization while keeping internal (resp. external) domain splitted (see attached example where left mesh shows the input material, middle mesh, the input level-set function and right mesh the output mesh after level-set discretization and non bijective mapping for the external domain).

<img width="1764" alt="Capture d’écran 2022-12-12 à 11 20 12" src="https://user-images.githubusercontent.com/11232703/207021325-dccc1687-0f40-408d-9e3e-11408709852c.png">

### Limitations
As user provides a non bijective map and we can store only one mapping per reference:
  - we cannot ensure that the overwritting of the mapping will give the result expected by the user
  - temporary interfaces between domains that are mapped to the same references may lead to erroneous detection of non-manifold situations
  
 This feature has to be use at your own risk and avoided if possible. 
