### PR TITLE
Fix tags on parallel interface when in LS discretization mode - for ParMmg

### DIFF
--- a/src/mmg3d/hash_3d.c
+++ b/src/mmg3d/hash_3d.c
@@ -1374,7 +1374,13 @@ int MMG5_bdryTria(MMG5_pMesh mesh, MMG5_int ntmesh) {
         if ( pxt ) {
           /* Useful only when saving mesh or in ls mode */
           for( j = 0; j < 3; j++ ) {
-            /* Assign tags to tria from xtetra->tag and remove redundant boundary tag */
+            /* Assign tags to tria from xtetra->tag and remove redundant boundary tag:
+               when called from ParMmg in ls mode, it is needed to remove the parallel tags
+               coming from previous surface analysis to ensure the suitable setting of the
+               MG_BDY tag along edges at the intersection between geometrical (true)
+               boundaries and purely parallel interfaces. For that, it is mandatory to
+               remove the MG_PARBDYBDY tag already added along such edges
+               (see the step 2 of the mmgHashTria implementation) */
             if ( pxt->tag[MMG5_iarf[i][j]] ) {
               ptt->tag[j] = pxt->tag[MMG5_iarf[i][j]];
               /* MG_BDY is removed because by definition a triangle is on the boundary */

--- a/src/mmg3d/hash_3d.c
+++ b/src/mmg3d/hash_3d.c
@@ -1370,18 +1370,31 @@ int MMG5_bdryTria(MMG5_pMesh mesh, MMG5_int ntmesh) {
          * mesh->nt=0 at the beginning of the function) */
         ptt->cc = 4*k + i;
 
+        /* If in LS mode, in analysis after ls discretization: xtetra exists. It has been created by MMG5_bdrySet */
         if ( pxt ) {
-          /* useful only when saving mesh or in ls mode */
+          /* Useful only when saving mesh or in ls mode */
           for( j = 0; j < 3; j++ ) {
+            /* Assign tags to tria from xtetra->tag and remove redundant boundary tag */
             if ( pxt->tag[MMG5_iarf[i][j]] ) {
               ptt->tag[j] = pxt->tag[MMG5_iarf[i][j]];
-              /* Remove redundant boundary tag */
+              /* MG_BDY is removed because by definition a triangle is on the boundary */
               ptt->tag[j] &= ~MG_BDY;
+              /* MG_PARBDYBDY is removed because it will be handled properly by MMG5_mmgHashTria  */
+              ptt->tag[j] &= ~MG_PARBDYBDY;
+              /* If the face from which we arrive is not a parallel face, then remove also the parallel tags
+              MG_PARBDY, MG_NOSURF and MG_REQ */
+              if ( !(pxt->ftag[i] & MG_PARBDY)) {
+                ptt->tag[j] &= ~MG_PARBDY;
+                ptt->tag[j] &= ~MG_NOSURF;
+                ptt->tag[j] &= ~MG_REQ;
+              }
             }
+            /* Assign ref to tria from xtetra->edg */
             if ( pxt->edg[MMG5_iarf[i][j]] )
               ptt->edg[j] = pxt->edg[MMG5_iarf[i][j]];
           }
         }
+
         if ( adj ) {
           if ( mesh->info.iso ) {
             /* Triangle at the interface between two tets is set to the user-defined ref if any, or else to mesh->info.isoref ref */


### PR DESCRIPTION
In ParMmg and in LS discretization mode, when we arrive for the second time in `MMG5_bdryTria`, in the surface analysis, `xtetra.tag` exists and `tria.tag` is updated using `xtretra` values.

In `MMG5_bdryTria`, the edge tags of the triangle are assigned based on what is stored in `xtetra.tag`. However, in parallel, th edges should not inherit:
(1) the tag `PARBDYBDY` here and  
(2) the tags `PARBDY`, `NOSURF` and `REQ` when we arrive from a non-parallel faces.
The assignment of these appropriate tags is done later in  `MMG5_mmgHashTria`