### PR TITLE
Feature/fix missing bdy ppt tag for parmmg+ls

### DIFF
--- a/src/mmg3d/hash_3d.c
+++ b/src/mmg3d/hash_3d.c
@@ -1706,7 +1706,7 @@ int MMG5_chkBdryTria(MMG5_pMesh mesh) {
     for (k=1; k<=mesh->nt; k++) {
       ptt = &mesh->tria[k];
       for (i=0; i<3; i++) {
-        if ( !mesh->info.iso ) mesh->point[ptt->v[i]].tag |= MG_BDY;
+        mesh->point[ptt->v[i]].tag |= MG_BDY;
       }
     }
     return 1;


### PR DESCRIPTION
This PR remove a useless test on the iso mode: in iso mode, the MG_BDY tag at bdry points was not added during the call of the chkBdryTria function. It was not an issue as this tag is setted during the step of reconstruction of boundary tria from xtetra.