### PR TITLE
Modified max numbers of entities

### DIFF
--- a/src/mmg2d/zaldy_2d.c
+++ b/src/mmg2d/zaldy_2d.c
@@ -238,8 +238,8 @@ int MMG2D_memOption(MMG5_pMesh mesh) {
 
   mesh->memMax = MMG5_memSize();
 
-  mesh->npmax = MG_MAX(1.5*mesh->np,MMG2D_NPMAX);
-  mesh->ntmax = MG_MAX(1.5*mesh->nt,MMG2D_NEMAX);
+  mesh->npmax = MG_MAX((MMG5_int)(1.5*mesh->np),MMG2D_NPMAX);
+  mesh->ntmax = MG_MAX((MMG5_int)(1.5*mesh->nt),MMG2D_NEMAX);
   mesh->namax = mesh->na;
 
   return  MMG2D_memOption_memSet(mesh);

--- a/src/mmg3d/zaldy_3d.c
+++ b/src/mmg3d/zaldy_3d.c
@@ -270,9 +270,9 @@ int MMG3D_memOption_memRepartition(MMG5_pMesh mesh) {
  */
 int MMG3D_memOption(MMG5_pMesh mesh) {
 
-  mesh->npmax = MG_MAX((int)(1.5*mesh->np),MMG3D_NPMAX);
-  mesh->nemax = MG_MAX((int)(1.5*mesh->ne),MMG3D_NEMAX);
-  mesh->ntmax = MG_MAX((int)(1.5*mesh->nt),MMG3D_NTMAX);
+  mesh->npmax = MG_MAX((1.5*mesh->np),MMG3D_NPMAX);
+  mesh->nemax = MG_MAX((1.5*mesh->ne),MMG3D_NEMAX);
+  mesh->ntmax = MG_MAX((1.5*mesh->nt),MMG3D_NTMAX);
 
   return  MMG3D_memOption_memSet(mesh);
 }

--- a/src/mmg3d/zaldy_3d.c
+++ b/src/mmg3d/zaldy_3d.c
@@ -270,9 +270,9 @@ int MMG3D_memOption_memRepartition(MMG5_pMesh mesh) {
  */
 int MMG3D_memOption(MMG5_pMesh mesh) {
 
-  mesh->npmax = MG_MAX((1.5*mesh->np),MMG3D_NPMAX);
-  mesh->nemax = MG_MAX((1.5*mesh->ne),MMG3D_NEMAX);
-  mesh->ntmax = MG_MAX((1.5*mesh->nt),MMG3D_NTMAX);
+  mesh->npmax = MG_MAX((MMG5_int)(1.5*mesh->np),MMG3D_NPMAX);
+  mesh->nemax = MG_MAX((MMG5_int)(1.5*mesh->ne),MMG3D_NEMAX);
+  mesh->ntmax = MG_MAX((MMG5_int)(1.5*mesh->nt),MMG3D_NTMAX);
 
   return  MMG3D_memOption_memSet(mesh);
 }

--- a/src/mmgs/zaldy_s.c
+++ b/src/mmgs/zaldy_s.c
@@ -206,8 +206,8 @@ int MMGS_memOption(MMG5_pMesh mesh) {
 
   mesh->memMax = MMG5_memSize();
 
-  mesh->npmax = MG_MAX(1.5*mesh->np,MMGS_NPMAX);
-  mesh->ntmax = MG_MAX(1.5*mesh->nt,MMGS_NTMAX);
+  mesh->npmax = MG_MAX((MMG5_int)(1.5*mesh->np),MMGS_NPMAX);
+  mesh->ntmax = MG_MAX((MMG5_int)(1.5*mesh->nt),MMGS_NTMAX);
 
   return  MMGS_memOption_memSet(mesh);
 }


### PR DESCRIPTION
Removed casting maximum number of entitites in `int` to avoid overflow problems when using 8 byte integers.