### PR TITLE
Feature/xreg2

### DIFF
--- a/cmake/testing/mmg2d_tests.cmake
+++ b/cmake/testing/mmg2d_tests.cmake
@@ -679,6 +679,12 @@ ADD_TEST(NAME mmg2d_CoorRegularizationNegativeArea
   ${MMG2D_CI_TESTS}/CoorRegularizationNegativeArea/CoorRegularizationNegativeArea
   -out ${CTEST_OUTPUT_DIR}/CoorRegularizationNegativeArea.o.meshb)
 
+# ls discretisation + xreg + choice of value for xreg
+ADD_TEST(NAME mmg2d_CoorRegularization_apple_value
+  COMMAND ${EXECUT_MMG2D} -v 5 -ls -xreg 0.9
+  ${MMG2D_CI_TESTS}/CoorRegularization_apple/apple
+  -out ${CTEST_OUTPUT_DIR}/CoorRegularization_apple_value.o.meshb)
+
 ###############################################################################
 #####
 #####         Check Lagrangian motion option

--- a/cmake/testing/mmg_tests.cmake
+++ b/cmake/testing/mmg_tests.cmake
@@ -376,6 +376,11 @@ ADD_TEST(NAME mmg_CommandLineAni_${SHRT_EXEC}
     ${MMG_CI_TESTS}/CoorRegularizationRandomCube/cubeRandom.mesh
     -out ${CTEST_OUTPUT_DIR}/CoorRegularizationRandomCube_${SHRT_EXEC}.o.meshb)
 
+  ADD_TEST( NAME mmg_CoorRegularizationRandomCube_value_${SHRT_EXEC}
+    COMMAND ${EXEC} -v 5 -xreg 0.9
+    ${MMG_CI_TESTS}/CoorRegularizationRandomCube/cubeRandom.mesh
+    -out ${CTEST_OUTPUT_DIR}/CoorRegularizationRandomCube_value_${SHRT_EXEC}.o.meshb)
+
   # -lssurf
   IF ( ${SHRT_EXEC} MATCHES "3d" )
     SET ( ADD_ARG "-opnbdy" )

--- a/src/common/API_functions.c
+++ b/src/common/API_functions.c
@@ -95,7 +95,7 @@ void MMG5_Init_parameters(MMG5_pMesh mesh) {
   /* control gradation on required entities */
   mesh->info.hgradreq = MMG5_HGRADREQ;
   /* xreg relaxation parameter value */
-  mesh->info.lxreg    = MMG5_LXREG;
+  mesh->info.lxreg    = MMG5_XREG;
 
   /* default values for pointers */
   /* list of user-defined references */

--- a/src/common/API_functions.c
+++ b/src/common/API_functions.c
@@ -94,6 +94,8 @@ void MMG5_Init_parameters(MMG5_pMesh mesh) {
   mesh->info.hgrad    = MMG5_HGRAD;
   /* control gradation on required entities */
   mesh->info.hgradreq = MMG5_HGRADREQ;
+  /* xreg relaxation parameter value */
+  mesh->info.lxreg    = MMG5_LXREG;
 
   /* default values for pointers */
   /* list of user-defined references */

--- a/src/common/libmmgtypes.h
+++ b/src/common/libmmgtypes.h
@@ -516,7 +516,7 @@ typedef MMG5_InvMat * MMG5_pInvMat;
 typedef struct {
   MMG5_pPar     par;
   double        dhd,hmin,hmax,hsiz,hgrad,hgradreq,hausd;
-  double        min[3],max[3],delta,ls,rmc;
+  double        min[3],max[3],delta,ls,lxreg,rmc;
   MMG5_int      *br; /*!< list of based references to which an implicit surface can be attached */
   MMG5_int      isoref; /*!< isovalue reference in ls mode */
   MMG5_int      nsd; /*!< index of subdomain to save (0 by default == all subdomains are saved) */

--- a/src/common/libtools.c
+++ b/src/common/libtools.c
@@ -97,6 +97,8 @@ void MMG5_mmgDefaultValues(MMG5_pMesh mesh) {
 
   fprintf(stdout,"gradation control for required entities (-hgradreq)  : %lf\n",
           (mesh->info.hgradreq < 0) ? mesh->info.hgradreq : exp(mesh->info.hgradreq) );
+  fprintf(stdout,"coordinate regularization parameter (-xreg) : %lf\n",
+          mesh->info.lxreg);
 }
 
 int MMG5_Set_multiMat(MMG5_pMesh mesh,MMG5_pSol sol,MMG5_int ref,

--- a/src/common/mmgcommon_private.h
+++ b/src/common/mmgcommon_private.h
@@ -125,6 +125,7 @@ extern "C" {
 #define MMG5_LAG         -1 /**< default value for lagrangian option */
 #define MMG5_NR          -1 /**< no ridge detection */
 #define MMG5_LS         0.0 /**< default level-set to discretize */
+#define MMG5_LXREG      0.4 /**< default relaxation parameter for coordinate regularization */
 #define MMG5_PROCTREE    32 /**< default size of the PROctree */
 #define MMG5_OFF          0 /**< 0 */
 #define MMG5_ON           1 /**< 1 */

--- a/src/common/mmgcommon_private.h
+++ b/src/common/mmgcommon_private.h
@@ -125,7 +125,7 @@ extern "C" {
 #define MMG5_LAG         -1 /**< default value for lagrangian option */
 #define MMG5_NR          -1 /**< no ridge detection */
 #define MMG5_LS         0.0 /**< default level-set to discretize */
-#define MMG5_LXREG      0.4 /**< default relaxation parameter for coordinate regularization */
+#define MMG5_XREG       0.4 /**< default relaxation parameter for coordinate regularization */
 #define MMG5_PROCTREE    32 /**< default size of the PROctree */
 #define MMG5_OFF          0 /**< 0 */
 #define MMG5_ON           1 /**< 1 */

--- a/src/mmg2d/API_functions_2d.c
+++ b/src/mmg2d/API_functions_2d.c
@@ -98,6 +98,8 @@ void MMG2D_Init_parameters(MMG5_pMesh mesh) {
   /* default values for doubles */
   /* level set value */
   mesh->info.ls       = MMG5_LS;
+/* xreg relaxation parameter value */
+  mesh->info.lxreg    = MMG5_LXREG;
 
   /* Ridge detection */
   mesh->info.dhd      = MMG5_ANGEDG;
@@ -344,6 +346,13 @@ int MMG2D_Set_dparameter(MMG5_pMesh mesh, MMG5_pSol sol, int dparam, double val)
     break;
   case MMG2D_DPARAM_ls :
     mesh->info.ls       = val;
+    break;
+  case MMG2D_DPARAM_lxreg :
+    if (val < 0.0 || val > 1.0) {
+      fprintf(stderr,"\n  ## Error: %s: Coordinate regularization parameter must be comprised between 0 and 1.\n",__func__);
+    }
+    else
+      mesh->info.lxreg    = val;
     break;
   case MMG2D_DPARAM_rmc :
     if ( !val ) {

--- a/src/mmg2d/API_functions_2d.c
+++ b/src/mmg2d/API_functions_2d.c
@@ -99,7 +99,7 @@ void MMG2D_Init_parameters(MMG5_pMesh mesh) {
   /* level set value */
   mesh->info.ls       = MMG5_LS;
 /* xreg relaxation parameter value */
-  mesh->info.lxreg    = MMG5_LXREG;
+  mesh->info.lxreg    = MMG5_XREG;
 
   /* Ridge detection */
   mesh->info.dhd      = MMG5_ANGEDG;
@@ -347,7 +347,7 @@ int MMG2D_Set_dparameter(MMG5_pMesh mesh, MMG5_pSol sol, int dparam, double val)
   case MMG2D_DPARAM_ls :
     mesh->info.ls       = val;
     break;
-  case MMG2D_DPARAM_lxreg :
+  case MMG2D_DPARAM_xreg :
     if (val < 0.0 || val > 1.0) {
       fprintf(stderr,"\n  ## Error: %s: Coordinate regularization parameter must be comprised between 0 and 1.\n",__func__);
     }

--- a/src/mmg2d/analys_2d.c
+++ b/src/mmg2d/analys_2d.c
@@ -524,8 +524,8 @@ int MMG2D_regnor(MMG5_pMesh mesh) {
   maxit = 10;
   res0 = 0.0;
   nn = 0;
-  lm1 = 0.4;
-  lm2 = 0.399;
+  lm1 = mesh->info.lxreg;
+  lm2 = lm1;
 
   /* Temporary table for normal vectors */
   MMG5_SAFE_CALLOC(tmp,2*mesh->np+1,double,return 0);

--- a/src/mmg2d/analys_2d.c
+++ b/src/mmg2d/analys_2d.c
@@ -525,7 +525,7 @@ int MMG2D_regnor(MMG5_pMesh mesh) {
   res0 = 0.0;
   nn = 0;
   lm1 = mesh->info.lxreg;
-  lm2 = lm1;
+  lm2 = 0.99*lm1;
 
   /* Temporary table for normal vectors */
   MMG5_SAFE_CALLOC(tmp,2*mesh->np+1,double,return 0);

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -86,7 +86,7 @@ extern "C" {
     MMG2D_DPARAM_hgrad,             /*!< [val], Control gradation */
     MMG2D_DPARAM_hgradreq,          /*!< [val], Control gradation on required entites (advanced usage) */
     MMG2D_DPARAM_ls,                /*!< [val], Value of level-set */
-    MMG2D_DPARAM_lxreg,             /*!< [val], Value of relaxation parameter for coordinates regularization (0<val<1) */
+    MMG2D_DPARAM_xreg,              /*!< [val], Value of relaxation parameter for coordinates regularization (0<val<1) */
     MMG2D_DPARAM_rmc,               /*!< [-1/val], Remove small connex componants in level-set mode */
     MMG2D_IPARAM_nofem,             /*!< [1/0], Generate a non finite element mesh */
     MMG2D_IPARAM_isoref,            /*!< [0/n], Iso-surface boundary material reference */

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -86,6 +86,7 @@ extern "C" {
     MMG2D_DPARAM_hgrad,             /*!< [val], Control gradation */
     MMG2D_DPARAM_hgradreq,          /*!< [val], Control gradation on required entites (advanced usage) */
     MMG2D_DPARAM_ls,                /*!< [val], Value of level-set */
+    MMG2D_DPARAM_lxreg,             /*!< [val], Value of relaxation parameter for coordinates regularization (0<val<1) */
     MMG2D_DPARAM_rmc,               /*!< [-1/val], Remove small connex componants in level-set mode */
     MMG2D_IPARAM_nofem,             /*!< [1/0], Generate a non finite element mesh */
     MMG2D_IPARAM_isoref,            /*!< [0/n], Iso-surface boundary material reference */

--- a/src/mmg2d/libmmg2d_tools.c
+++ b/src/mmg2d/libmmg2d_tools.c
@@ -381,7 +381,7 @@ int MMG2D_parsar(int argc,char *argv[],MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol s
           if ( !MMG2D_Set_iparameter(mesh,met,MMG2D_IPARAM_xreg,1) )
             return 0;
           if ( ++i < argc && (isdigit(argv[i][0]) ) ) {
-            if ( !MMG2D_Set_dparameter(mesh,met,MMG2D_DPARAM_lxreg,atof(argv[i])) )
+            if ( !MMG2D_Set_dparameter(mesh,met,MMG2D_DPARAM_xreg,atof(argv[i])) )
               return 0;
           }
           else i--;

--- a/src/mmg2d/libmmg2d_tools.c
+++ b/src/mmg2d/libmmg2d_tools.c
@@ -380,6 +380,11 @@ int MMG2D_parsar(int argc,char *argv[],MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol s
         if ( !strcmp(argv[i],"-xreg") ) {
           if ( !MMG2D_Set_iparameter(mesh,met,MMG2D_IPARAM_xreg,1) )
             return 0;
+          if ( ++i < argc && (isdigit(argv[i][0]) ) ) {
+            if ( !MMG2D_Set_dparameter(mesh,met,MMG2D_DPARAM_lxreg,atof(argv[i])) )
+              return 0;
+          }
+          else i--;
         }
         break;
       case '3':

--- a/src/mmg3d/API_functions_3d.c
+++ b/src/mmg3d/API_functions_3d.c
@@ -2410,7 +2410,7 @@ int MMG3D_Set_dparameter(MMG5_pMesh mesh, MMG5_pSol sol, int dparam, double val)
   case MMG3D_DPARAM_ls :
     mesh->info.ls       = val;
     break;
-  case MMG3D_DPARAM_lxreg :
+  case MMG3D_DPARAM_xreg :
     if (val < 0.0 || val > 1.0) {
       fprintf(stderr,"\n  ## Error: %s: Coordinate regularization parameter must be comprised between 0 and 1.\n",__func__);
     }

--- a/src/mmg3d/API_functions_3d.c
+++ b/src/mmg3d/API_functions_3d.c
@@ -103,6 +103,8 @@ void MMG3D_Init_parameters(MMG5_pMesh mesh) {
   /* default values for doubles */
   /* level set value */
   mesh->info.ls       = MMG5_LS;
+  /* xreg relaxation parameter value */
+  mesh->info.lxreg    = MMG5_LXREG;
 
 #ifndef MMG_PATTERN
   mesh->info.PROctree = MMG5_PROCTREE;
@@ -2409,6 +2411,13 @@ int MMG3D_Set_dparameter(MMG5_pMesh mesh, MMG5_pSol sol, int dparam, double val)
     break;
   case MMG3D_DPARAM_ls :
     mesh->info.ls       = val;
+    break;
+  case MMG3D_DPARAM_lxreg :
+    if (val < 0.0 || val > 1.0) {
+      fprintf(stderr,"\n  ## Error: %s: Coordinate regularization parameter must be comprised between 0 and 1.\n",__func__);
+    }
+    else
+      mesh->info.lxreg    = val;
     break;
   case MMG3D_DPARAM_rmc :
     if ( !val ) {

--- a/src/mmg3d/API_functions_3d.c
+++ b/src/mmg3d/API_functions_3d.c
@@ -103,8 +103,6 @@ void MMG3D_Init_parameters(MMG5_pMesh mesh) {
   /* default values for doubles */
   /* level set value */
   mesh->info.ls       = MMG5_LS;
-  /* xreg relaxation parameter value */
-  mesh->info.lxreg    = MMG5_LXREG;
 
 #ifndef MMG_PATTERN
   mesh->info.PROctree = MMG5_PROCTREE;

--- a/src/mmg3d/analys_3d.c
+++ b/src/mmg3d/analys_3d.c
@@ -997,7 +997,7 @@ int MMG3D_regver(MMG5_pMesh mesh) {
   nit  = 10;
   res0 = 0.0;
   lm1  = mesh->info.lxreg;
-  lm2  = lm1;
+  lm2  = 0.99*lm1;
   while ( it++ < nit ) {
     /* step 1: laplacian */
     for (k=1; k<=mesh->np; k++) {

--- a/src/mmg3d/analys_3d.c
+++ b/src/mmg3d/analys_3d.c
@@ -996,8 +996,8 @@ int MMG3D_regver(MMG5_pMesh mesh) {
   it   = 0;
   nit  = 10;
   res0 = 0.0;
-  lm1  = 0.4;
-  lm2  = 0.399;
+  lm1  = mesh->info.lxreg;
+  lm2  = lm1;
   while ( it++ < nit ) {
     /* step 1: laplacian */
     for (k=1; k<=mesh->np; k++) {

--- a/src/mmg3d/libmmg3d.h
+++ b/src/mmg3d/libmmg3d.h
@@ -101,6 +101,7 @@ enum MMG3D_Param {
   MMG3D_DPARAM_hgrad,                     /*!< [val], Control gradation */
   MMG3D_DPARAM_hgradreq,                  /*!< [val], Control gradation on required entites (advanced usage) */
   MMG3D_DPARAM_ls,                        /*!< [val], Value of level-set */
+  MMG3D_DPARAM_lxreg,                     /*!< [val], Value of relaxation parameter for coordinates regularization (0<val<1) */
   MMG3D_DPARAM_rmc,                       /*!< [-1/val], Remove small connex componants in level-set mode */
   MMG3D_PARAM_size,                       /*!< [n], Number of parameters */
 };

--- a/src/mmg3d/libmmg3d.h
+++ b/src/mmg3d/libmmg3d.h
@@ -101,7 +101,7 @@ enum MMG3D_Param {
   MMG3D_DPARAM_hgrad,                     /*!< [val], Control gradation */
   MMG3D_DPARAM_hgradreq,                  /*!< [val], Control gradation on required entites (advanced usage) */
   MMG3D_DPARAM_ls,                        /*!< [val], Value of level-set */
-  MMG3D_DPARAM_lxreg,                     /*!< [val], Value of relaxation parameter for coordinates regularization (0<val<1) */
+  MMG3D_DPARAM_xreg,                      /*!< [val], Value of relaxation parameter for coordinates regularization (0<val<1) */
   MMG3D_DPARAM_rmc,                       /*!< [-1/val], Remove small connex componants in level-set mode */
   MMG3D_PARAM_size,                       /*!< [n], Number of parameters */
 };

--- a/src/mmg3d/libmmg3d_tools.c
+++ b/src/mmg3d/libmmg3d_tools.c
@@ -513,7 +513,7 @@ int MMG3D_parsar(int argc,char *argv[],MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol s
           if ( !MMG3D_Set_iparameter(mesh,met,MMG3D_IPARAM_xreg,1) )
             return 0;
           if ( ++i < argc && (isdigit(argv[i][0]) ) ) {
-            if ( !MMG3D_Set_dparameter(mesh,met,MMG3D_DPARAM_lxreg,atof(argv[i])) )
+            if ( !MMG3D_Set_dparameter(mesh,met,MMG3D_DPARAM_xreg,atof(argv[i])) )
               return 0;
           }
           else i--;

--- a/src/mmg3d/libmmg3d_tools.c
+++ b/src/mmg3d/libmmg3d_tools.c
@@ -512,6 +512,11 @@ int MMG3D_parsar(int argc,char *argv[],MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol s
         if ( !strcmp(argv[i],"-xreg") ) {
           if ( !MMG3D_Set_iparameter(mesh,met,MMG3D_IPARAM_xreg,1) )
             return 0;
+          if ( ++i < argc && (isdigit(argv[i][0]) ) ) {
+            if ( !MMG3D_Set_dparameter(mesh,met,MMG3D_DPARAM_lxreg,atof(argv[i])) )
+              return 0;
+          }
+          else i--;
         }
         break;
       default:

--- a/src/mmgs/API_functions_s.c
+++ b/src/mmgs/API_functions_s.c
@@ -1557,7 +1557,7 @@ int MMGS_Set_dparameter(MMG5_pMesh mesh, MMG5_pSol sol, int dparam, double val){
   case MMGS_DPARAM_ls :
     mesh->info.ls         = val;
     break;
-  case MMGS_DPARAM_lxreg :
+  case MMGS_DPARAM_xreg :
     if (val < 0.0 || val > 1.0) {
       fprintf(stderr,"\n  ## Error: %s: Coordinate regularization parameter must be comprised between 0 and 1.\n",__func__);
     }

--- a/src/mmgs/API_functions_s.c
+++ b/src/mmgs/API_functions_s.c
@@ -1557,6 +1557,13 @@ int MMGS_Set_dparameter(MMG5_pMesh mesh, MMG5_pSol sol, int dparam, double val){
   case MMGS_DPARAM_ls :
     mesh->info.ls         = val;
     break;
+  case MMGS_DPARAM_lxreg :
+    if (val < 0.0 || val > 1.0) {
+      fprintf(stderr,"\n  ## Error: %s: Coordinate regularization parameter must be comprised between 0 and 1.\n",__func__);
+    }
+    else
+      mesh->info.lxreg    = val;
+    break;
   case MMGS_DPARAM_rmc :
     if ( !val ) {
       /* Default value */

--- a/src/mmgs/analys_s.c
+++ b/src/mmgs/analys_s.c
@@ -841,8 +841,8 @@ int MMGS_regver(MMG5_pMesh mesh) {
   it   = 0;
   nit  = 10;
   res0 = 0.0;
-  lm1  = 0.4;
-  lm2  = 0.399;
+  lm1  = mesh->info.lxreg;
+  lm2  = lm1;
   while ( it++ < nit ) {
     /* step 1: laplacian */
     for (k=1; k<=mesh->np; k++) {

--- a/src/mmgs/analys_s.c
+++ b/src/mmgs/analys_s.c
@@ -842,7 +842,7 @@ int MMGS_regver(MMG5_pMesh mesh) {
   nit  = 10;
   res0 = 0.0;
   lm1  = mesh->info.lxreg;
-  lm2  = lm1;
+  lm2  = 0.99*lm1;
   while ( it++ < nit ) {
     /* step 1: laplacian */
     for (k=1; k<=mesh->np; k++) {

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -88,7 +88,7 @@ enum MMGS_Param {
   MMGS_DPARAM_hgrad,             /*!< [val], Control gradation */
   MMGS_DPARAM_hgradreq,          /*!< [val], Control gradation on required entites (advanced usage) */
   MMGS_DPARAM_ls,                /*!< [val], Value of level-set */
-  MMGS_DPARAM_lxreg,             /*!< [val], Value of relaxation parameter for coordinates regularization (0<val<1) */
+  MMGS_DPARAM_xreg,              /*!< [val], Value of relaxation parameter for coordinates regularization (0<val<1) */
   MMGS_DPARAM_rmc,               /*!< [-1/val], Remove small connex componants in level-set mode */
   MMGS_PARAM_size,               /*!< [n], Number of parameters */
 };

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -88,6 +88,7 @@ enum MMGS_Param {
   MMGS_DPARAM_hgrad,             /*!< [val], Control gradation */
   MMGS_DPARAM_hgradreq,          /*!< [val], Control gradation on required entites (advanced usage) */
   MMGS_DPARAM_ls,                /*!< [val], Value of level-set */
+  MMGS_DPARAM_lxreg,             /*!< [val], Value of relaxation parameter for coordinates regularization (0<val<1) */
   MMGS_DPARAM_rmc,               /*!< [-1/val], Remove small connex componants in level-set mode */
   MMGS_PARAM_size,               /*!< [n], Number of parameters */
 };

--- a/src/mmgs/libmmgs_tools.c
+++ b/src/mmgs/libmmgs_tools.c
@@ -415,7 +415,7 @@ int MMGS_parsar(int argc,char *argv[],MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol so
           if ( !MMGS_Set_iparameter(mesh,met,MMGS_IPARAM_xreg,1) )
             return 0;
           if ( ++i < argc && (isdigit(argv[i][0]) ) ) {
-            if ( !MMGS_Set_dparameter(mesh,met,MMGS_DPARAM_lxreg,atof(argv[i])) )
+            if ( !MMGS_Set_dparameter(mesh,met,MMGS_DPARAM_xreg,atof(argv[i])) )
               return 0;
           }
           else i--;

--- a/src/mmgs/libmmgs_tools.c
+++ b/src/mmgs/libmmgs_tools.c
@@ -414,6 +414,11 @@ int MMGS_parsar(int argc,char *argv[],MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol so
         if ( !strcmp(argv[i],"-xreg") ) {
           if ( !MMGS_Set_iparameter(mesh,met,MMGS_IPARAM_xreg,1) )
             return 0;
+          if ( ++i < argc && (isdigit(argv[i][0]) ) ) {
+            if ( !MMGS_Set_dparameter(mesh,met,MMGS_DPARAM_lxreg,atof(argv[i])) )
+              return 0;
+          }
+          else i--;
         }
         break;
       default:


### PR DESCRIPTION
Added the possibility of choosing a value _val_ for the regularization of coordinates when using option -xreg _val_ :
Let P be a point to regularize. Let Q be the mean of surrounding points on manifold. New point R is computed as:
R = val * Q + (1 - val) * P
Default value is _val_ = 0.4. Given value should be comprised between 0 and 1.

One CI test for each software has been added as well.
