### PR TITLE
Feature/pmmg issue97

### DIFF
--- a/src/mmg3d/boulep_3d.c
+++ b/src/mmg3d/boulep_3d.c
@@ -440,6 +440,149 @@ int MMG5_boulenmInt(MMG5_pMesh mesh,MMG5_int start,int ip,double t[3]) {
 
 /**
  * \param mesh pointer toward the mesh structure.
+ * \param hash pointer toward an allocated hash table.
+ * \param start index of the starting tetrahedra.
+ * \param ip local index of the point in the tetrahedra \a start.
+ * \param ng pointer toward the number of ridges.
+ * \param nr pointer toward the number of reference edges.
+ * \param nm pointer toward the number of non-manifold edges.
+ * \return ns the number of special edges passing through ip, -1 if fail.
+ *
+ * Count the numer of ridges and reference edges incident to
+ * the vertex \a ip when ip is non-manifold.
+ *
+ */
+int MMG5_boulernm(MMG5_pMesh mesh,MMG5_Hash *hash,MMG5_int start,int ip,MMG5_int *ng,MMG5_int *nr,MMG5_int *nm){
+  MMG5_pTetra    pt,pt1;
+  MMG5_pxTetra   pxt;
+  MMG5_hedge    *ph;
+  MMG5_int       *adja,nump,k,k1;
+  int            ns,ilist,cur;
+  MMG5_int       list[MMG3D_LMAX+2],base,ia,ib,a,b,key,jj;
+  int8_t         j,l,i;
+  uint8_t        ie;
+
+  /* reset the hash table */
+  for ( k=0;  k<=hash->max; ++k ) {
+    hash->item[k].a = 0;
+    hash->item[k].b = 0;
+  }
+
+  for ( k=0;  k<=hash->siz; ++k ) {
+    hash->item[k].nxt = 0;
+  }
+  for (k=hash->siz; k<hash->max; k++) {
+    hash->item[k].nxt = k+1;
+  }
+
+  base = ++mesh->base;
+  pt   = &mesh->tetra[start];
+  nump = pt->v[ip];
+
+  /* Store initial tetrahedron */
+  pt->flag = base;
+  list[0] = 4*start + ip;
+  ilist = 1;
+
+  *ng = *nr = *nm = ns = 0;
+
+  /* Explore list and travel by adjacency through elements sharing p */
+  cur = 0;
+  while ( cur < ilist ) {
+    k = list[cur] / 4;
+    i = list[cur] % 4; // index of point p in tetra k
+    pt = &mesh->tetra[k];
+
+    /* Count the number of ridge of ref edges passing through ip. */
+    if ( pt->xt ) {
+      pxt = &mesh->xtetra[pt->xt];
+      for (l=0; l<3; ++l) {
+        ie = MMG5_arpt[i][l];
+
+        if ( MG_EDG(pxt->tag[ie]) || (MG_NOM & pxt->tag[ie]) ) {
+          /* Seek if we have already seen the edge. If not, hash it and
+           * increment ng or nr.*/
+          a = pt->v[MMG5_iare[ie][0]];
+          b = pt->v[MMG5_iare[ie][1]];
+          ia  = MG_MIN(a,b);
+          ib  = MG_MAX(a,b);
+          key = (MMG5_KA*(int64_t)ia + MMG5_KB*(int64_t)ib) % hash->siz;
+          ph  = &hash->item[key];
+
+          if ( ph->a == ia && ph->b == ib )
+            continue;
+          else if ( ph->a ) {
+            while ( ph->nxt && ph->nxt < hash->max ) {
+              ph = &hash->item[ph->nxt];
+              if ( ph->a == ia && ph->b == ib )  continue;
+            }
+            ph->nxt   = hash->nxt;
+            ph        = &hash->item[hash->nxt];
+
+            if ( hash->nxt >= hash->max-1 ) {
+              if ( mesh->info.ddebug )
+                fprintf(stderr,"\n  ## Warning: %s: memory alloc problem (edge):"
+                        " %" MMG5_PRId "\n",__func__,hash->max);
+              MMG5_TAB_RECALLOC(mesh,hash->item,hash->max,MMG5_GAP,MMG5_hedge,
+                                 "MMG5_edge",return -1);
+              /* ph pointer may be false after realloc */
+              ph        = &hash->item[hash->nxt];
+
+              for (jj=ph->nxt; jj<hash->max; jj++)  hash->item[jj].nxt = jj+1;
+            }
+            hash->nxt = ph->nxt;
+          }
+
+          /* insert new edge */
+          ph->a = ia;
+          ph->b = ib;
+          ph->nxt = 0;
+
+          /* Order of following tests impacts the ridge and non-manifold edges
+           * count (an edge that has both tags pass only in first test) but
+           * should not influence the setting for corners and required tags in
+           * setVertexNmTag function) */
+          if ( pxt->tag[ie] & MG_GEO ) {
+            ++(*ng);
+          }
+          else if ( pxt->tag[ie] & MG_NOM ) {
+            ++(*nm);
+          }
+          else if ( pxt->tag[ie] & MG_REF ) {
+            ++(*nr);
+          }
+          ++ns;
+        }
+      }
+    }
+
+    /* Continue to travel */
+    adja = &mesh->adja[4*(k-1)+1];
+
+    for (l=0; l<3; l++) {
+      i  = MMG5_inxt3[i];
+      k1 = adja[i];
+      if ( !k1 )  continue;
+      k1 /= 4;
+      pt1 = &mesh->tetra[k1];
+      if ( pt1->flag == base )  continue;
+      pt1->flag = base;
+      for (j=0; j<4; j++)
+        if ( pt1->v[j] == nump )  break;
+      assert(j<4);
+      /* overflow */
+      if ( ilist > MMG3D_LMAX-3 )  return 0;
+      list[ilist] = 4*k1+j;
+      ilist++;
+    }
+    cur++;
+  }
+
+  return ns;
+}
+
+/**
+ * \param mesh pointer toward the mesh structure.
  * \param start index of the starting tetra.
  * \param ip index in \a start of the looked point.
  * \param iface index in \a start of the starting face.

--- a/src/mmg3d/libmmg3d_private.h
+++ b/src/mmg3d/libmmg3d_private.h
@@ -238,6 +238,7 @@ extern int  MMG5_BezierRidge(MMG5_pMesh mesh,MMG5_int ip0, MMG5_int ip1, double 
 extern int  MMG5_BezierNom(MMG5_pMesh mesh,MMG5_int ip0,MMG5_int ip1,double s,double *o,double *no,double *to);
 int  MMG5_norface(MMG5_pMesh mesh ,MMG5_int k, int iface, double v[3]);
 int  MMG3D_findEdge(MMG5_pMesh,MMG5_pTetra,MMG5_int,MMG5_int,MMG5_int,int,int8_t*,int8_t* );
+int  MMG5_boulernm (MMG5_pMesh mesh,MMG5_Hash *hash, MMG5_int start, int ip, MMG5_int *ng, MMG5_int *nr,MMG5_int *nm);
 int  MMG5_boulenm(MMG5_pMesh mesh, MMG5_int start, int ip, int iface, double n[3],double t[3]);
 int  MMG5_boulenmInt(MMG5_pMesh mesh, MMG5_int start, int ip, double t[3]);
 int  MMG5_boulevolp(MMG5_pMesh mesh, MMG5_int start, int ip, int64_t * list);


### PR DESCRIPTION
Re-introduction of `boulernm` function for fast-fix of ParMmg compilation with the develop branch of Mmg.

⚠️ As it is not efficient, this function has to be removed and the new `setVertexNmTag` function of Mmg as to be used instead. For now it is not possible because `boulernm` was probably bugged (to be confirmed) and some 'regular' non-manifold points where marked as corner+required. Removing these erroneous tags raises errors in the parallel surface analysis of ParMmg (it has to be investigated).