### PR TITLE
Call delaunay kernel instead of pattern one in ls mode.

### DIFF
--- a/src/mmg3d/libmmg3d.c
+++ b/src/mmg3d/libmmg3d.c
@@ -1418,7 +1418,7 @@ int MMG3D_mmg3dls(MMG5_pMesh mesh,MMG5_pSol sol,MMG5_pSol umet) {
     MMG5_RETURN_AND_PACK(mesh,sol,met,MMG5_LOWFAILURE);
   }
 #else
-  if ( !MMG5_mmg3d1_pattern(mesh,met,NULL) ) {
+  if ( !MMG5_mmg3d1_delone(mesh,met,NULL) ) {
     if ( mettofree ) { MMG5_DEL_MEM(mesh,met->m);MMG5_SAFE_FREE (met); }
     if ( !(mesh->adja) && !MMG3D_hashTetra(mesh,1) ) {
       fprintf(stderr,"\n  ## Hashing problem. Invalid mesh.\n");


### PR DESCRIPTION
## :warning: DO NOT MERGE NOW ⚠️ 
##  🚧 Call Delaunay kernel in isosurface discretization mode 🚧

It should allow:
  - to have a more idempotent algo
  - to allow the deletion of pattern kernel (maintenance reduction)
 
## TODO 
This PR has to be tested on true test cases before merge.