### PR TITLE
[CMake] Correcting last versions of CMake modules

### DIFF
--- a/cmake/tools/FindMMG2D.cmake
+++ b/cmake/tools/FindMMG2D.cmake
@@ -91,6 +91,7 @@ if(MMG_INCDIR)
     NAMES libmmgtypes.h
     HINTS ${MMG_INCDIR}
     PATH_SUFFIXES "mmg/mmg2d" "mmg2d")
+else()
   if(MMG_DIR)
     set(MMG2D_libmmgtypes.h_DIRS "MMG2D_libmmgtypes.h_DIRS-NOTFOUND")
     find_path(MMG2D_libmmgtypes.h_DIRS
@@ -105,8 +106,7 @@ if(MMG_INCDIR)
       PATH_SUFFIXES  "mmg" "mmg/common")
   endif()
 endif()
-STRING(REGEX REPLACE "(mmg/mmg2d)|(mmg/common)" ""
-  MMG2D_libmmgtypes.h_DIRS ${MMG2D_libmmgtypes.h_DIRS} )
+STRING(REGEX REPLACE "(mmg/mmg2d)|(mmg/common)" "" MMG2D_libmmgtypes.h_DIRS "${MMG2D_libmmgtypes.h_DIRS}")
 
 mark_as_advanced(MMG2D_libmmgtypes.h_DIRS)
 

--- a/cmake/tools/FindMMG3D.cmake
+++ b/cmake/tools/FindMMG3D.cmake
@@ -91,6 +91,7 @@ if(MMG_INCDIR)
     NAMES libmmgtypes.h
     HINTS ${MMG_INCDIR}
     PATH_SUFFIXES "mmg/mmg3d" "mmg3d")
+else()
   if(MMG_DIR)
     set(MMG3D_libmmgtypes.h_DIRS "MMG3D_libmmgtypes.h_DIRS-NOTFOUND")
     find_path(MMG3D_libmmgtypes.h_DIRS
@@ -105,8 +106,7 @@ if(MMG_INCDIR)
       PATH_SUFFIXES  "mmg" "mmg/common")
   endif()
 endif()
-STRING(REGEX REPLACE "(mmg/mmg3d)|(mmg/common)" ""
-  MMG3D_libmmgtypes.h_DIRS ${MMG3D_libmmgtypes.h_DIRS} )
+STRING(REGEX REPLACE "(mmg/mmg3d)|(mmg/common)" "" MMG3D_libmmgtypes.h_DIRS "${MMG3D_libmmgtypes.h_DIRS}" )
 
 mark_as_advanced(MMG3D_libmmgtypes.h_DIRS)
 

--- a/cmake/tools/FindMMGS.cmake
+++ b/cmake/tools/FindMMGS.cmake
@@ -91,6 +91,7 @@ if(MMG_INCDIR)
     NAMES libmmgtypes.h
     HINTS ${MMG_INCDIR}
     PATH_SUFFIXES "mmg/mmgs" "mmgs")
+else()
   if(MMG_DIR)
     set(MMGS_libmmgtypes.h_DIRS "MMGS_libmmgtypes.h_DIRS-NOTFOUND")
     find_path(MMGS_libmmgtypes.h_DIRS
@@ -105,8 +106,7 @@ if(MMG_INCDIR)
       PATH_SUFFIXES  "mmg" "mmg/common")
   endif()
 endif()
-STRING(REGEX REPLACE "(mmg/mmgs)|(mmg/common)" ""
-  MMGS_libmmgtypes.h_DIRS ${MMGS_libmmgtypes.h_DIRS} )
+STRING(REGEX REPLACE "(mmg/mmgs)|(mmg/common)" "" MMGS_libmmgtypes.h_DIRS "${MMGS_libmmgtypes.h_DIRS}" )
 
 mark_as_advanced(MMGS_libmmgtypes.h_DIRS)
 


### PR DESCRIPTION
@Algiane 

1. Missing `else` when looking for includes
2. Wrong CMake argument for REGEX (I think this is depending on the CMake version, correction should work 100% of the times)