### PR TITLE
Modification of the settag function

### DIFF
--- a/src/mmg3d/boulep_3d.c
+++ b/src/mmg3d/boulep_3d.c
@@ -1185,18 +1185,16 @@ int MMG3D_settag_oneDir(MMG5_pMesh  mesh,MMG5_int start, MMG5_int na, MMG5_int n
 
     if ( pt->xt ) {
       pxt = &mesh->xtetra[pt->xt];
-      if ( (pxt->ftag[MMG5_ifar[i][0]] & MG_BDY) ||
-           (pxt->ftag[MMG5_ifar[i][1]] & MG_BDY) ) {
-        taginit = pxt->tag[i];
-        pxt->tag[i] |= tag;
-        /* Remove the potential nosurf tag if initially the edge is
-         * really required */
-        if ( ((taginit & MG_REQ) && !(taginit & MG_NOSURF)) ||
-             ((    tag & MG_REQ) && !(    tag & MG_NOSURF)) ) {
-          pxt->tag[i] &= ~MG_NOSURF;
-        }
-        pxt->edg[i]  = MG_MAX(pxt->edg[i],edg);
+
+      taginit = pxt->tag[i];
+      pxt->tag[i] |= tag;
+      /* Remove the potential nosurf tag if initially the edge is
+       * really required */
+      if ( ((taginit & MG_REQ) && !(taginit & MG_NOSURF)) ||
+           ((    tag & MG_REQ) && !(    tag & MG_NOSURF)) ) {
+        pxt->tag[i] &= ~MG_NOSURF;
       }
+      pxt->edg[i]  = MG_MAX(pxt->edg[i],edg);
     }
     /* set new triangle for travel */
     adja = &mesh->adja[4*(adj-1)+1];
@@ -1244,18 +1242,15 @@ int MMG5_settag(MMG5_pMesh mesh,MMG5_int start,int ia,int16_t tag,int edg) {
 
   if ( pt->xt ) {
     pxt = &mesh->xtetra[pt->xt];
-    if ( (pxt->ftag[MMG5_ifar[ia][0]] & MG_BDY) ||
-         (pxt->ftag[MMG5_ifar[ia][1]] & MG_BDY) ) {
-      taginit = pxt->tag[ia];
-      pxt->tag[ia] |= tag;
-      /* Remove the potential nosurf tag if initially the edge is
-       * really required */
-      if ( ((taginit & MG_REQ) && !(taginit & MG_NOSURF)) ||
-           ((    tag & MG_REQ) && !(    tag & MG_NOSURF)) ) {
-        pxt->tag[ia] &= ~MG_NOSURF;
-      }
-      pxt->edg[ia]  = MG_MAX(pxt->edg[ia],edg);
+    taginit = pxt->tag[ia];
+    pxt->tag[ia] |= tag;
+    /* Remove the potential nosurf tag if initially the edge is
+     * really required */
+    if ( ((taginit & MG_REQ) && !(taginit & MG_NOSURF)) ||
+         ((    tag & MG_REQ) && !(    tag & MG_NOSURF)) ) {
+      pxt->tag[ia] &= ~MG_NOSURF;
     }
+    pxt->edg[ia]  = MG_MAX(pxt->edg[ia],edg);
   }
 
   adj = MMG3D_settag_oneDir(mesh,start,na,nb,tag,edg,piv,adj);


### PR DESCRIPTION
# Description of the issue
The settag function updates tag info by travelling the tetra of the shell of a given edge. Commit 0f487e0a (which aims to add the support of required entities) has introduced the fact that the edge tag is updated only for tetra in which the edge belongs to a boundary face.

Thus, if the edge has no boundary face, it is not updated.

It may leads to tag inconsistencies in ParMmg where the settag function is called (in `cleanMesh` function).
 and where edges not belonging to bdy faces may be marked as MG_BDY.

As a recall:
  - any edge marked as MG_BDY has to have consistent tags with the tags of the same edge in the other tetra.
  - regular edges belonging to a boundary face inside the current tet may have a 0 tag (because for now the splitting operators are creating boundary edges with 0 tags when splitting boundary triangles, see split_3d.c).
  - regular or non regular edges not having a bdy face inside the tetra may have a 0 tag.
  
# Resolution
 Now the edge tag is updated for all the tetra of the shell that have a xtetra.
 
 # Check for regression
 This modification has been tested by running, in Debug mode,  the continuous integration tests that contains required entities (`Req` pattern in test name) and the tests related to the nosurf option (`nosurf` pattern) : the adaptation waves are the same.

Remark: Comparative outputs may contains useless 2D or surface tests due to the usage of the regex.
 
[old-nosurf.txt](https://github.com/MmgTools/mmg/files/13687623/old-nosurf.txt)
[new-nosurf.txt](https://github.com/MmgTools/mmg/files/13687607/new-nosurf.txt)
[old-req.txt](https://github.com/MmgTools/mmg/files/13687612/old-req.txt)
[new-req.txt](https://github.com/MmgTools/mmg/files/13687600/new-req.txt)

 