### PR TITLE
Split internal edges connecting bdy points (mmg3d lag).

### DIFF
--- a/src/mmg3d/colver_3d.c
+++ b/src/mmg3d/colver_3d.c
@@ -428,7 +428,6 @@ int MMG3D_get_shellEdgeTag_oneDir(MMG5_pMesh  mesh,MMG5_int start, MMG5_int na, 
  * consistent through the edge shell);
  *
  */
-static inline
 int MMG3D_get_shellEdgeTag(MMG5_pMesh  mesh,MMG5_int start, int8_t ia,int16_t *tag,MMG5_int *ref) {
   MMG5_pTetra  pt;
   MMG5_pxTetra pxt;

--- a/src/mmg3d/libmmg3d_private.h
+++ b/src/mmg3d/libmmg3d_private.h
@@ -260,6 +260,7 @@ void MMG3D_coquilFaceSecondLoopInit(MMG5_pMesh mesh,MMG5_int piv,int8_t *iface,i
 void MMG5_coquilFaceErrorMessage(MMG5_pMesh mesh, MMG5_int k1, MMG5_int k2);
 int16_t MMG5_coquilTravel(MMG5_pMesh,MMG5_int,MMG5_int,MMG5_int*,MMG5_int*,int8_t*,int8_t*);
 int16_t MMG5_openCoquilTravel(MMG5_pMesh,MMG5_int,MMG5_int,MMG5_int*,MMG5_int*,int8_t*,int8_t*);
+int  MMG3D_get_shellEdgeTag(MMG5_pMesh,MMG5_int,int8_t,int16_t*,MMG5_int *);
 int  MMG5_settag(MMG5_pMesh,MMG5_int,int,int16_t,int);
 int  MMG5_deltag(MMG5_pMesh,MMG5_int,int,int16_t);
 int  MMG5_setNmTag(MMG5_pMesh mesh, MMG5_Hash *hash);


### PR DESCRIPTION
This PR:

  1. autorize the split of internal edges connecting boundary points in lagrangian option of mmg3d.
  2. fix the detection of boundary edges (that has lead to forbid the previous splits, see commit `73ae8fe7e`). Erroneous check was added by commit `5384387d7` under the erroneous assertion that boundary edges belonging to boundary faces are always marked as `MG_BDY`. It is not the case as at least pattern splitting are created regular boundary edges with no tags and as tetra without boundary faces may have edges along the boundary and either no xtetra, or a xtetra with a 0 tag for the edge or a xtetra whith suitable edge infos.
  
  # History
    1. In oct 2028, probably linked to a bug report from a user, commit `5384387d7` attempts to authorize the split of internal edges connecting boundary points while forbidding split of bdy edges but the detection of the boundary edges was erroneous. 2 cases were forbidden:
      - tetra without boundary faces but with one boundary edge may not have an xtetra attached or may have a xtetra with wrong info (no tag) for the boundary edge not linked to a boundary face inside the xtetra.
      - splitting operators are creating regular boundary edges without boundary tags.
      
    2. In Nov 2020, again probably linked to a bug report from a user, the commit `73ae8fe7e` has reintroduced the test over the boundary extremities to forbid the split of boundary edges (forbidding the split of internal edges connecting boundary nodes at the same time).

  # Test case
  I have not founded the inital test cases or a test case where the previous commits are creating visible errors so I attach a simple test case with an attempt to highlight potential issues.
  
[lagMot.tgz](https://github.com/MmgTools/mmg/files/13702426/lagMot.tgz)

Mmg is run in lagrangian mode with remeshing allowed (`-lag 2`) : 
```bash
mmg3d_debug -lag 2 tinyBoxt.mesh -v 5
```

  # Split of internal edges connecting boundary nodes
  The following patch is applied to highlight the too strict ban of edge splitting : 
[intEdge-bdyPts.patch](https://github.com/MmgTools/mmg/files/13702479/intEdge-bdyPts.patch).

  The tetra 256 for example is totally constrained as it has all its vertices along boundaries.
![IntEdg-BdyPts-tet256](https://github.com/MmgTools/mmg/assets/11232703/527c5424-1c7a-47d6-a7a7-570072509eb6)
We would like to authorize the split of the internal edges of this tetra.

# Wrong detection of boundary edges
On the current test case, there are no boundary edges that should be splitted and that are detected as the longest of the tetra so it is not possible to show a split that should be avoid.

Though, we can highlight that boundary edges are found after the test that should skip them (patch 
[bdyEdg-noTag.patch](https://github.com/MmgTools/mmg/files/13702603/bdyEdg-noTag.patch).

For example, the following picture shows such an edge and the tetra from which it is not detected as boundary by initial test but it is by the new one.
![bdyEdg-noTag](https://github.com/MmgTools/mmg/assets/11232703/a723fbd9-0f4c-4f6f-b128-2b937cdfa22f)

