### PR TITLE
Fast fix of unefficiency or the setVertexNmTag function visible only …

### DIFF
--- a/src/mmg3d/boulep_3d.c
+++ b/src/mmg3d/boulep_3d.c
@@ -463,6 +463,8 @@ int MMG5_boulernm(MMG5_pMesh mesh,MMG5_Hash *hash,MMG5_int start,int ip,MMG5_int
   uint8_t        ie;
 
   /* reset the hash table */
+  hash->nxt = hash->siz;
+
   for ( k=0;  k<=hash->max; ++k ) {
     hash->item[k].a = 0;
     hash->item[k].b = 0;
@@ -514,8 +516,10 @@ int MMG5_boulernm(MMG5_pMesh mesh,MMG5_Hash *hash,MMG5_int start,int ip,MMG5_int
           else if ( ph->a ) {
             while ( ph->nxt && ph->nxt < hash->max ) {
               ph = &hash->item[ph->nxt];
-              if ( ph->a == ia && ph->b == ib )  continue;
+              if ( ph->a == ia && ph->b == ib )  break;
             }
+            if ( ph->a == ia && ph->b == ib  ) continue;
+
             ph->nxt   = hash->nxt;
             ph        = &hash->item[hash->nxt];
 
@@ -551,7 +555,16 @@ int MMG5_boulernm(MMG5_pMesh mesh,MMG5_Hash *hash,MMG5_int start,int ip,MMG5_int
           else if ( pxt->tag[ie] & MG_REF ) {
             ++(*nr);
           }
+
+          assert ( pxt->tag[ie] & MG_GEO  ||  pxt->tag[ie] & MG_NOM  || pxt->tag[ie] & MG_REF );
           ++ns;
+
+          if ( ns > 2 ) {
+            /* Point will be marked as singular: no need to have the exact count
+             * of feature edges */
+            assert ( *ng + *nr + *nm > 2 );
+            return ns;
+          }
         }
       }
     }

--- a/src/mmg3d/hash_3d.c
+++ b/src/mmg3d/hash_3d.c
@@ -633,13 +633,16 @@ int MMG5_setVertexNmTag(MMG5_pMesh mesh) {
 
   /* Hash table used by boulernm to store the special edges passing through
    * a given point */
-  np = 0;
-  for (k=1; k<=mesh->np; ++k) {
-    ppt = &mesh->point[k];
-    if ( (!(ppt->tag & MG_NOM)) || (ppt->tag & MG_REQ) ) continue;
-    ++np;
-  }
+  /* np = 0; */
+  /* for (k=1; k<=mesh->np; ++k) { */
+  /*   ppt = &mesh->point[k]; */
+  /*   if ( (!(ppt->tag & MG_NOM)) || (ppt->tag & MG_REQ) ) continue; */
+  /*   ++np; */
+  /* } */
 
+  /* Use a very small hash table as it is useless to count and hash pore than 3
+   * feature edges passing through the points */
+  np = 5;
   if ( ! MMG5_hashNew(mesh,&hash,np,(MMG5_int)(3.71*np)) ) return 0;
 
   nc = nre = 0;


### PR DESCRIPTION
…for a high number of nm points (due to boulernm unefficiency).