### PR TITLE
Fix CoquilFace warning

### DIFF
--- a/src/mmg3d/colver_3d.c
+++ b/src/mmg3d/colver_3d.c
@@ -393,7 +393,8 @@ int MMG3D_get_shellEdgeTag_oneDir(MMG5_pMesh  mesh,MMG5_int start, MMG5_int na, 
     if ( pt->xt ) {
       pxt = &mesh->xtetra[pt->xt];
       *ref  = pxt->edg[i];
-      if ( pxt->tag[i] & MG_BDY ) {
+      if ((pxt->ftag[MMG5_ifar[i][0]] & MG_BDY) || (pxt->ftag[MMG5_ifar[i][1]] & MG_BDY)) {
+        *tag |= MG_BDY;
         *tag |= pxt->tag[i];
         *filled = 1;
         return adj;
@@ -445,7 +446,8 @@ int MMG3D_get_shellEdgeTag(MMG5_pMesh  mesh,MMG5_int start, int8_t ia,int16_t *t
 
   if ( pt->xt ) {
     pxt = &mesh->xtetra[pt->xt];
-    if ( pxt->tag[ia] & MG_BDY ) {
+    if ((pxt->ftag[MMG5_ifar[ia][0]] & MG_BDY) || (pxt->ftag[MMG5_ifar[ia][1]] & MG_BDY)) {
+      *tag |= MG_BDY;
       *tag |= pxt->tag[ia];
       *ref = pxt->edg[ia];
       return 1;

--- a/src/mmg3d/colver_3d.c
+++ b/src/mmg3d/colver_3d.c
@@ -393,9 +393,12 @@ int MMG3D_get_shellEdgeTag_oneDir(MMG5_pMesh  mesh,MMG5_int start, MMG5_int na, 
     if ( pt->xt ) {
       pxt = &mesh->xtetra[pt->xt];
       *ref  = pxt->edg[i];
-      if ((pxt->ftag[MMG5_ifar[i][0]] & MG_BDY) || (pxt->ftag[MMG5_ifar[i][1]] & MG_BDY)) {
-        *tag |= MG_BDY;
+      if ( pxt->tag[i] & MG_BDY ) {
         *tag |= pxt->tag[i];
+        *filled = 1;
+        return adj;
+      } else if ((pxt->ftag[MMG5_ifar[i][0]] & MG_BDY) || (pxt->ftag[MMG5_ifar[i][1]] & MG_BDY)) {
+        *tag |= (pxt->tag[i] | MG_BDY);
         *filled = 1;
         return adj;
       }
@@ -446,11 +449,15 @@ int MMG3D_get_shellEdgeTag(MMG5_pMesh  mesh,MMG5_int start, int8_t ia,int16_t *t
 
   if ( pt->xt ) {
     pxt = &mesh->xtetra[pt->xt];
-    if ((pxt->ftag[MMG5_ifar[ia][0]] & MG_BDY) || (pxt->ftag[MMG5_ifar[ia][1]] & MG_BDY)) {
-      *tag |= MG_BDY;
-      *tag |= pxt->tag[ia];
-      *ref = pxt->edg[ia];
-      return 1;
+    *ref = pxt->edg[ia];
+    if ( pxt->tag[ia] & MG_BDY ) {
+        *tag |= pxt->tag[ia];
+        *ref = pxt->edg[ia];
+        return 1;
+    } else if ((pxt->ftag[MMG5_ifar[ia][0]] & MG_BDY) || (pxt->ftag[MMG5_ifar[ia][1]] & MG_BDY)) {
+        *tag |= (pxt->tag[ia] | MG_BDY);
+        *ref = pxt->edg[ia];
+        return 1;
     }
   }
 


### PR DESCRIPTION
This update fixes the triggering of a warning relative to the check of the number of boundary faces in the shell of a manifold edge. 

# Issue description
Collapses would sometimes merge two boundary manifold edges (that would each have 2 boundary faces in their shells) into one edge with 4 faces in the shell. 

It happens when a non-boundary triangle has 3 boundary edges and we collapse one of the boundary edge (the two other edges being merged together). 
(See attached picture were the edge `p-q` is collapsed, the 3 colored edges are boundary edges and the triangle `p-p-q` is an internal triangle).
![non-bdy-tri](https://github.com/MmgTools/mmg/assets/11232703/cfc353e6-5b9c-42bb-aae2-0c00d20c6f2a)

To avoid this situation, when collapsing an edge, we travel the shell of the edge and we check the presence of an "internal triangle with 3 boundary edges" situation. It requires to be able to identify if an edge is a boundary edge. 

The bug solved by this PR is due to the non-consistency of boundary tags between faces and edges.

# Tag management in Mmg 
Currently, the Mmg convention seems to be the following one:
  - an edge related to a boundary face inside a given tetra is:
    - marked as `MG_BDY`+another tag if it is related to a given feature (ridge, ref edge, nosurf...);
    - marked `MG_BDY` or not marked (0 tag) if it is a regular surface edge (regular surface edges without tags are created by the pattern splittings, see [here](https://github.com/MmgTools/mmg/blob/3a5e3abc38f7f100a481bcebe8aa23e105d7c381/src/mmg3d/split_3d.c#L176-L181).
  - a boundary edge not related to a boundary face may have a`MG_BDY` tag or not (it is due to the fact that it is expensive to update the edge tag informations for each edge of a tetra when a xtetra is added to the tetra during a collapse, thus, only edges of the new boundary face are updated).
  - a tetra with a boundary edge but no boundary face may have or not have a xtetra: in any case, we must not treat a boundary edge from a non-boundary face.
  - If an edge, related to a boundary face or not, has a non-nul tag, the tag has to contain all the needed informations (an edge has either no tag at all, or all the needed tags). It means that matching edges should have no tags or consistent tags inside the tetra to which they belong.  

Note that it seems that we have few tests that seems erroneous regarding this convention:
  - in lagrangian motion
  - during the computation of anisotropic edge lengths
  - at anisotropic metric interpolation

# Resolution
As the `MG_BDY` tag is not always present along regular boundary edges, instead of checking for `xt->tag[i] & MG_BDY` , we now check the edge tag from a boundary face (we test `xt->ftag & MG_BDY` for both faces sharing edge i): if the edge has no tag at all, it is a regular edge so we now that the edge is exactly `MG_BDY`,  if it has a non-nul tag, we recover the tag stored in the xtetra .