### PR TITLE
Feature/pmmg issue97

### DIFF
--- a/src/mmg3d/libmmg3d_private.h
+++ b/src/mmg3d/libmmg3d_private.h
@@ -263,6 +263,7 @@ int16_t MMG5_openCoquilTravel(MMG5_pMesh,MMG5_int,MMG5_int,MMG5_int*,MMG5_int*,i
 int  MMG5_settag(MMG5_pMesh,MMG5_int,int,int16_t,int);
 int  MMG5_deltag(MMG5_pMesh,MMG5_int,int,int16_t);
 int  MMG5_setNmTag(MMG5_pMesh mesh, MMG5_Hash *hash);
+int  MMG5_setVertexNmTag(MMG5_pMesh mesh,int func(int8_t) );
 int  MMG5_chkcol_int(MMG5_pMesh,MMG5_pSol,MMG5_int,int8_t,int8_t,int64_t*,int,int8_t);
 int  MMG5_chkcol_bdy(MMG5_pMesh,MMG5_pSol,MMG5_int,int8_t,int8_t,int64_t*,int,MMG5_int*,int,MMG5_int,MMG5_int,int8_t,int,int8_t);
 int  MMG3D_chkmanicoll(MMG5_pMesh,MMG5_int,int,int,MMG5_int,MMG5_int,MMG5_int,MMG5_int,int8_t,int8_t);


### PR DESCRIPTION
This PR replaces the use of the `tmp` point field in the `setVertexNmTag` function by the use of a temporary array.

For Mmg it should not change anything but it fixes the issue introduced in the parallel analysis of ParMmg by the modification of the `tmp` field (that is used to store the global node numbering and should not be modified before, at least, the end of the normal computation).

See ParMmg issue [97](https://github.com/MmgTools/ParMmg/issues/97)