### PR TITLE
Fix possibly invalid pointer

### DIFF
--- a/src/mmg2d/analys_2d.c
+++ b/src/mmg2d/analys_2d.c
@@ -54,6 +54,10 @@ int MMG2D_setadj(MMG5_pMesh mesh, int8_t init_cc) {
   int16_t          tag;
   int8_t           i,ii,i1,i2;
 
+  if ( !mesh->nt ) {
+    return 1;
+  }
+
   if ( abs(mesh->info.imprim) > 5  || mesh->info.ddebug )
     fprintf(stdout,"  ** SETTING TOPOLOGY\n");
 

--- a/src/mmg2d/hash_2d.c
+++ b/src/mmg2d/hash_2d.c
@@ -29,7 +29,7 @@
  * \param mesh pointer toward the mesh
  * \return 1 if success, 0 if fail
  *
- * Create adjacency relations between the triangles dein the mesh
+ * Create adjacency relations between the triangles in the mesh
  *
  */
 int MMG2D_hashTria(MMG5_pMesh mesh) {
@@ -40,7 +40,7 @@ int MMG2D_hashTria(MMG5_pMesh mesh) {
   unsigned int   key;
 
   if ( mesh->adja )  return 1;
-  if ( !mesh->nt )  return 0;
+  if ( !mesh->nt )  return 1;
 
   /* memory alloc */
   MMG5_SAFE_CALLOC(hcode,mesh->nt+1,MMG5_int,return 0);

--- a/src/mmg2d/length_2d.c
+++ b/src/mmg2d/length_2d.c
@@ -140,6 +140,10 @@ int MMG2D_prilen(MMG5_pMesh mesh,MMG5_pSol sol) {
   ibmax = 0;
   nullEdge = 0;
 
+  if ( !mesh->nt ) {
+    return 0;
+  }
+
   for (k=0; k<9; k++)  hl[k] = 0;
 
   for (k=1; k<=mesh->nt; k++) {

--- a/src/mmg2d/quality_2d.c
+++ b/src/mmg2d/quality_2d.c
@@ -187,6 +187,10 @@ int MMG2D_outqua(MMG5_pMesh mesh,MMG5_pSol met) {
   MMG5_int      k,iel,ok,nex;
   static int8_t mmgWarn0;
 
+  if ( !mesh->nt ) {
+    return 1;
+  }
+
   /* Compute triangle quality*/
   for (k=1; k<=mesh->nt; k++) {
     pt = &mesh->tria[k];

--- a/src/mmg2d/zaldy_2d.c
+++ b/src/mmg2d/zaldy_2d.c
@@ -64,7 +64,9 @@ void MMG2D_delPt(MMG5_pMesh mesh,MMG5_int ip) {
   ppt->tmp    = mesh->npnil;
 
   mesh->npnil = ip;
-  if ( ip == mesh->np )  mesh->np--;
+  if ( ip == mesh->np ) {
+    while ( (!MG_VOK((&mesh->point[mesh->np]))) && mesh->np )  mesh->np--;
+  }
 }
 
 void MMG5_delEdge(MMG5_pMesh mesh,MMG5_int iel) {
@@ -119,7 +121,9 @@ int MMG2D_delElt(MMG5_pMesh mesh,MMG5_int iel) {
     memset(&mesh->adja[iadr],0,3*sizeof(MMG5_int));
 
   mesh->nenil = iel;
-  if ( iel == mesh->nt )  mesh->nt--;
+  if ( iel == mesh->nt ) {
+    while ( (!MG_EOK((&mesh->tria[mesh->nt]))) && mesh->nt ) mesh->nt--;
+  }
   return 1;
 }
 

--- a/src/mmg3d/anisomovpt_3d.c
+++ b/src/mmg3d/anisomovpt_3d.c
@@ -328,6 +328,9 @@ int MMG5_movbdyregpt_ani(MMG5_pMesh mesh, MMG5_pSol met, MMG3D_pPROctree PROctre
 
   /** Step 5 : come back to original problem, compute patch in triangle iel and
    * check that geometric approx has not been degraded too much */
+  // Remark: if we call following function with a pointer for n, we have to set
+  // the pointer again after the function call as it may invalidate it if it
+  // reallocates the xpoint array
   nxp = MMG3D_movbdyregpt_geom(mesh,lists,kel,ip0,n,lambda,o,no);
   if ( nxp < 0 ) {
     return -1;

--- a/src/mmg3d/zaldy_3d.c
+++ b/src/mmg3d/zaldy_3d.c
@@ -91,7 +91,7 @@ void MMG3D_delPt(MMG5_pMesh mesh,MMG5_int ip) {
   ppt->tmp    = mesh->npnil;
   mesh->npnil = ip;
   if ( ip == mesh->np ) {
-    while ( !MG_VOK((&mesh->point[mesh->np])) )  mesh->np--;
+    while ( (!MG_VOK((&mesh->point[mesh->np]))) && mesh->np )  mesh->np--;
   }
 }
 
@@ -135,7 +135,7 @@ int MMG3D_delElt(MMG5_pMesh mesh,MMG5_int iel) {
     memset(&mesh->adja[iadr],0,4*sizeof(MMG5_int));
   mesh->nenil = iel;
   if ( iel == mesh->ne ) {
-    while ( !MG_EOK((&mesh->tetra[mesh->ne])) )  mesh->ne--;
+    while ( (!MG_EOK((&mesh->tetra[mesh->ne]))) && mesh->ne )  mesh->ne--;
   }
   return 1;
 }

--- a/src/mmgs/zaldy_s.c
+++ b/src/mmgs/zaldy_s.c
@@ -64,7 +64,7 @@ void MMGS_delPt(MMG5_pMesh mesh,MMG5_int ip) {
   ppt->tmp    = mesh->npnil;
   mesh->npnil = ip;
   if ( ip == mesh->np ) {
-    while ( !MG_VOK((&mesh->point[mesh->np])) )  mesh->np--;
+    while ( (!MG_VOK((&mesh->point[mesh->np]))) && mesh->np )  mesh->np--;
   }
 }
 
@@ -104,7 +104,7 @@ int MMGS_delElt(MMG5_pMesh mesh,MMG5_int iel) {
     memset(&mesh->adja[3*(iel-1)+1],0,3*sizeof(MMG5_int));
   mesh->nenil = iel;
   if ( iel == mesh->nt ) {
-    while ( !MG_EOK((&mesh->tria[mesh->nt])) )  mesh->nt--;
+    while ( (!MG_EOK((&mesh->tria[mesh->nt]))) && mesh->nt )  mesh->nt--;
   }
   return 1;
 }


### PR DESCRIPTION
This PR Fixes:
  -  a possible invalid pointer in `MMG3D_movbdyregpt_iso` after the reallocation of the `xpoint` array by the `MMG3D_movbdyregpt_geom` function (see [`ls-CenIn-DisOut-8`](https://github.com/MmgTools/ParMmg/actions/runs/7087830726/job/19288965242) ParMmg continuous test for example);
   - a possible memory error when deleting all the tetra/points from the mesh (for example in the `keep_only1subdomain` function, see [`mmg3d_hybrid-nsd1`](https://github.com/MmgTools/mmg/actions/runs/7089246726/job/19293565132) continuous integration test case)
   
It reports this last fix inside the `MMG[2D|S]_del[Pt|Elt]` functions.