### PR TITLE
Feature/ls checkmaniball parmmg

### DIFF
--- a/src/mmg3d/mmg3d1_delone.c
+++ b/src/mmg3d/mmg3d1_delone.c
@@ -1032,7 +1032,7 @@ int MMG5_mmg3d1_delone(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int *permNodGlob) {
     fprintf(stdout,"  ** MESH ANALYSIS\n");
 
   if ( mesh->info.iso && !MMG3D_chkmani(mesh) ) {
-    fprintf(stderr,"\n  ## Non orientable implicit surface. Exit program.\n");
+    fprintf(stderr,"\n  ## Non orientable implicit surface before remeshing. Exit program.\n");
     return 0;
   }
 
@@ -1142,7 +1142,7 @@ int MMG5_mmg3d1_delone(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int *permNodGlob) {
   }
 
   if ( mesh->info.iso && !MMG3D_chkmani(mesh) ) {
-    fprintf(stdout,"\n  ## Warning: %s: Non orientable implicit surface.\n",__func__);
+    fprintf(stdout,"\n  ## Warning: %s: Non orientable implicit surface after remeshing.\n",__func__);
   }
 
   if ( PROctree ) {

--- a/src/mmg3d/mmg3d1_pattern.c
+++ b/src/mmg3d/mmg3d1_pattern.c
@@ -431,7 +431,7 @@ int MMG5_mmg3d1_pattern(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int *permNodGlob) {
     fprintf(stdout,"  ** MESH ANALYSIS\n");
 
   if ( mesh->info.iso && !MMG3D_chkmani(mesh) ) {
-    fprintf(stderr,"\n  ## Non orientable implicit surface. Exit program.\n");
+    fprintf(stderr,"\n  ## Non orientable implicit surface before remeshing. Exit program.\n");
     return 0;
   }
 
@@ -534,7 +534,7 @@ int MMG5_mmg3d1_pattern(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int *permNodGlob) {
   }
 
   if ( mesh->info.iso && !MMG3D_chkmani(mesh) ) {
-    fprintf(stdout,"\n  ## Warning: %s: Non orientable implicit surface.\n",__func__);
+    fprintf(stdout,"\n  ## Warning: %s: Non orientable implicit surface after remeshing.\n",__func__);
     return 1;
   }
 

--- a/src/mmg3d/mmg3d2.c
+++ b/src/mmg3d/mmg3d2.c
@@ -1420,7 +1420,7 @@ int MMG3D_chkmaniball(MMG5_pMesh mesh, MMG5_int start, int8_t ip){
   MMG5_pTetra    pt,pt1;
   int            ilist,cur,nref;
   MMG5_int       base,ref,*adja,list[MMG3D_LMAX+2],k,k1,nump;
-  int8_t         i,l,j,pmmg_bdy,iedge;
+  int8_t         i,l,j,pmmg_bdy;
 
   base = ++mesh->base;
   ilist = 0;

--- a/src/mmg3d/mmg3d2.c
+++ b/src/mmg3d/mmg3d2.c
@@ -1418,7 +1418,6 @@ int MMG3D_update_xtetra ( MMG5_pMesh mesh ) {
  */
 int MMG3D_chkmaniball(MMG5_pMesh mesh, MMG5_int start, int8_t ip){
   MMG5_pTetra    pt,pt1;
-  MMG5_xTetra    pxt;
   int            ilist,cur,nref;
   MMG5_int       base,ref,*adja,list[MMG3D_LMAX+2],k,k1,nump;
   int8_t         i,l,j,pmmg_bdy,iedge;
@@ -1513,16 +1512,8 @@ int MMG3D_chkmaniball(MMG5_pMesh mesh, MMG5_int start, int8_t ip){
     k = list[cur] / 4;
     pt = &mesh->tetra[k];
     if( pt->ref == ref ) {
-      pxt = mesh->xtetra[pt->xt];
       pmmg_bdy=0;
-      /* if an edge is MG_PARBDY: this is not a non-manifold topology */
-      /*    - True  for centralized input in parmmg */
-      /*    - Wrong for distributed input in parmmg: TODO */
-      for (iedge=0; iedge<6; iedge++) {
-        if ( !(pxt.tag[iedge] & MG_PARBDY) ) continue;
-        pmmg_bdy=1;
-      }
-      /* if the starting point is MG_PARBDY: this is not a non-manifold topology */
+      /* If the starting point is MG_PARBDY: this is not a non-manifold topology */
       /*    - True  for centralized input in parmmg */
       /*    - Wrong for distributed input in parmmg: TODO */
       if ( mesh->point[nump].tag & MG_PARBDY) {


### PR DESCRIPTION
MMG3D_chkmaniball has been modified for ParMmg:
- if a point, an edge, a triangle or a tetra has the tag PARBDY, do not raise a non-manifold error - at least for now, as the "missing" element(s) of the ball might be on another partition. An additional check will be added in ParMmg later.