### PR TITLE
Feature/assert bdy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ include/*
 *.o
 
 .DS_Store
+
+TAGS
+.scannerwork/*
+sonar-project.properties
+.github/workflows/sonarqube.yml

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,3 @@ include/*
 TAGS
 .scannerwork/*
 sonar-project.properties
-.github/workflows/sonarqube.yml

--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -2641,6 +2641,10 @@ int MMG5_split3op(MMG5_pMesh mesh, MMG5_pSol met, MMG5_int k, MMG5_int vx[6],int
     xt[1].ftag[ip1] = 0 ; xt[1].ftag[ip2] = 0 ;
     MG_SET(xt[1].ori, ip1); MG_SET(xt[1].ori, ip2);
 
+    if ( xt[2].edg[ie1] ) {
+      assert ( 0 );
+    }
+
     pt[2]->v[ip0] = vx[ie0] ; pt[2]->v[ip2] = vx[ie5] ;
     xt[2].tag[ie1] = 0;  xt[2].tag[ie2] = 0;
     xt[2].tag[ie3] = 0;  xt[2].edg[ie2] = 0;

--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -2641,10 +2641,6 @@ int MMG5_split3op(MMG5_pMesh mesh, MMG5_pSol met, MMG5_int k, MMG5_int vx[6],int
     xt[1].ftag[ip1] = 0 ; xt[1].ftag[ip2] = 0 ;
     MG_SET(xt[1].ori, ip1); MG_SET(xt[1].ori, ip2);
 
-    if ( xt[2].edg[ie1] ) {
-      assert ( 0 );
-    }
-
     pt[2]->v[ip0] = vx[ie0] ; pt[2]->v[ip2] = vx[ie5] ;
     xt[2].tag[ie1] = 0;  xt[2].tag[ie2] = 0;
     xt[2].tag[ie3] = 0;  xt[2].edg[ie1] = 0;

--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -2647,8 +2647,8 @@ int MMG5_split3op(MMG5_pMesh mesh, MMG5_pSol met, MMG5_int k, MMG5_int vx[6],int
 
     pt[2]->v[ip0] = vx[ie0] ; pt[2]->v[ip2] = vx[ie5] ;
     xt[2].tag[ie1] = 0;  xt[2].tag[ie2] = 0;
-    xt[2].tag[ie3] = 0;  xt[2].edg[ie2] = 0;
-    xt[2].edg[ie3] = 0;
+    xt[2].tag[ie3] = 0;  xt[2].edg[ie1] = 0;
+    xt[2].edg[ie2] = 0;  xt[2].edg[ie3] = 0;
     xt[2].ref [ip1] = 0 ; xt[2].ref [ip3] = 0 ;
     xt[2].ftag[ip1] = 0 ; xt[2].ftag[ip3] = 0 ;
     MG_SET(xt[2].ori, ip1); MG_SET(xt[2].ori, ip3);


### PR DESCRIPTION
Correction of a bug in function MMG5_split3op : fixed assignments of tags and refs when splitting tetrahedra.