### PR TITLE
libmmg3d_private.h: include inttypes.h for PRId

### DIFF
--- a/src/mmg3d/libmmg3d_private.h
+++ b/src/mmg3d/libmmg3d_private.h
@@ -24,6 +24,12 @@
 #ifndef LIBMMG3D_PRIVATE_H
 #define LIBMMG3D_PRIVATE_H
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include <inttypes.h>
+
 #include "libmmgcommon_private.h"
 #include "PRoctree_3d_private.h"
 


### PR DESCRIPTION
The code uses PRId* macros without including a header and define needed for those.