### PR TITLE
Feature/fix coquilface

### DIFF
--- a/src/mmg3d/colver_3d.c
+++ b/src/mmg3d/colver_3d.c
@@ -613,38 +613,36 @@ int MMG5_chkcol_bdy(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t iface,
       if ( pt->xt && (pxt->ftag[ipp] & MG_BDY) && (pxt->ftag[iq] & MG_BDY) )
         return 0;
 
-      if ( pt->xt )  {
-        for (i=0; i<4; i++) {
-          if ( i==ipp || i==iq ) {
-            continue;
+      for (i=0; i<4; i++) {
+        if ( i==ipp || i==iq ) {
+          continue;
+        }
+
+        /*  Avoid surface crimping: check that the collapse doesn't merge 3
+         *  bdy edge along a non bdy face: we have to check the edge of each
+         *  shell because some MG_BDY tags may be missings due to the creation
+         *  of an xtetra during a previous collapse */
+        if ( (!pt->xt) || !(pxt->ftag[i] & MG_BDY) ) {
+          int16_t tag0,tag1,tag2;
+          int     ref0,ref1,ref2;
+
+          tag0 = tag1 = tag2 = 0;
+          ref0 = ref1 = ref2 = 0;
+
+          if ( !MMG3D_get_shellEdgeTag(mesh,iel,MMG5_iarf[i][0],&tag0,&ref0) ) {
+            fprintf(stderr,"\n  ## Error: %s: 0. unable to get edge info.\n",__func__);
+            return 0;
           }
-
-          /*  Avoid surface crimping: check that the collapse doesn't merge 3
-           *  bdy edge along a non bdy face: we have to check the edge of each
-           *  shell because some MG_BDY tags may be missings due to the creation
-           *  of an xtetra during a previous collapse */
-          if ( !(pxt->ftag[i] & MG_BDY) ) {
-            int16_t tag0,tag1,tag2;
-            int     ref0,ref1,ref2;
-
-            tag0 = tag1 = tag2 = 0;
-            ref0 = ref1 = ref2 = 0;
-
-            if ( !MMG3D_get_shellEdgeTag(mesh,iel,MMG5_iarf[i][0],&tag0,&ref0) ) {
-              fprintf(stderr,"\n  ## Error: %s: 0. unable to get edge info.\n",__func__);
-              return 0;
-            }
-            if ( !MMG3D_get_shellEdgeTag(mesh,iel,MMG5_iarf[i][1],&tag1,&ref1) ) {
-              fprintf(stderr,"\n  ## Error: %s: 1. unable to get edge info.\n",__func__);
-              return 0;
-            }
-            if ( !MMG3D_get_shellEdgeTag(mesh,iel,MMG5_iarf[i][2],&tag2,&ref2) ) {
-              fprintf(stderr,"\n  ## Error: %s: 2. unable to get edge info.\n",__func__);
-              return 0;
-            }
-            if ( (tag0 & MG_BDY) && (tag1 & MG_BDY) && (tag2 & MG_BDY ) ) {
-              return 0;
-            }
+          if ( !MMG3D_get_shellEdgeTag(mesh,iel,MMG5_iarf[i][1],&tag1,&ref1) ) {
+            fprintf(stderr,"\n  ## Error: %s: 1. unable to get edge info.\n",__func__);
+            return 0;
+          }
+          if ( !MMG3D_get_shellEdgeTag(mesh,iel,MMG5_iarf[i][2],&tag2,&ref2) ) {
+            fprintf(stderr,"\n  ## Error: %s: 2. unable to get edge info.\n",__func__);
+            return 0;
+          }
+          if ( (tag0 & MG_BDY) && (tag1 & MG_BDY) && (tag2 & MG_BDY ) ) {
+            return 0;
           }
         }
       }


### PR DESCRIPTION
[fix-collapse.tar.gz](https://github.com/MmgTools/mmg/files/13415588/fix-collapse.tar.gz)
Modified checks in MMG5_chkcol_bdy to prevent some unwanted collapses.

Several files are attached. `ctest-logs-devel.txt` and `ctest-logs-fix.txt` contain the logs of the continuous integration tests for both the unfixed (`devel`) and fixed versions of the code. Only mmg3d tests have been run (long tests included). For these tests, mmg has been compiled in `Release` mode, with `32-bit integers`. `Scotch` is used in sequential mode (`BUILD_PTSCOTCH=OFF`) for reproducibility. Computing times are similar and adaptation waves are strictly identical with or without the fix.

`test-devel.log` and `test-fix.log` are the output of mmg for the following test (download [input mesh](https://static.bordeaux.inria.fr/mmg/meshes-drive/mmg-PR227.mesh)):
```
mmg3d_debug mmg-PR227.mesh -hausd 0.5 -hmin 1 -hmax 5 -nr -nofem -xreg -m 7000 -v 10
```
The CoquilFace warning that appears in the devel version has been successfully removed with this update. However, another similar warning appears later in the remeshing process, which requires further investigation and will be the object of future update.

The configuration of interest for this update is as illustrated in the picture:
![schema_collapse](https://github.com/MmgTools/mmg/assets/115083621/a66510b7-38f4-4965-b6db-ff3c52a697a2)
The collapse that is represented on the picture (point _ip_ over point _iq_) merges two manifold edges that each possess exactly two boundary faces (hatched triangles on the picture). Hence, the collapse results in a non-manifold edge since there are now four boundary triangles in the shell of the edge. The modification of the topology of the mesh being unwanted, some tests have been modified in order to refuse such a collapse.
