### PR TITLE
[CMake] Correcting CMake modules in compilation errors found in certain CMake versions

### DIFF
--- a/cmake/tools/FindMMG2D.cmake
+++ b/cmake/tools/FindMMG2D.cmake
@@ -90,9 +90,9 @@ if(MMG_INCDIR)
   find_path(MMG2D_libmmgtypes.h_DIRS
     NAMES libmmgtypes.h
     HINTS ${MMG_INCDIR}
-    PATH_SUFFIXES "mmg/mmg2d" "mmg2d")
+    PATH_SUFFIXES "mmg" "mmg/mmg2d" "mmg2d" "mmg/common")
 else()
-  if(MMG_DIR)
+    if(MMG_DIR)
     set(MMG2D_libmmgtypes.h_DIRS "MMG2D_libmmgtypes.h_DIRS-NOTFOUND")
     find_path(MMG2D_libmmgtypes.h_DIRS
       NAMES libmmgtypes.h

--- a/cmake/tools/FindMMG2D.cmake
+++ b/cmake/tools/FindMMG2D.cmake
@@ -92,7 +92,7 @@ if(MMG_INCDIR)
     HINTS ${MMG_INCDIR}
     PATH_SUFFIXES "mmg" "mmg/mmg2d" "mmg2d" "mmg/common")
 else()
-    if(MMG_DIR)
+  if(MMG_DIR)
     set(MMG2D_libmmgtypes.h_DIRS "MMG2D_libmmgtypes.h_DIRS-NOTFOUND")
     find_path(MMG2D_libmmgtypes.h_DIRS
       NAMES libmmgtypes.h

--- a/cmake/tools/FindMMG3D.cmake
+++ b/cmake/tools/FindMMG3D.cmake
@@ -90,7 +90,7 @@ if(MMG_INCDIR)
   find_path(MMG3D_libmmgtypes.h_DIRS
     NAMES libmmgtypes.h
     HINTS ${MMG_INCDIR}
-    PATH_SUFFIXES "mmg/mmg3d" "mmg3d")
+    PATH_SUFFIXES "mmg/mmg3d" "mmg3d" "mmg/common")
 else()
   if(MMG_DIR)
     set(MMG3D_libmmgtypes.h_DIRS "MMG3D_libmmgtypes.h_DIRS-NOTFOUND")

--- a/cmake/tools/FindMMGS.cmake
+++ b/cmake/tools/FindMMGS.cmake
@@ -90,7 +90,7 @@ if(MMG_INCDIR)
   find_path(MMGS_libmmgtypes.h_DIRS
     NAMES libmmgtypes.h
     HINTS ${MMG_INCDIR}
-    PATH_SUFFIXES "mmg/mmgs" "mmgs")
+    PATH_SUFFIXES "mmg/mmgs" "mmgs" "mmg/common")
 else()
   if(MMG_DIR)
     set(MMGS_libmmgtypes.h_DIRS "MMGS_libmmgtypes.h_DIRS-NOTFOUND")


### PR DESCRIPTION
@marcnunezc has found in the discussion from https://github.com/KratosMultiphysics/Kratos/issues/10560 the following solution for compiling with MMG your project when using the provided CMake MMG modules. I did not experience the fail, but apparently depends on the CMake version.