### PR TITLE
Force the split of regular boundary edges connecting ridge or non-manifold vertices

### DIFF
--- a/src/mmg3d/mmg3d1.c
+++ b/src/mmg3d/mmg3d1.c
@@ -487,9 +487,16 @@ int8_t MMG5_chkedg(MMG5_pMesh mesh,MMG5_Tria *pt,int8_t ori, double hmax,
     /*   } */
     /* } */
 
-    hma2 = MMG3D_LLONG*MMG3D_LLONG*hmax*hmax;
+
+    /* Split regular boundary edges connecting ridge or non-manifold points */
+    if ( (MG_GEO_OR_NOM(p[i1]->tag) && MG_GEO_OR_NOM(p[i2]->tag)) && !MG_GEO_OR_NOM(pt->tag[i]) ) {
+      MG_SET(pt->flag,i);
+      continue;
+    }
 
     /* check length */
+    hma2 = MMG3D_LLONG*MMG3D_LLONG*hmax*hmax;
+
     ux = p[i2]->c[0] - p[i1]->c[0];
     uy = p[i2]->c[1] - p[i1]->c[1];
     uz = p[i2]->c[2] - p[i1]->c[2];

--- a/src/mmg3d/swap_3d.c
+++ b/src/mmg3d/swap_3d.c
@@ -134,6 +134,18 @@ int MMG5_chkswpbdy(MMG5_pMesh mesh, MMG5_pSol met, int64_t *list,int ilist,
            (tt2.v[MMG5_inxt2[ia2]] == nq && tt2.v[MMG5_iprv2[ia2]] == np) );
   na2 = tt2.v[ia2];
 
+#ifdef NDEBUG
+  /* Check that we don't have a regular bdy edge connecting ridge or nm points */
+  if ( MG_GEO_OR_NOM(mesh->point[np].tag) && MG_GEO_OR_NOM(mesh->point[nq].tag) ) {
+    assert ( ! MG_GEO_OR_NOM(tt1.tag[ia1]) );
+    assert ( ! MG_GEO_OR_NOM(tt2.tag[ia2]) );
+  }
+#endif
+  /* No swap if it creates a regular boundary edge connecting ridge or non-manifold points */
+  if ( MG_GEO_OR_NOM(mesh->point[na1].tag) && MG_GEO_OR_NOM(mesh->point[na2].tag) ) {
+    return 0;
+  }
+
   /* Check non convexity (temporarily use b0,b1)*/
   MMG5_norpts(mesh,tt1.v[ia1],tt1.v[MMG5_inxt2[ia1]],tt2.v[ia2],b0);
   MMG5_norpts(mesh,tt2.v[ia2],tt2.v[MMG5_inxt2[ia2]],tt1.v[ia1],b1);


### PR DESCRIPTION
⚠️ Not to be merged: user specific ask ⚠️ 
---

The current PR forces the splitting of "regular" surface edges connecting vertices along "feature" edges (ridges or non-manifold edges). 
See attached picture: The green nodes are inserted along the "regular" surface edges that connects nodes along ridges.
Surface triangles and underlying tetrahedra are splitting accordingly.
<img src="https://github.com/MmgTools/mmg/assets/11232703/1941b834-7c0a-469e-8c0f-d82a055a3b43" width="35%" height="35%"> <img src="https://github.com/MmgTools/mmg/assets/11232703/e3a600c1-9158-4984-aaf6-5e27a0ac4b81" width="35%" height="35%"> 
