### PR TITLE
API Documentation fixes mainly in libmmgs.h, and a workaround for a Doxygen problem

### DIFF
--- a/src/common/inout.c
+++ b/src/common/inout.c
@@ -531,6 +531,7 @@ int  MMG5_check_readedMesh ( MMG5_pMesh mesh, MMG5_int nref ) {
   MMG5_pTetra pt;
   int         i;
   MMG5_int    k,aux;
+  double      area;
 
   if ( nref ) {
     fprintf(stdout,"\n     $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ \n");
@@ -555,10 +556,11 @@ int  MMG5_check_readedMesh ( MMG5_pMesh mesh, MMG5_int nref ) {
       for(i=0 ; i<3 ; i++)
         ptt->edg[i] = 0;
 
-      if ( MMG2D_quickarea(mesh->point[ptt->v[0]].c,mesh->point[ptt->v[1]].c,
-                           mesh->point[ptt->v[2]].c) < 0.0 ) {
-        /* mesh->xt temporary used to count reoriented tetra*/
-        mesh->xt++;
+      area = MMG2D_quickarea(mesh->point[ptt->v[0]].c,
+                             mesh->point[ptt->v[1]].c,
+                             mesh->point[ptt->v[2]].c);
+      if ( area < 0.0 ) {
+        mesh->xt++;  /* mesh->xt temporarily used to count reoriented tetra*/
         aux = ptt->v[2];
         ptt->v[2] = ptt->v[1];
         ptt->v[1] = aux;

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -144,12 +144,13 @@ extern "C" {
     MMG2D_IPARAM_isoref,            /*!< [0/n], Iso-surface boundary material reference */
   };
 
-/*----------------------------- functions header -----------------------------*/
+/*----------------------------- function headers -----------------------------*/
 /* Initialization functions */
 /* init structures */
 
 /**
- * \brief Initialize a mesh structure and optionally the associated solution and metric structures.
+ * \brief Initialize a mesh structure and optionally the associated solution and
+ * metric structures.
  *
  * \param starter dummy argument used to initialize the variadic argument list
  * \param ... variadic arguments.
@@ -169,9 +170,7 @@ extern "C" {
  * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
  * are \ref MMG5_pSol.
  *
- * MMG structures allocation and initialization.
- *
- * \remark No fortran interface to allow variadic arguments.
+ * \remark No fortran interface, to allow variadic arguments.
  *
  */
   LIBMMG2D_EXPORT int MMG2D_Init_mesh(const int starter,...);
@@ -1720,7 +1719,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure or the NULL pointer.
  * \param sol pointer to the level-set structure or the NULL pointer.
- * \param filename name of file.
+ * \param filename name of the file to load.
  *
  * \return 0 if the file is not found, -1 if failing for another reason (insufficient memory, file
  * format...), 1 on success.
@@ -1744,7 +1743,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
+ * \param filename name of the file to load.
  *
  * \return 0 if the file is not found, -1 if failing for another reason (insufficient memory, file
  * format...), 1 on success.
@@ -1769,7 +1768,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure or the NULL pointer.
  * \param sol pointer to the level-set structure or the NULL pointer.
- * \param filename name of file.
+ * \param filename name of the file to load.
  *
  * \return 0 if the file is not found, -1 if failing for another reason (insufficient memory, file
  * format...), 1 on success.
@@ -1793,7 +1792,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
+ * \param filename name of the file to load.
  *
  * \return 0 if the file is not found, -1 if failing for another reason (insufficient memory, file
  * format...), 1 on success.
@@ -1818,7 +1817,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure or the NULL pointer.
  * \param sol pointer to the level-set structure or the NULL pointer.
- * \param filename name of file.
+ * \param filename name of the file to load.
  *
  * \return 0 if the file is not found, -1 if failing for another reason (insufficient memory, file
  * format...), 1 on success.
@@ -1842,7 +1841,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
+ * \param filename name of the file to load.
  *
  * \return 0 if the file is not found, -1 if failing for another reason (insufficient memory, file
  * format...), 1 on success.
@@ -1866,7 +1865,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
+ * \param filename name of the file to load.
  *
  * \return 0 if the file is not found, -1 if failing for another reason (lack of
  * memory, file format...), 1 on success.
@@ -1890,7 +1889,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to a list of solution structures.
- * \param filename name of file.
+ * \param filename name of the file to load.
  *
  * \return 0 if the file is not found, -1 if failing for another reason (lack of
  * memory, file format...), 1 on success.
@@ -1941,7 +1940,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure or the NULL pointer.
  * \param sol pointer to the level-set structure or the NULL pointer.
- * \param filename name of file.
+ * \param filename name of the file to load.
  *
  * \return 0 if the file is not found, -1 if failing for another reason (insufficient memory, file
  * format...), 1 on success.
@@ -1962,7 +1961,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solutions array
- * \param filename name of file.
+ * \param filename name of the file to load.
  *
  * \return 0 if the file is not found, -1 if failing for another reason
  * (insufficient memory, file format...), 1 on success.
@@ -2007,7 +2006,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
+ * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
  *
  * This function writes a mesh and optionally one data field in MSH file format
@@ -2074,7 +2073,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
+ * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
  *
  * This function writes a mesh and a list of data fields in Vtk file format (.vtk extension).
@@ -2095,7 +2094,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
+ * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
  *
  * This function writes a mesh and 0 or 1 data fields in vtu Vtk file format (.vtu extension).
@@ -2116,7 +2115,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
+ * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
  *
  * This function writes a mesh and a list of data fields in vtu Vtk file format (.vtu extension).
@@ -2137,7 +2136,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
+ * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
  *
  * This function writes a mesh and optionally one data field in polydata Vtk
@@ -2201,7 +2200,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * \brief Save mesh data in a file whose format depends on the filename extension.
  *
  * \param mesh pointer to the mesh structure.
- * \param filename name of file to write.
+ * \param filename name of the file to write
  * \return 0 on failure, 1 otherwise.
  *
  * \remark Fortran interface:
@@ -2722,7 +2721,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
 
 
 /**
- * \brief Set common pointer functions between mmgs and mmg2d to the matching mmg2d
+ * \brief Set common function pointers between mmgs and mmg2d to the matching mmg2d
  * functions.
  */
   LIBMMG2D_EXPORT void MMG2D_Set_commonFunc(void);

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -36,7 +36,13 @@
  * - To keep the genheader program working, don't break line between an enum
  *   name and the opening brace (it creates errors under windows)
  *
- * - Use the MMG2D_ prefix: the MMG5_ prefix will become obsolete.
+ * - Since Mmg version 5,
+ * -- data structures and parameters that are common between mmg3d, mmg2d
+ *    and mmgs use the MMG5_ prefix;
+ * -- API functions should have an MMG3D_, MMG2D_, or MMGS_ prefix,
+ *    depending on the library; and
+ * -- some MMG5_ API functions exists but they are common to the
+ *    three libraries.
  *
  */
 
@@ -57,7 +63,7 @@
  * triangles and quadrangles. Edges can also be represented. All of these \a
  * entities can have a \a reference: an integer value that can serve as a group
  * identifier. In addition mesh entities can have \a attributes such as
- * "required".
+ * "required" or "corner".
  *
  * Data defined on meshes can be for example functions that are meant for
  * level-set discretization, metric tensors that will govern edge lengths, and

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -2471,7 +2471,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * domains with different references, if it belongs to one triangle only or if
  * it is a singular edge (ridge or required).
  *
- * Append these edges to the list of edge.
+ * Append these edges to the list of edges.
  *
  * \warning reallocate the edge array and append the internal edges. This may
  * modify the behaviour of other functions.

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -92,7 +92,7 @@ extern "C" {
 #include "mmg/mmg2d/mmg2d_export.h"
 
 /**
- * Maximum array size when storing adjacent points (or ball) of a vertex.
+ * Maximum array size when storing adjacent vertices (or ball) of a vertex.
  */
 #define MMG2D_LMAX   1024
 
@@ -118,9 +118,9 @@ extern "C" {
     MMG2D_IPARAM_lag,               /*!< [-1/0/1/2], Enable Lagrangian motion */
     MMG2D_IPARAM_3dMedit,           /*!< [0/1/2], Read/write 2D mesh in 3D (Medit only). out if val=1 in/out if val=2 */
     MMG2D_IPARAM_optim,             /*!< [1/0], Optimize mesh keeping its initial edge sizes */
-    MMG2D_IPARAM_noinsert,          /*!< [1/0], Avoid/allow point insertion */
+    MMG2D_IPARAM_noinsert,          /*!< [1/0], Avoid/allow vertex insertion */
     MMG2D_IPARAM_noswap,            /*!< [1/0], Avoid/allow edge or face flipping */
-    MMG2D_IPARAM_nomove,            /*!< [1/0], Avoid/allow point relocation */
+    MMG2D_IPARAM_nomove,            /*!< [1/0], Avoid/allow vertex relocation */
     MMG2D_IPARAM_nosurf,            /*!< [1/0], Avoid/allow surface modifications */
     MMG2D_IPARAM_nreg,              /*!< [0/1], Enable normal regularization */
     MMG2D_IPARAM_xreg,              /*!< [0/1], Enable regularization by moving vertices */
@@ -129,7 +129,7 @@ extern "C" {
     MMG2D_IPARAM_numberOfLSBaseReferences,   /*!< [n], Number of base references for bubble removal */
     MMG2D_IPARAM_numberOfMat,                /*!< [n], Number of materials in level-set mode */
     MMG2D_IPARAM_anisosize,                 /*!< [1/0], Turn on/off anisotropic metric creation when no metric is provided */
-    MMG2D_IPARAM_nosizreq,          /*!< [0/1], Allow/avoid overwriting of sizes at required points (advanced usage) */
+    MMG2D_IPARAM_nosizreq,          /*!< [0/1], Allow/avoid overwriting of sizes at required vertices (advanced usage) */
     MMG2D_DPARAM_angleDetection,    /*!< [val], Threshold for angle detection */
     MMG2D_DPARAM_hmin,              /*!< [val], Minimal edge length */
     MMG2D_DPARAM_hmax,              /*!< [val], Maximal edge length */
@@ -503,10 +503,10 @@ LIBMMG2D_EXPORT int  MMG2D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * \brief Set the coordinates and reference of a single vertex.
  *
  * \param mesh pointer to the mesh structure.
- * \param c0 coordinate of the point along the first dimension.
- * \param c1 coordinate of the point along the second dimension.
- * \param ref point reference.
- * \param pos position of the point in the mesh.
+ * \param c0 coordinate of the vertex along the first dimension.
+ * \param c1 coordinate of the vertex along the second dimension.
+ * \param ref vertex reference.
+ * \param pos position of the vertex in the mesh.
  * \return 1 on success, 0 in case of failure
  *
  * Set vertex of coordinates \a c0, \a c1 and reference \a ref
@@ -1103,11 +1103,11 @@ LIBMMG2D_EXPORT int  MMG2D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * \brief Get the coordinates and reference ref of the next vertex of a mesh.
  *
  * \param mesh pointer to the mesh structure.
- * \param c0 pointer to the coordinate of the point along the first dimension.
- * \param c1 pointer to the coordinate of the point along the second dimension.
- * \param ref pointer to the point reference.
- * \param isCorner pointer to the flag saying if point is corner.
- * \param isRequired pointer to the flag saying if point is required.
+ * \param c0 pointer to the coordinate of the vertex along the first dimension.
+ * \param c1 pointer to the coordinate of the vertex along the second dimension.
+ * \param ref pointer to the vertex reference.
+ * \param isCorner pointer to the flag saying if vertex is corner.
+ * \param isRequired pointer to the flag saying if vertex is required.
  * \return 1.
  *
  * This function retrieves the coordinates \a c0 and \a c1, and reference \a
@@ -1133,12 +1133,12 @@ LIBMMG2D_EXPORT int  MMG2D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * \brief Get the coordinates and reference of a specific vertex in the mesh.
  *
  * \param mesh pointer to the mesh structure.
- * \param c0 pointer to the coordinate of the point along the first dimension.
- * \param c1 pointer to the coordinate of the point along the second dimension.
- * \param ref pointer to the point reference.
- * \param isCorner pointer to the flag saying if point is corner.
- * \param isRequired pointer to the flag saying if point is required.
- * \param idx index of point to get.
+ * \param c0 pointer to the coordinate of the vertex along the first dimension.
+ * \param c1 pointer to the coordinate of the vertex along the second dimension.
+ * \param ref pointer to the vertex reference.
+ * \param isCorner pointer to the flag saying if vertex is corner.
+ * \param isRequired pointer to the flag saying if vertex is required.
+ * \param idx index of vertex to get.
  * \return 1.
  *
  * Get coordinates \a c0, \a c1 and reference \a ref of
@@ -1162,15 +1162,15 @@ LIBMMG2D_EXPORT int  MMG2D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  *
  * \param mesh pointer to the mesh structure.
  * \param vertices pointer to the array of vertex coordinates.
- * The coordinates of the \f$i^{th}\f$ point are stored in
+ * The coordinates of the \f$i^{th}\f$ vertex are stored in
  * vertices[(i-1)*2]\@2.
  * \param refs pointer to the array of references.
- * The ref of the \f$i^th\f$ point is stored in refs[i-1].
+ * The ref of the \f$i^th\f$ vertex is stored in refs[i-1].
  * \param areCorners pointer to the array of flags saying if
- * points are corners.
- * areCorners[i-1]=1 if the \f$i^{th}\f$ point is corner.
- * \param areRequired pointer to the array of flags saying if points
- * are required. areRequired[i-1]=1 if the \f$i^{th}\f$ point is required.
+ * vertices are corners.
+ * areCorners[i-1]=1 if the \f$i^{th}\f$ vertex is corner.
+ * \param areRequired pointer to the array of flags saying if vertices
+ * are required. areRequired[i-1]=1 if the \f$i^{th}\f$ vertex is required.
  * \return 1.
  *
  * \remark Fortran interface: (commentated in order to allow to pass \%val(0)
@@ -1725,7 +1725,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * format...), 1 on success.
  *
  * Read a mesh and 0 or 1 data fields in VTK vtp file format (.vtp extension). We
- * read only low-order points, edges, triangles and quadrangles.
+ * read only low-order vertices, edges, triangles and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG2D_LOADVTPMESH(mesh,met,sol,filename,strlen0,retval)\n
@@ -1749,7 +1749,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * format...), 1 on success.
  *
  * Read a mesh and a list of data fields in VTK vtp file format (.vtp extension). We
- * read only low-order points, edges, triangles and quadrangles.
+ * read only low-order vertices, edges, triangles and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG2D_LOADVTPMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1774,7 +1774,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * format...), 1 on success.
  *
  * Read a mesh and 0 or 1 data fields in VTK vtu file format (.vtu extension). We
- * read only low-order points, edges, triangles and quadrangles.
+ * read only low-order vertices, edges, triangles and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG2D_LOADVTUMESH(mesh,met,sol,filename,strlen0,retval)\n
@@ -1798,7 +1798,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * format...), 1 on success.
  *
  * Read a mesh and a list of data fields in VTK vtu file format (.vtu extension). We
- * read only low-order points, edges, triangles and quadrangles.
+ * read only low-order vertices, edges, triangles and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG2D_LOADVTUMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1823,7 +1823,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * format...), 1 on success.
  *
  * Read mesh and 0 or 1 data fields in VTK file format (.vtk extension). We
- * read only low-order points, edges, triangles and quadrangles.
+ * read only low-order vertices, edges, triangles and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG2D_LOADVTKMESH(mesh,met,sol,filename,strlen0,retval)\n
@@ -1847,7 +1847,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * format...), 1 on success.
  *
  * This function reads a mesh and a list of data fields in VTK file format (.vtk
- * extension). We read only low-order points, edges, triangles and quadrangles.
+ * extension). We read only low-order vertices, edges, triangles and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG2D_LOADVTKMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1871,7 +1871,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * memory, file format...), 1 on success.
  *
  * This function reads a mesh and 0 or 1 data fields in MSH file format (.msh
- * extension). We read only low-order points, edges, triangles, and quadrangles.
+ * extension). We read only low-order vertices, edges, triangles, and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG2D_LOADMSHMESH(mesh,sol,filename,strlen0,retval)\n
@@ -1895,7 +1895,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * memory, file format...), 1 on success.
  *
  * This function reads a mesh and all data fields from a file in MSH file format
- * (.msh extension). We read only low-order points, edges, triangles,
+ * (.msh extension). We read only low-order vertices, edges, triangles,
  * quadrangles, tetrahedra and prisms.
  *
  * \remark Fortran interface:
@@ -1966,7 +1966,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * \return 0 if the file is not found, -1 if failing for another reason
  * (insufficient memory, file format...), 1 on success.
  *
- * Load 1 or more solutions in a solution file at medit file format
+ * Load 1 or more solutions in a solution file in medit file format
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG2D_LOADALLSOLS(mesh,sol,filename,strlen0,retval)\n
@@ -2409,7 +2409,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
 
 /**
  * \brief Compute unit tensor according to the lengths of the
- * edges passing through a point.
+ * edges passing through a vertex.
  *
  * \param mesh pointer to the mesh structure
  * \param met pointer to the sol structure
@@ -2545,7 +2545,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * \param ip vertex index.
  * \param lispoi pointer to an array of size MMG2D_LMAX that will contain
  * the indices of adjacent vertices to the vertex \a ip.
- * \return nbpoi the number of adjacent points if success, 0 on failure.
+ * \return nbpoi the number of adjacent vertices if success, 0 on failure.
  *
  * Find the indices of the adjacent vertices of the vertex \a
  * ip.
@@ -2569,7 +2569,7 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * \param start index of a triangle holding \a ip.
  * \param lispoi pointer to an array of size MMG2D_LMAX that will contain
  * the indices of adjacent vertices to the vertex \a ip.
- * \return nbpoi the number of adjacent points if success, 0 on failure.
+ * \return nbpoi the number of adjacent vertices if success, 0 on failure.
  *
  * Find the indices of the adjacent vertices of the vertex \a
  * ip of the triangle \a start.

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -167,7 +167,7 @@ extern "C" {
  * MMG2D_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppLs,
  * &your_level_set,MMG5_ARG_end).
  *
- * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
+ * Here, \a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
  * are \ref MMG5_pSol.
  *
  * \remark No fortran interface, to allow variadic arguments.
@@ -2639,18 +2639,20 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
   LIBMMG2D_EXPORT int MMG2D_Get_trisFromEdge(MMG5_pMesh mesh, MMG5_int ked, MMG5_int ktri[2],int ied[2]);
 
 /**
- * \brief Compute the real eigenvalues and eigenvectors of a symetric matrix
+ * \brief Compute the real eigenvalues and eigenvectors of a symmetric matrix
  *
- * \param m upper part of a symetric matric diagonalizable in |R
+ * \param m upper part of a symMetric matrix diagonalizable in |R
  * \param lambda array of the metric eigenvalues
  * \param vp array of the metric eigenvectors
  *
  * \return the order of the eigenvalues
  *
- * This function computes the real eigenvalues and eigenvectors of a symetric matrix m
+ * This function computes the real eigenvalues and eigenvectors of a symmetric matrix m
  * whose upper part is provided (m11, m12, m22, in this order).
+ *
  * lambda[0] is the eigenvalue associated to the eigenvector ( v[0][0], v[0,1] )
  * in C and to the eigenvector v(1,:) in fortran
+ *
  * lambda[1] is the eigenvalue associated to the eigenvector ( v[1][0], v[1,1] )
  * in C and to the eigenvector v(2,:) in fortran
  *

--- a/src/mmg3d/libmmg3d.h
+++ b/src/mmg3d/libmmg3d.h
@@ -150,9 +150,9 @@ enum MMG3D_Param {
   MMG3D_IPARAM_lag,                       /*!< [-1/0/1/2], Enable Lagrangian motion */
   MMG3D_IPARAM_optim,                     /*!< [1/0], Optimize mesh keeping its initial edge sizes */
   MMG3D_IPARAM_optimLES,                  /*!< [1/0], Strong mesh optimization for LES computations */
-  MMG3D_IPARAM_noinsert,                  /*!< [1/0], Avoid/allow point insertion */
+  MMG3D_IPARAM_noinsert,                  /*!< [1/0], Avoid/allow vertex insertion */
   MMG3D_IPARAM_noswap,                    /*!< [1/0], Avoid/allow edge or face flipping */
-  MMG3D_IPARAM_nomove,                    /*!< [1/0], Avoid/allow point relocation */
+  MMG3D_IPARAM_nomove,                    /*!< [1/0], Avoid/allow vertex relocation */
   MMG3D_IPARAM_nosurf,                    /*!< [1/0], Avoid/allow surface modifications */
   MMG3D_IPARAM_nreg,                      /*!< [0/1], Enable regularization of normals */
   MMG3D_IPARAM_xreg,                      /*!< [0/1], Enable boundary regularization by moving vertices */
@@ -430,11 +430,11 @@ LIBMMG3D_EXPORT int  MMG3D_Set_inputParamName(MMG5_pMesh mesh, const char* fpara
 /**
  * \brief Set the coordinates of a single vertex.
  * \param mesh pointer to the mesh structure.
- * \param c0 coordinate of the point along the first dimension.
- * \param c1 coordinate of the point along the second dimension.
- * \param c2 coordinate of the point along the third dimension.
- * \param ref point reference.
- * \param pos position of the point in the mesh.
+ * \param c0 coordinate of the vertex along the first dimension.
+ * \param c1 coordinate of the vertex along the second dimension.
+ * \param c2 coordinate of the vertex along the third dimension.
+ * \param ref vertex reference.
+ * \param pos position of the vertex in the mesh.
  * \return 1.
  *
  * This function sets the coordinates of a vertex \a c0, \a c1,\a c2 and reference \a ref
@@ -458,8 +458,8 @@ LIBMMG3D_EXPORT int  MMG3D_Set_inputParamName(MMG5_pMesh mesh, const char* fpara
  * \param mesh pointer to the mesh structure.
  * \param vertices  array of vertex coordinates in the order \f$[x_1, y_1, z_1, x_2, \ldots, z_N]\f$
  *   where \f$N\f$ is the number of vertices in the mesh.
- * \param refs  array of point references.
- *   The reference of point \f$i\f$ is stored in refs[\f$i-1\f$].
+ * \param refs  array of vertex references.
+ *   The reference of vertex \f$i\f$ is stored in refs[\f$i-1\f$].
  * \return 1.
  *
  * This function sets the coordinates and references of all vertices in a mesh
@@ -777,7 +777,7 @@ LIBMMG3D_EXPORT int  MMG3D_Set_inputParamName(MMG5_pMesh mesh, const char* fpara
  * \param k vertex index.
  * \return 1.
  *
- * This function removes the required attribute from point \a k.
+ * This function removes the required attribute from vertex \a k.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG3D_UNSET_REQUIREDVERTEX(mesh,k,retval)\n
@@ -1112,10 +1112,10 @@ LIBMMG3D_EXPORT int  MMG3D_Set_inputParamName(MMG5_pMesh mesh, const char* fpara
  * \brief Set the normal orientation at a single vertex.
  *
  * \param mesh pointer to the mesh structure.
- * \param k point index
- * \param n0 x componant of the normal at point \a k.
- * \param n1 y componant of the normal at point \a k.
- * \param n2 z componant of the normal at point \a k.
+ * \param k vertex index
+ * \param n0 x componant of the normal at vertex \a k.
+ * \param n1 y componant of the normal at vertex \a k.
+ * \param n2 z componant of the normal at vertex \a k.
  *
  * \return 1 if success.
  *
@@ -1543,7 +1543,7 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
                                          MMG5_int* np,int* typSol);
 
 /**
- * \brief Get the number of elements and dimension of a solution defined on vertices.
+ * \brief Get the number of elements, type, and dimensions of several solutions defined on vertices.
  *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to an array of sol structure.
@@ -1572,15 +1572,15 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * next vertex of \a mesh.
  *
  * \param mesh pointer to the mesh structure.
- * \param c0 pointer to the coordinate of the point along the first
+ * \param c0 pointer to the coordinate of the vertex along the first
  * dimension.
- * \param c1 pointer to the coordinate of the point along the second
+ * \param c1 pointer to the coordinate of the vertex along the second
  * dimension.
- * \param c2 pointer to the coordinate of the point along the third
+ * \param c2 pointer to the coordinate of the vertex along the third
  * dimension.
- * \param ref pointer to the point reference.
- * \param isCorner pointer to the flag saying if point is corner.
- * \param isRequired pointer to the flag saying if point is required.
+ * \param ref pointer to the vertex reference.
+ * \param isCorner pointer to the flag saying if vertex is corner.
+ * \param isRequired pointer to the flag saying if vertex is required.
  * \return 1.
  *
  * This function retrieves the coordinates \a c0, \a c1,\a c2 and reference \a
@@ -1607,13 +1607,13 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * \brief Get the coordinates and reference of a specific vertex in the mesh.
  *
  * \param mesh pointer to the mesh structure.
- * \param c0 pointer to the coordinate of the point along the first dimension.
- * \param c1 pointer to the coordinate of the point along the second dimension.
- * \param c2 pointer to the coordinate of the point along the third dimension.
- * \param ref pointer to the point reference.
- * \param isCorner pointer to the flag saying if point is corner.
- * \param isRequired pointer to the flag saying if point is required.
- * \param idx index of point to get.
+ * \param c0 pointer to the coordinate of the vertex along the first dimension.
+ * \param c1 pointer to the coordinate of the vertex along the second dimension.
+ * \param c2 pointer to the coordinate of the vertex along the third dimension.
+ * \param ref pointer to the vertex reference.
+ * \param isCorner pointer to the flag saying if vertex is corner.
+ * \param isRequired pointer to the flag saying if vertex is required.
+ * \param idx index of vertex to get.
  * \return 1.
  *
  * Get coordinates \a c0, \a c1, \a c2 and reference \a ref of
@@ -1637,15 +1637,15 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  *
  * \param mesh pointer to the mesh structure.
  * \param vertices pointer to the array of the points coordinates.
- * The coordinates of the \f$i^{th}\f$ point are stored in
+ * The coordinates of the \f$i^{th}\f$ vertex are stored in
  * vertices[(i-1)*3]\@3.
- * \param refs pointer to the array of the point references.
- * The ref of the \f$i^th\f$ point is stored in refs[i-1].
+ * \param refs pointer to the array of the vertex references.
+ * The ref of the \f$i^th\f$ vertex is stored in refs[i-1].
  * \param areCorners pointer to the array of the flags saying if
  * points are corners.
- * areCorners[i-1]=1 if the \f$i^{th}\f$ point is corner.
+ * areCorners[i-1]=1 if the \f$i^{th}\f$ vertex is corner.
  * \param areRequired pointer to the array of flags saying if points
- * are required. areRequired[i-1]=1 if the \f$i^{th}\f$ point is required.
+ * are required. areRequired[i-1]=1 if the \f$i^{th}\f$ vertex is required.
  * \return 1.
  *
  * \remark Fortran interface: (commentated in order to allow to pass \%val(0)
@@ -1936,7 +1936,7 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  *
  * \param mesh pointer to the mesh structure.
  * \param edges pointer to the array of edges.
- * The vertices of the \f$i^{th}\f$ edge should be given in edge[(i-1)*2] and edge[(i-1)*2+1].
+ * The vertices of the \f$i^{th}\f$ edge should be given in edges[(i-1)*2] and edges[(i-1)*2+1].
  * \param refs edges references. refs[i-1] is the ref of the \f$i^{th}\f$ edge.
  * \return 0 if failed, 1 otherwise.
  *
@@ -1956,7 +1956,7 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  *
  * \param mesh pointer to the mesh structure.
  * \param edges pointer to the array of edges.
- * The vertices of the \f$i^{th}\f$ edge are stored in edge[(i-1)*2] and edge[(i-1)*2+1].
+ * The vertices of the \f$i^{th}\f$ edge are stored in edges[(i-1)*2] and edges[(i-1)*2+1].
  * \param refs edges references. refs[i-1] is the ref of the \f$i^{th}\f$ edge.
  * \param areRidges 1 if the edge is a ridge, 0 otherwise.
  * \param areRequired 1 if the edge is required, 0 otherwise.
@@ -1979,10 +1979,10 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * \brief Get the normal orientation at a single mesh vertex.
  *
  * \param mesh pointer to the mesh structure.
- * \param k point index
- * \param n0 x componant of the normal at point \a k.
- * \param n1 y componant of the normal at point \a k.
- * \param n2 z componant of the normal at point \a k.
+ * \param k vertex index
+ * \param n0 x componant of the normal at vertex \a k.
+ * \param n1 y componant of the normal at vertex \a k.
+ * \param n2 z componant of the normal at vertex \a k.
  *
  * \return 1 if success.
  *
@@ -2061,7 +2061,7 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  LIBMMG3D_EXPORT int  MMG3D_Get_scalarSols(MMG5_pSol met, double* s);
 
 /**
- * \brief Get the next element of a vector solution structure defined at vertices.
+ * \brief Get the next element of a vector solution structure.
  *
  * \param met pointer to the sol structure.
  * \param vx x value of the vectorial solution.
@@ -2069,10 +2069,10 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * \param vz z value of the vectorial solution.
  * \return 0 if failed, 1 otherwise.
  *
- * This function retrieves the solution \f$(v_x,v_y,vz)\f$ of the next vertex
- * of \a mesh. It is meant to be called in a loop over all vertices. When it has
- * been called as many times as there are vertices in the mesh, the internal
- * loop counter will be reset.
+ * This function retrieves the next vector-valued element \f$(v_x,v_y,vz)\f$ of
+ * the solution. It is meant to be called in a loop over all elements.  When it
+ * has been called as many times as there are elements in the solution, the
+ * internal loop counter will be reset.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG3D_GET_VECTORSOL(met,vx,vy,vz,retval)\n
@@ -2085,7 +2085,7 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  LIBMMG3D_EXPORT int MMG3D_Get_vectorSol(MMG5_pSol met, double* vx, double* vy, double* vz);
 
 /**
- * \brief Get all elements of a vector solution structure defined at vertices.
+ * \brief Get all elements of a vector solution structure.
  *
  * \param met pointer to the sol structure.
  * \param sols array of the solutions at mesh vertices. sols[3*(i-1)]\@3 is
@@ -2105,7 +2105,7 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  LIBMMG3D_EXPORT int MMG3D_Get_vectorSols(MMG5_pSol met, double* sols);
 
 /**
- * \brief Get the next element of a tensor solution structure defined at vertices.
+ * \brief Get the next element of a tensor solution structure.
  *
  * \param met pointer to the sol structure.
  * \param m11 pointer to the position (1,1) in the solution tensor.
@@ -2116,11 +2116,11 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * \param m33 pointer to the position (3,3) in the solution tensor.
  * \return 0 if failed, 1 otherwise.
  *
- * This function retrieves the tensor-valued solution
- * \f$(m_{11},m_{12},m_{13},m_{22},m_{23},m_{33})\f$ of the next vertex of \a
- * mesh. It is meant to be called in a loop over all vertices. When it has been
- * called as many times as there are vertices in the mesh, the internal loop
- * counter will be reset.
+ * This function retrieves the next element
+ * \f$(m_{11},m_{12},m_{13},m_{22},m_{23},m_{33})\f$ of a tensor-valued solution
+ * field.  It is meant to be called in a loop over all vertices. When it has
+ * been called as many times as there are elements in the solution, the internal
+ * loop counter will be reset.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG3D_GET_TENSORSOL(met,m11,m12,m13,m22,m23,m33,retval)\n
@@ -2134,14 +2134,12 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
                                          double *m22,double *m23, double *m33);
 
 /**
- * \brief Get all elements of a tensor solution structure defined at vertices.
+ * \brief Get all elements of a tensor solution field.
  *
  * \param met pointer to the sol structure.
  * \param sols array of the solutions at mesh vertices.
  * The solution at vertex \a i will be stored in sols[6*(i-1)] to sols[6*(i-1)+5].
  * \return 0 if failed, 1 otherwise.
- *
- * Get tensorial solutions at mesh vertices.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG3D_GET_TENSORSOLS(met,sols,retval)\n
@@ -2154,17 +2152,19 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  LIBMMG3D_EXPORT int MMG3D_Get_tensorSols(MMG5_pSol met, double *sols);
 
 /**
- * \brief Get one out of several scalar solutions at a specific vertex.
+ * \brief Get one out of several solutions at a specific vertex.
  *
  * \param sol pointer to the array of solutions
  * \param i position of the solution field that we want to get.
- * \param s solution(s) at mesh vertex \a pos.
+ * \param s solution(s) at mesh vertex \a pos. The required size
+ *   of this array depends on the type of solution.
  * \param pos index of the vertex on which we get the solution.
  *
  * \return 0 if failed, 1 otherwise.
  *
  * Get values of the ith field of the solution array at vertex \a pos.
  * (pos from 1 to nb_vertices included and \a i from 1 to \a nb_sols).
+ * The type of solution is inferred from \a sol.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG3D_GET_ITHSOL_INSOLSATVERTICES(sol,i,s,pos,retval)\n
@@ -2179,7 +2179,7 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
   LIBMMG3D_EXPORT int  MMG3D_Get_ithSol_inSolsAtVertices(MMG5_pSol sol,int i, double* s,MMG5_int pos);
 
 /**
- * \brief Get one out of several scalar solutions at all vertices in the mesh.
+ * \brief Get one out of several solutions at all vertices in the mesh.
  *
  * \param sol pointer to the array of solutions
  * \param i position of the solution field that we want to get.
@@ -2254,12 +2254,12 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * \brief Add a vertex to the mesh.
  *
  * \param mesh pointer to the mesh structure.
- * \param c0 x coor of the new point
- * \param c1 y coor of the new point
- * \param c2 z coor of the new point
- * \param ref point reference.
+ * \param c0 x coor of the new vertex
+ * \param c1 y coor of the new vertex
+ * \param c2 z coor of the new vertex
+ * \param ref vertex reference.
  *
- * \return 0 if unable to create the point, the index of the new point
+ * \return 0 if unable to create the vertex, the index of the new vertex
  * otherwise.
  *
  * This function adds a vertex with coordinates \a c0 \a c1 \a c2 and reference

--- a/src/mmg3d/libmmg3d.h
+++ b/src/mmg3d/libmmg3d.h
@@ -123,7 +123,7 @@ extern "C" {
 #include "mmg/mmg3d/mmg3d_export.h"
 
 /**
- * Maximum array size when storing adjacent points (or ball) of a vertex.
+ * Maximum array size when storing adjacent vertices (or ball) of a vertex.
  */
 #define MMG3D_LMAX      10240
 
@@ -162,8 +162,8 @@ enum MMG3D_Param {
   MMG3D_IPARAM_numsubdomain,              /*!< [0/n], Save only the subdomain (reference) n (0==all subdomains) */
   MMG3D_IPARAM_renum,                     /*!< [1/0], Turn on/off renumbering with Scotch */
   MMG3D_IPARAM_anisosize,                 /*!< [1/0], Turn on/off anisotropic metric creation when no metric is provided */
-  MMG3D_IPARAM_octree,                    /*!< [n], Max number of points per PROctree cell (DELAUNAY) */
-  MMG3D_IPARAM_nosizreq,                  /*!< [0/1], Allow/avoid overwriting of sizes at required points (advanced usage) */
+  MMG3D_IPARAM_octree,                    /*!< [n], Max number of vertices per PROctree cell (DELAUNAY) */
+  MMG3D_IPARAM_nosizreq,                  /*!< [0/1], Allow/avoid overwriting of sizes at required vertices (advanced usage) */
   MMG3D_IPARAM_isoref,                    /*!< [0/n], Isosurface boundary material reference */
   MMG3D_DPARAM_angleDetection,            /*!< [val], Value for angle detection (degrees) */
   MMG3D_DPARAM_hmin,                      /*!< [val], Minimal edge length */
@@ -216,7 +216,7 @@ enum MMG3D_Param {
  * \remark No fortran interface to allow variadic arguments.
  *
  * \warning detected bugs:
- *   - some points along open boundaries end up with a normal (while they should not)
+ *   - some vertices along open boundaries end up with a normal (while they should not)
  *
  */
  LIBMMG3D_EXPORT int MMG3D_Init_mesh(const int starter,...);
@@ -1636,15 +1636,15 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * \brief Get the coordinates and references of all vertices in the mesh.
  *
  * \param mesh pointer to the mesh structure.
- * \param vertices pointer to the array of the points coordinates.
+ * \param vertices pointer to the array of coordinates.
  * The coordinates of the \f$i^{th}\f$ vertex are stored in
  * vertices[(i-1)*3]\@3.
  * \param refs pointer to the array of the vertex references.
  * The ref of the \f$i^th\f$ vertex is stored in refs[i-1].
  * \param areCorners pointer to the array of the flags saying if
- * points are corners.
+ * vertices are corners.
  * areCorners[i-1]=1 if the \f$i^{th}\f$ vertex is corner.
- * \param areRequired pointer to the array of flags saying if points
+ * \param areRequired pointer to the array of flags saying if vertices
  * are required. areRequired[i-1]=1 if the \f$i^{th}\f$ vertex is required.
  * \return 1.
  *
@@ -2311,7 +2311,7 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * format...), 1 if success.
  *
  * This function reads a mesh and 0 or 1 data fields in MSH file format (.msh
- * extension). We read only low-order points, edges, triangles, quadrangles,
+ * extension). We read only low-order vertices, edges, triangles, quadrangles,
  * tetrahedra and prisms.
  *
  * \remark Fortran interface:
@@ -2337,7 +2337,7 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * format...), 1 if success.
  *
  * This function reads a mesh and 0 or 1 data field in VTU (VTK) file format (.vtu
- * extension). We read only low-order points, edges, tria, quadra, tetra and
+ * extension). We read only low-order vertices, edges, tria, quadra, tetra and
  * prisms. Point and cell references must be stored in PointData or CellData
  * whose names contain the "medit:ref" keyword.
  *
@@ -2363,7 +2363,7 @@ LIBMMG3D_EXPORT int  MMG3D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * format...), 1 if success.
  *
  * This functionreads a mesh and a list of data in VTU file format (.vtu extension). We read
- * only low-order points, edges, tria, quadra, tetra and prisms. Point and cell
+ * only low-order vertices, edges, tria, quadra, tetra and prisms. Point and cell
  * references must be stored in PointData or CellData whose names contains the
  * "medit:ref" keyword.
  *
@@ -2390,7 +2390,7 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  * format...), 1 if success.
  *
  * This function reads a mesh and 0 or 1 data fields in VTK file format (.vtu extension). We read
- * only low-order points, edges, tria, quadra, tetra and prisms. Point and cell
+ * only low-order vertices, edges, tria, quadra, tetra and prisms. Point and cell
  * references must be stored in PointData or CellData whose names contain the
  * "medit:ref" keyword.
  *
@@ -2416,7 +2416,7 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  * format...), 1 if success.
  *
  * Read mesh and a list of data in VTK file format (.vtu extension). We read
- * only low-order points, edges, tria, quadra, tetra and prisms. Point and cell
+ * only low-order vertices, edges, tria, quadra, tetra and prisms. Point and cell
  * references must be stored in PointData or CellData whose names contains the
  * "medit:ref" keyword.
  *
@@ -2442,7 +2442,7 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  * format...), 1 if success.
  *
  * Read mesh and a list of data in MSH file format (.msh extension). We read only
- * low-order points, edges, tria, quadra, tetra and prisms.
+ * low-order vertices, edges, tria, quadra, tetra and prisms.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG3D_LOADMSHMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -2526,7 +2526,7 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  * \return 0 if failed, 1 otherwise.
  *
  * Write mesh and a list of data fields (that are considered as solutions and
- * not metrics, thus, we do nothing over the ridge points) in MSH file format
+ * not metrics, thus, we do nothing over the ridge vertices) in MSH file format
  * (.msh extension).  Save file in ASCII format for .msh extension, in binary
  * format for .mshb one.
  *
@@ -3178,7 +3178,7 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
 
 /**
  * \brief Compute isotropic size map according to the mean of the length of the
- * edges passing through a point.
+ * edges passing through a vertex.
  *
  * \param mesh pointer to the mesh structure
  * \param met pointer to the sol structure

--- a/src/mmg3d/libmmg3d.h
+++ b/src/mmg3d/libmmg3d.h
@@ -204,7 +204,7 @@ enum MMG3D_Param {
  * MMG5_ARG_ppMet,&empty_metric,MMG5_ARG_ppDisp, &your_displacement,
  * MMG5_ARG_end).
  *
- * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric \a your_level_set and
+ * Here, \a your_mesh is a \ref MMG5_pMesh, \a your_metric \a your_level_set and
  * \a your_displacement are \ref MMG5_pSol.
  *
  * \return 1 on success, 0 on failure
@@ -3363,7 +3363,7 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
 /**
  * \brief Compute the real eigenvalues and eigenvectors of a symmetric matrix
  *
- * \param m upper part of a symmetric matric diagonalizable in |R
+ * \param m upper part of a symmetric matrix diagonalizable in |R
  * \param lambda array of the metric eigenvalues
  * \param vp array of the metric eigenvectors
  *
@@ -3371,10 +3371,13 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  *
  * Compute the real eigenvalues and eigenvectors of a symmetric matrix m whose
  * upper part is provided (m11, m12, m13, m22, m23, m33 in this order).
+ *
  * lambda[0] is the eigenvalue associated to the eigenvector ( v[0][0], v[0,1], v[0,2] )
  * in C and to the eigenvector v(1,:) in fortran
+ *
  * lambda[1] is the eigenvalue associated to the eigenvector ( v[1][0], v[1,1], v[1,2] )
  * in C and to the eigenvector v(2,:) in fortran
+ *
  * lambda[2] is the eigenvalue associated to the eigenvector ( v[2][0], v[2,1], v[2,2] )
  * in C and to the eigenvector v(3,:) in fortran
  *
@@ -3391,7 +3394,7 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
 /**
  * \brief Clean data (triangles and edges) linked to isosurface.
  *
- * \param mesh pointer to the mesh sructure
+ * \param mesh pointer to the mesh structure
  *
  * \return 1 if successful, 0 otherwise.
  *

--- a/src/mmg3d/libmmg3d.h
+++ b/src/mmg3d/libmmg3d.h
@@ -36,7 +36,13 @@
  * - To keep the genheader program working, don't break line between an enum
  *   name and the opening brace (it creates errors under windows)
  *
- * - Use the MMG3D_ prefix: the MMG5_ prefix will become obsolete.
+ * - Since Mmg version 5,
+ * -- data structures and parameters that are common between mmg3d, mmg2d
+ *    and mmgs use the MMG5_ prefix;
+ * -- API functions should have an MMG3D_, MMG2D_, or MMGS_ prefix,
+ *    depending on the library; and
+ * -- some MMG5_ API functions exists but they are common to the
+ *    three libraries.
  *
  */
 

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -140,10 +140,13 @@ enum MMGS_Param {
   MMGS_PARAM_size,               /*!< [n], Number of parameters */
 };
 
-/*----------------------------- functions header -----------------------------*/
+/*----------------------------- function headers -----------------------------*/
 /* Initialization functions */
 /* init structures */
 /**
+ * \brief Initialize a mesh structure and optionally the associated solution and
+ * metric structures.
+ *
  * \param starter dummy argument used to initialize the variadic argument list
  * \param ... variadic arguments.
  *
@@ -160,11 +163,9 @@ enum MMGS_Param {
  * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
  * are \ref MMG5_pSol.
  *
- * \return 1 if success, 0 if fail
+ * \return 1 on success, 0 on failure
  *
- * MMG structures allocation and initialization.
- *
- * \remark No fortran interface to allow variadic arguments.
+ * \remark No fortran interface, to allow variadic arguments.
  *
  */
 LIBMMGS_EXPORT int MMGS_Init_mesh(const int starter,...);
@@ -252,7 +253,7 @@ LIBMMGS_EXPORT int  MMGS_Set_inputSolName(MMG5_pMesh mesh,MMG5_pSol sol, const c
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure.
  * \param solout name of the output solution file.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  *  Set the name of output solution file.
  *
@@ -291,9 +292,9 @@ LIBMMGS_EXPORT int  MMGS_Set_inputParamName(MMG5_pMesh mesh, const char* fparami
  * \param typEntity type of solutions entities (vertices, triangles...).
  * \param np number of solutions.
  * \param typSol type of solution (scalar, vectorial...).
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
- * Initialize an array of solutions field: set dimension, types and number of
+ * Initialize an array of solution field: set dimension, types and number of
  * data.
  * To use to initialize an array of solution fields (not used by Mmg itself).
  *
@@ -314,9 +315,9 @@ LIBMMGS_EXPORT int  MMGS_Set_inputParamName(MMG5_pMesh mesh, const char* fparami
  * \param nentities number of entities
  * \param typSol    Array of size nsol listing the type of the solutions
  *                  (scalar, vectorial...).
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
- * Initialize an array of solutions field defined at vertices: set dimension,
+ * Initialize an array of solution field defined at vertices: set dimension,
  * types and number of data.
  * To use to initialize an array of solution fields (not used by Mmg itself).
  *
@@ -337,7 +338,7 @@ LIBMMGS_EXPORT int MMGS_Set_solsAtVerticesSize(MMG5_pMesh mesh, MMG5_pSol *sol,i
  * \param np number of vertices.
  * \param nt number of triangles.
  * \param na number of edges.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set the number of vertices, triangles and edges of the
  * mesh and allocate the associated tables. If call twice, reset the
@@ -406,10 +407,10 @@ LIBMMGS_EXPORT int  MMGS_Set_vertex(MMG5_pMesh mesh, double c0, double c1,
  * \param v2 third vertex of triangle.
  * \param ref triangle reference.
  * \param pos triangle position in the mesh.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set triangle of vertices \a v0, \a v1, \a v2 and reference \a ref
- * at position \a pos in mesh structure.(\a pos from 1 to nb_tria included).
+ * at position \a pos in mesh structure.(\a pos from 1 to nb_triangles included).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_TRIANGLE(mesh,v0,v1,v2,ref,pos,retval)\n
@@ -423,11 +424,11 @@ LIBMMGS_EXPORT int  MMGS_Set_triangle(MMG5_pMesh mesh, MMG5_int v0, MMG5_int v1,
                                       MMG5_int v2, MMG5_int ref,MMG5_int pos);
 /**
  * \param mesh pointer to the mesh structure.
- * \param tria pointer to the table of the tria vertices
- * Vertices of the \f$i^{th}\f$ tria are stored in tria[(i-1)*3]\@3.
+ * \param tria pointer to the table of the triangles vertices
+ * Vertices of the \f$i^{th}\f$ triangles are stored in tria[(i-1)*3]\@3.
  * \param refs pointer to the table of the triangle references.
  * refs[i-1] is the ref of the \f$i^{th}\f$ tria.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set vertices and references of the mesh triangles.
  *
@@ -447,7 +448,7 @@ LIBMMGS_EXPORT int  MMGS_Set_triangle(MMG5_pMesh mesh, MMG5_int v0, MMG5_int v1,
  * \param v1 second extremity of the edge.
  * \param ref edge reference.
  * \param pos edge position in the mesh.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set edges of extremities \a v0, \a v1 and reference \a ref at
  * position \a pos in mesh structure (\a pos from 1 to nb_edges included).
@@ -634,7 +635,7 @@ LIBMMGS_EXPORT int  MMGS_Set_requiredEdge(MMG5_pMesh mesh, MMG5_int k);
  * \param edges pointer to the array of edges.
  * Vertices of the \f$i^{th}\f$ edge are stored in edge[(i-1)*2]\@2.
  * \param refs edges references. refs[i-1] is the ref of the \f$i^{th}\f$ edge.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set vertices and references of the mesh edges.
  *
@@ -654,7 +655,7 @@ LIBMMGS_EXPORT int  MMGS_Set_requiredEdge(MMG5_pMesh mesh, MMG5_int k);
  * \param refs edges references. refs[i-1] is the ref of the \f$i^{th}\f$ edge.
  * \param areRidges 1 if the edge is a ridge, 0 otherwise.
  * \param areRequired 1 if the edge is required, 0 otherwise.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get vertices and references of the mesh edges.
  *
@@ -677,7 +678,7 @@ LIBMMGS_EXPORT int  MMGS_Set_requiredEdge(MMG5_pMesh mesh, MMG5_int k);
  * \param n1 y componant of the normal at point \a k.
  * \param n2 z componant of the normal at point \a k.
  *
- * \return 1 if success.
+ * \return 1 on success.
  *
  * Set normals (n0,n1,n2) at point \a k.
  *
@@ -696,9 +697,9 @@ LIBMMGS_EXPORT int  MMGS_Set_normalAtVertex(MMG5_pMesh mesh, MMG5_int k, double 
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure.
  * \param k index of the triangle for which we want to get the quality.
- * \return the computed quality or 0. if fail.
+ * \return the computed quality or 0. on failure.
  *
- * Get quality of tria \a k.
+ * Get quality of triangles \a k.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_TRIANGLEQUALITY(mesh,met,k,retval)\n
@@ -714,7 +715,7 @@ LIBMMGS_EXPORT int  MMGS_Set_normalAtVertex(MMG5_pMesh mesh, MMG5_int k, double 
  * \param met pointer to the sol structure.
  * \param s solution scalar value.
  * \param pos position of the solution in the mesh.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set scalar value \a s at position \a pos in solution structure
  * (\a pos from 1 to nb_vertices included).
@@ -733,7 +734,7 @@ LIBMMGS_EXPORT int  MMGS_Set_scalarSol(MMG5_pSol met, double s,MMG5_int pos);
  * \param met pointer to the sol structure.
  * \param s table of the scalar solutions values.
  * s[i-1] is the solution at vertex i.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set scalar solutions at mesh vertices.
  *
@@ -752,7 +753,7 @@ LIBMMGS_EXPORT int  MMGS_Set_scalarSols(MMG5_pSol met, double *s);
  * \param vy y value of the vectorial solution.
  * \param vz z value of the vectorial solution.
  * \param pos position of the solution in the mesh (begin to 1).
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set vectorial value \f$(v_x,v_y,v_z)\f$ at position \a pos in solution
  * structure.
@@ -772,7 +773,7 @@ LIBMMGS_EXPORT int MMGS_Set_vectorSol(MMG5_pSol met, double vx,double vy, double
  * \param met pointer to the sol structure.
  * \param sols table of the vectorial solutions
  * sols[3*(i-1)]\@3 is the solution at vertex i
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set vectorial solutions at mesh vertices
  *
@@ -794,7 +795,7 @@ LIBMMGS_EXPORT int MMGS_Set_vectorSols(MMG5_pSol met, double *sols);
  * \param m23 value of the tensorial solution at position (2,3) in the tensor.
  * \param m33 value of the tensorial solution at position (3,3) in the tensor.
  * \param pos position of the solution in the mesh (begin to 1).
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set tensorial values at position \a pos in solution
  * structure.
@@ -815,7 +816,7 @@ LIBMMGS_EXPORT int MMGS_Set_tensorSol(MMG5_pSol met, double m11,double m12, doub
  * \param met pointer to the sol structure.
  * \param sols table of the tensorial solutions.
  * sols[6*(i-1)]\@6 is the solution at vertex i
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set tensorial values by array.
  *
@@ -834,7 +835,7 @@ LIBMMGS_EXPORT int MMGS_Set_tensorSols(MMG5_pSol met, double *sols);
  * \param s solution(s) at mesh vertex \a pos.
  * \param pos index of the vertex on which we set the solution.
  *
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set values of the solution at the ith field of the solution array and at
  * position \pos (\a pos from 1 to nb_vertices included and i from 1 to nb_sols).
@@ -857,7 +858,7 @@ LIBMMGS_EXPORT int MMGS_Set_tensorSols(MMG5_pSol met, double *sols);
  * is given by s[k-1] for a scalar sol, s[3*(k-1)]\@3 for a vectorial solution
  * and s[6*(k-1)]\@6 for a tensor solution.
  *
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set values of the solution at the ith field of the solution array (\a i from
  * 1 to nb_sols).
@@ -877,7 +878,7 @@ LIBMMGS_EXPORT int MMGS_Set_tensorSols(MMG5_pSol met, double *sols);
 /**
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the sol structure.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Check if the number of given entities match with mesh and sol size
  * (not mandatory) and check mesh datas.
@@ -897,7 +898,7 @@ LIBMMGS_EXPORT int MMGS_Chk_meshData(MMG5_pMesh mesh, MMG5_pSol met);
  * \param sol pointer to the sol structure (unused).
  * \param iparam integer parameter to set (see \ref MMGS_Param structure).
  * \param val value for the parameter.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set integer parameter \a iparam at value \a val.
  *
@@ -917,7 +918,7 @@ LIBMMGS_EXPORT int  MMGS_Set_iparameter(MMG5_pMesh mesh,MMG5_pSol sol, int ipara
  * \param sol pointer to the sol structure (unused).
  * \param dparam double parameter to set (see \ref MMGS_Param structure).
  * \param val value of the parameter.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set double parameter \a dparam at value \a val.
  *
@@ -940,7 +941,7 @@ LIBMMGS_EXPORT int  MMGS_Set_dparameter(MMG5_pMesh mesh,MMG5_pSol sol, int dpara
  * \param hmin minimal edge size.
  * \param hmax maximal edge size.
  * \param hausd value of the Hausdorff number.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set local parameters: set the hausdorff value at \a hausd, the minmal edge
  * size value at \a hmin and the maximal edge size value at \a hmax for all
@@ -966,7 +967,7 @@ LIBMMGS_EXPORT int  MMGS_Set_localParameter(MMG5_pMesh mesh, MMG5_pSol sol, int 
  * \param split MMG5_MMAT_NoSplit if the entity must not be splitted, MMG5_MMAT_Split otherwise
  * \param rmin reference for the negative side after LS discretization
  * \param rplus reference for the positive side after LS discretization
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set the reference mapping for the elements of ref \a ref in ls discretization mode.
  *
@@ -991,7 +992,7 @@ LIBMMGS_EXPORT int  MMGS_Set_localParameter(MMG5_pMesh mesh, MMG5_pSol sol, int 
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure.
  * \param br new level-set base reference.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Set a new level-set base reference of ref \a br in ls discretization
  * mode. Based references are boundary conditions to which implicit domain can
@@ -1162,7 +1163,7 @@ LIBMMGS_EXPORT int  MMGS_Get_vertices(MMG5_pMesh mesh, double* vertices, MMG5_in
  * \param v2 pointer to the third vertex of triangle.
  * \param ref pointer to the triangle reference.
  * \param isRequired pointer to the flag saying if triangle is required.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get vertices \a v0,\a v1,\a v2 and reference \a ref of next
  * triangle of mesh.
@@ -1181,13 +1182,13 @@ LIBMMGS_EXPORT int  MMGS_Get_triangle(MMG5_pMesh mesh, MMG5_int* v0, MMG5_int* v
 /**
  * \param mesh pointer to the mesh structure.
  * \param tria pointer to the table of the triangles vertices
- * Vertices of the \f$i^{th}\f$ tria are stored in tria[(i-1)*3]\@3.
+ * Vertices of the \f$i^{th}\f$ triangles are stored in tria[(i-1)*3]\@3.
  * \param refs pointer to the table of the triangles references.
  * refs[i-1] is the ref of the \f$i^{th}\f$ tria.
  * \param areRequired pointer to table of the flags saying if triangles
  * are required. areRequired[i-1]=1 if the \f$i^{th}\f$ tria
  * is required.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get vertices and references of the mesh triangles.
  *
@@ -1211,7 +1212,7 @@ LIBMMGS_EXPORT int  MMGS_Get_triangles(MMG5_pMesh mesh, MMG5_int* tria, MMG5_int
  * \param ref pointer to the edge reference.
  * \param isRidge pointer to the flag saying if the edge is ridge.
  * \param isRequired pointer to the flag saying if the edge is required.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get extremities \a e0, \a e1 and reference \a ref of next edge of mesh.
  *
@@ -1235,7 +1236,7 @@ LIBMMGS_EXPORT int  MMGS_Get_edge(MMG5_pMesh mesh, MMG5_int* e0, MMG5_int* e1, M
  * \param n1 y componant of the normal at point \a k.
  * \param n2 z componant of the normal at point \a k.
  *
- * \return 1 if success.
+ * \return 1 on success.
  *
  * Get normals (n0,n1,n2) at point \a k.
  *
@@ -1253,7 +1254,7 @@ LIBMMGS_EXPORT int  MMGS_Get_normalAtVertex(MMG5_pMesh mesh, MMG5_int k, double 
 /**
  * \param met pointer to the sol structure.
  * \param s pointer to the scalar solution value.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get solution \a s of next vertex of mesh.
  *
@@ -1270,7 +1271,7 @@ LIBMMGS_EXPORT int  MMGS_Get_scalarSol(MMG5_pSol met, double* s);
  * \param met pointer to the sol structure.
  * \param s table of the scalar solutions at mesh vertices. s[i-1] is
  * the solution at vertex i.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get solutions at mesh vertices.
  *
@@ -1288,7 +1289,7 @@ LIBMMGS_EXPORT int  MMGS_Get_scalarSols(MMG5_pSol met, double* s);
  * \param vx x value of the vectorial solution.
  * \param vy y value of the vectorial solution.
  * \param vz z value of the vectorial solution.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get vectorial solution \f$(v_x,v_y,vz)\f$ of next vertex of mesh.
  *
@@ -1305,7 +1306,7 @@ LIBMMGS_EXPORT int MMGS_Get_vectorSol(MMG5_pSol met, double* vx, double* vy, dou
  * \param met pointer to the sol structure.
  * \param sols table of the solutions at mesh vertices. sols[3*(i-1)]\@3 is
  * the solution at vertex i.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get vectorial solutions at mesh vertices
  *
@@ -1326,7 +1327,7 @@ LIBMMGS_EXPORT int MMGS_Get_vectorSols(MMG5_pSol met, double* sols);
  * \param m22 pointer to the position (2,2) in the solution tensor.
  * \param m23 pointer to the position (2,3) in the solution tensor.
  * \param m33 pointer to the position (3,3) in the solution tensor.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get tensorial solution of next vertex of mesh.
  *
@@ -1344,7 +1345,7 @@ LIBMMGS_EXPORT int MMGS_Get_tensorSol(MMG5_pSol met, double *m11,double *m12, do
  * \param met pointer to the sol structure.
  * \param sols table of the solutions at mesh vertices.
  * sols[6*(i-1)]\@6 is the solution at vertex i.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get tensorial solutions at mesh vertices.
  *
@@ -1363,7 +1364,7 @@ LIBMMGS_EXPORT int MMGS_Get_tensorSols(MMG5_pSol met, double *sols);
  * \param s solution(s) at mesh vertex \a pos.
  * \param pos index of the vertex on which we get the solution.
  *
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get values of the ith field of the solution array at vertex \a pos.
  * (\a pos from 1 to nb_vertices included and \a i from 1 to nb_sols).
@@ -1386,7 +1387,7 @@ LIBMMGS_EXPORT int MMGS_Get_tensorSols(MMG5_pSol met, double *sols);
  * is given by s[k-1] for a scalar sol, s[3*(k-1)]\@3 for a vectorial solution
  * and s[6*(k-1)]\@6 for a tensor solution.
  *
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get values of the solution at the ith field of the solution array.
  * (\a i from 1 to \a nb_sols).
@@ -1421,8 +1422,8 @@ LIBMMGS_EXPORT int MMGS_Get_iparameter(MMG5_pMesh mesh, MMG5_int iparam);
 /* input/output functions */
 /**
  * \param mesh pointer to the mesh structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
  * Read mesh data.
  *
@@ -1441,11 +1442,11 @@ LIBMMGS_EXPORT int  MMGS_loadMesh(MMG5_pMesh mesh, const char* filename);
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure or the NULL pointer.
  * \param sol pointer to the level-set structure or the NULL pointer.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
- * Read mesh and 0 or 1 data field at VTK vtp file format (.vtp extension). We
- * read only low-order points, edges, tria and quad.
+ * Read a mesh and optionally one data field in VTK vtp file format (.vtp extension). We
+ * read only low-order vertices, edges, triangles and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADVTPMESH(mesh,met,sol,filename,strlen0,retval)\n
@@ -1460,11 +1461,11 @@ LIBMMGS_EXPORT int MMGS_loadVtpMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
- * Read mesh and a list of data fields at VTK vtp file format (.vtp extension). We
- * read only low-order points, edges, tria and quad.
+ * Read a mesh and multiple data fields in VTK vtp file format (.vtp extension). We
+ * read only low-order vertices, edges, triangles and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADVTPMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1480,11 +1481,11 @@ LIBMMGS_EXPORT int MMGS_loadVtpMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure or the NULL pointer.
  * \param sol pointer to the level-set structure or the NULL pointer.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
- * Read mesh and 0 or 1 data field at VTK vtu file format (.vtu extension). We
- * read only low-order points, edges, tria and quad.
+ * Read a mesh and optionally one data field in VTK vtu file format (.vtu extension). We
+ * read only low-order vertices, edges, triangles and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADVTUMESH(mesh,met,sol,filename,strlen0,retval)\n
@@ -1500,11 +1501,11 @@ LIBMMGS_EXPORT int MMGS_loadVtuMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
- * Read mesh and a list of data field at VTK vtu file format (.vtu extension). We
- * read only low-order points, edges, tria and quad.
+ * Read a mesh and multiple data field in VTK vtu file format (.vtu extension). We
+ * read only low-order vertices, edges, triangles and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADVTUMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1521,11 +1522,11 @@ LIBMMGS_EXPORT int MMGS_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure or the NULL pointer.
  * \param sol pointer to the level-set structure or the NULL pointer.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
- * Read mesh and 0 or 1 data field at VTK vtk file format (.vtk extension). We
- * read only low-order points, edges, tria and quad.
+ * Read a mesh and optionally one data field in VTK vtk file format (.vtk extension). We
+ * read only low-order vertices, edges, triangles and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADVTKMESH(mesh,met,sol,filename,strlen0,retval)\n
@@ -1541,11 +1542,11 @@ LIBMMGS_EXPORT int MMGS_loadVtkMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
- * Read mesh and a list of data field at VTK vtk file format (.vtk extension). We
- * read only low-order points, edges, tria and quad.
+ * Read a mesh and multiple data field in VTK vtk file format (.vtk extension). We
+ * read only low-order vertices, edges, triangles and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADVTKMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1561,11 +1562,11 @@ LIBMMGS_EXPORT int MMGS_loadVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
- * Read mesh and 0 or 1 data field at MSH file format (.msh extension). We read
- * only low-order points, edges, tria, quad, tetra and prisms.
+ * Read a mesh and optionally one data field at MSH file format (.msh extension). We read
+ * only low-order vertices, edges, triangles, quadrangles, tetrahedra and prisms.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADMSHMESH(mesh,sol,filename,strlen0,retval)\n
@@ -1581,11 +1582,11 @@ LIBMMGS_EXPORT int MMGS_loadMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to a list of solution structures.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
- * Read mesh and a list of data at MSH file format (.msh extension). We read only
- * low-order points, edges, tria, quadra, tetra and prisms.
+ * Read a mesh and multiple data at MSH file format (.msh extension). We read only
+ * low-order vertices, edges, triangles, quadrangles, tetrahedra and prisms.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADMSHMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1602,8 +1603,8 @@ LIBMMGS_EXPORT int MMGS_loadMshMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure or the NULL pointer.
  * \param sol pointer to the level-set structure or the NULL pointer.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
  * Read mesh data.
  *
@@ -1620,8 +1621,8 @@ LIBMMGS_EXPORT int MMGS_loadGenericMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol 
 
 /**
  * \param mesh pointer to the mesh structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
  * Save mesh data.
  *
@@ -1639,10 +1640,10 @@ LIBMMGS_EXPORT int  MMGS_saveMesh(MMG5_pMesh mesh, const char *filename);
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and 0 or 1 data field at MSH  file format (.msh extension).
+ * Write mesh and optionally one data field at MSH  file format (.msh extension).
  * Save file at ASCII format for .msh extension, at binary format for .mshb one.
  *
  * \remark Fortran interface:
@@ -1659,10 +1660,10 @@ LIBMMGS_EXPORT int MMGS_saveMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to write.
+ * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and a list of data fields (that are considered as solutions and
+ * Write mesh and multiple data fields (that are considered as solutions and
  * not metrics, thus, we do nothing over the ridge points) at MSH file format
  * (.msh extension).  Save file at ASCII format for .msh extension, at binary
  * format for .mshb one.
@@ -1681,10 +1682,10 @@ LIBMMGS_EXPORT int MMGS_saveMshMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to write.
+ * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and 0 or 1 data at Vtk file format (.vtk extension).
+ * Write mesh and optionally one data at Vtk file format (.vtk extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEVTKMESH(mesh,sol,filename,strlen0,retval)\n
@@ -1699,10 +1700,10 @@ LIBMMGS_EXPORT int MMGS_saveVtkMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to write.
+ * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and a list of data fields at Vtk file format (.vtk extension).
+ * Write mesh and multiple data fields at Vtk file format (.vtk extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEVTKMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1717,10 +1718,10 @@ LIBMMGS_EXPORT int MMGS_saveVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to write.
+ * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and 0 or 1 data at vtu Vtk file format (.vtu extension).
+ * Write mesh and optionally one data at vtu Vtk file format (.vtu extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEVTUMESH(mesh,sol,filename,strlen0,retval)\n
@@ -1735,10 +1736,10 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to write.
+ * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and a list of data fields at vtu Vtk file format (.vtu extension).
+ * Write mesh and multiple data fields at vtu Vtk file format (.vtu extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEVTUMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1753,10 +1754,10 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to write.
+ * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and 0 or 1 data at polydata Vtk file format (.vtp extension).
+ * Write mesh and optionally one data in polydata Vtk file format (.vtp extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEVTPMESH(mesh,sol,filename,strlen0,retval)\n
@@ -1771,10 +1772,10 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to write.
+ * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and a list of data fields at polydata Vtk file format (.vtp extension).
+ * Write mesh and multiple data fields in polydata Vtk file format (.vtp extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEVTPMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1789,8 +1790,8 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
 
 /**
  * \param mesh pointer to the mesh structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to write.
+ * \return 0 on failure, 1 otherwise.
  *
  * Save mesh data in a file whose format depends on the filename extension.
  *
@@ -1808,10 +1809,10 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
 /**
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the sol structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
- * Load metric field. The solution file (at medit file format) must contains
+ * Load metric field. The solution file (in medit file format) must contain
  * only 1 solution: the metric.
  *
  * \remark Fortran interface:
@@ -1827,10 +1828,10 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solutions array
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to load.
+ * \return 0 on failure, 1 otherwise.
  *
- * Load 1 or more solutions in a solution file at medit file format.
+ * Load 1 or more solutions in a solution file in medit file format.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADALLSOLS(mesh,sol,filename,strlen0,retval)\n
@@ -1845,10 +1846,10 @@ LIBMMGS_EXPORT int  MMGS_loadAllSols(MMG5_pMesh mesh,MMG5_pSol *sol, const char*
 /**
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the sol structure.
- * \param filename name of file.
- * \return 0 if failed, 1 otherwise.
+ * \param filename name of the file to write.
+ * \return 0 on failure, 1 otherwise.
  *
- * Write isotropic or anisotropic metric at medit file format.
+ * Write isotropic or anisotropic metric in medit file format.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVESOL(mesh,met,filename,strlen0,retval)\n
@@ -1864,9 +1865,9 @@ LIBMMGS_EXPORT int  MMGS_saveSol(MMG5_pMesh mesh, MMG5_pSol met, const char *fil
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solutions array
  * \param filename name of the solution file.
- * \return 0 or -1 if fail, 1 otherwise.
+ * \return 0 or -1 on failure, 1 otherwise.
  *
- * Save 1 or more solutions in a solution file at medit file format.
+ * Save 1 or more solutions in a solution file in medit file format.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEALLSOLS(mesh,sol,filename,strlen0,retval)\n
@@ -1913,7 +1914,7 @@ LIBMMGS_EXPORT int MMGS_Free_allSols(MMG5_pMesh mesh,MMG5_pSol *sol);
  * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
  * are \ref MMG5_pSol.
  *
- * \return 0 if fail, 1 if success
+ * \return 0 on failure, 1 on success
  *
  * Deallocations before return.
  *
@@ -1945,7 +1946,7 @@ LIBMMGS_EXPORT int MMGS_Free_all(const int starter,...);
  * Here, \a your_mesh is a pointer to \ref MMG5_pMesh and \a your_metric and
  * \a your_level_set a pointer to \ref MMG5_pSol.
  *
- * \return 0 if fail, 1 if success
+ * \return 0 on failure, 1 on success
  *
  * Structure deallocations before return.
  *
@@ -1974,7 +1975,7 @@ LIBMMGS_EXPORT int MMGS_Free_structures(const int starter,...);
  * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
  * are \ref MMG5_pSol.
  *
- * \return 0 if fail, 1 if success
+ * \return 0 on failure, 1 on success
  *
  * Structure deallocations before return.
  *
@@ -1988,11 +1989,10 @@ LIBMMGS_EXPORT int MMGS_Free_names(const int starter,...);
 
 /* library */
 /**
- * \param mesh pointer to the mesh structure.
- * \param met pointer to the sol (metric) structure.
- * \return \ref MMG5_SUCCESS if success, \ref MMG5_LOWFAILURE if fail but a
- * conform mesh is saved or \ref MMG5_STRONGFAILURE if fail and we can't save
- * the mesh.
+ * \param mesh pointer to the mesh structure.  \param met pointer to the sol
+ * (metric) structure.  \return \ref MMG5_SUCCESS on success, \ref
+ * MMG5_LOWFAILURE in case there is a failure but a conform mesh can be returned
+ * or \ref MMG5_STRONGFAILURE if there is a failure and we can't save the mesh.
  *
  * Main program for the library.
  *
@@ -2006,12 +2006,11 @@ LIBMMGS_EXPORT int MMGS_Free_names(const int starter,...);
 LIBMMGS_EXPORT int  MMGS_mmgslib(MMG5_pMesh mesh, MMG5_pSol met);
 
 /**
- * \param mesh pointer to the mesh structure.
- * \param sol pointer to the sol (level-set) structure.
- * \param met pointer to the sol (metric) structure (optionnal).
- * \return \ref MMG5_SUCCESS if success, \ref MMG5_LOWFAILURE if fail but a
- * conform mesh is saved or \ref MMG5_STRONGFAILURE if fail and we can't save
- * the mesh.
+ * \param mesh pointer to the mesh structure.  \param sol pointer to the sol
+ * (level-set) structure.  \param met pointer to the sol (metric) structure
+ * (optionnal).  \return \ref MMG5_SUCCESS on success, \ref MMG5_LOWFAILURE if
+ * there is a a failure but a conform mesh is saved or \ref MMG5_STRONGFAILURE
+ * if there is a a failure and we can't save the mesh.
  *
  * Main program for level set discretization library. If a metric \a met is
  * provided, use it to adapt the mesh.
@@ -2044,7 +2043,7 @@ LIBMMGS_EXPORT void  MMGS_setfunc(MMG5_pMesh mesh,MMG5_pSol met);
 /**
  * \param mesh pointer to the mesh structure.
  * \param nb_edges pointer to the number of non boundary edges.
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get the number of non boundary edges (for DG methods for example). An edge is
  * boundary if it is located at the interface of 2 domains with different
@@ -2071,7 +2070,7 @@ LIBMMGS_EXPORT void  MMGS_setfunc(MMG5_pMesh mesh,MMG5_pSol met);
  * \param e1 pointer to the second  extremity of the edge.
  * \param ref pointer to the edge reference.
  * \param idx index of the non boundary edge to get (between 1 and nb_edges)
- * \return 0 if failed, 1 otherwise.
+ * \return 0 on failure, 1 otherwise.
  *
  * Get extremities \a e0, \a e1 and reference \a ref of the idx^th non boundary
  * edge (for DG methods for example). An edge is boundary if it is located at
@@ -2095,7 +2094,7 @@ LIBMMGS_EXPORT void  MMGS_setfunc(MMG5_pMesh mesh,MMG5_pSol met);
 /**
  * \param mesh pointer to the mesh structure
  * \param met pointer to the sol structure
- * \return 1 if success
+ * \return 1 on success
  *
  * Compute isotropic size map according to the mean of the length of the
  * edges passing through a point.
@@ -2112,7 +2111,7 @@ LIBMMGS_EXPORT void  MMGS_setfunc(MMG5_pMesh mesh,MMG5_pSol met);
 /**
  * \param mesh pointer to the mesh structure
  * \param met pointer to the sol structure
- * \return 1 if success
+ * \return 1 on success
  *
  * Compute constant size map according to mesh->info.hsiz, mesh->info.hmin and
  * mesh->info.hmax. Update this 3 value if not compatible.
@@ -2157,7 +2156,7 @@ LIBMMGS_EXPORT int MMGS_usage(char *prog);
 LIBMMGS_EXPORT int  MMGS_parsar(int argc,char *argv[],MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol);
 /**
  * \param mesh pointer to the mesh structure.
- * \return 0 if fail, 1 if success.
+ * \return 0 on failure, 1 on success.
  *
  * Print the default parameters values.
  *
@@ -2228,7 +2227,7 @@ LIBMMGS_EXPORT int MMGS_Get_adjaTri(MMG5_pMesh mesh, MMG5_int kel, MMG5_int list
  * \param start index of a triangle holding \a ip.
  * \param lispoi pointer to an array of size MMGS_LMAX that will contain
  * the indices of adjacent vertices to the vertex \a ip.
- * \return nbpoi the number of adjacent points if success, 0 if fail.
+ * \return nbpoi the number of adjacent points on success, 0 on failure.
  *
  * Find the indices of the adjacent vertices of the vertex \a
  * ip of the triangle \a start.
@@ -2301,7 +2300,7 @@ LIBMMGS_EXPORT void MMGS_Free_solutions(MMG5_pMesh mesh,MMG5_pSol sol);
  LIBMMGS_EXPORT int MMGS_Clean_isoSurf(MMG5_pMesh mesh);
 
 /**
- * Set common pointer functions between mmgs and mmg3d to the matching mmgs
+ * Set common function pointers between mmgs and mmg3d to the matching mmgs
  * functions.
  */
 LIBMMGS_EXPORT void MMGS_Set_commonFunc(void);

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -92,7 +92,7 @@ extern "C" {
 #include "mmg/common/libmmgtypes.h"
 
 /**
- * Maximum array size when storing adjacent points (or ball) of a vertex.
+ * Maximum array size when storing adjacent vertices (or ball) of a vertex.
  */
 #define MMGS_LMAX      1024
 
@@ -126,7 +126,7 @@ enum MMGS_Param {
   MMGS_IPARAM_numsubdomain,      /*!< [0/n], Save only subdomain n (0==all subdomains) */
   MMGS_IPARAM_renum,             /*!< [1/0], Turn on/off renumbering with Scotch */
   MMGS_IPARAM_anisosize,         /*!< [1/0], Turn on/off anisotropic metric creation when no metric is provided */
-  MMGS_IPARAM_nosizreq,          /*!< [0/1], Allow/avoid overwritings of sizes at required points (advanced usage) */
+  MMGS_IPARAM_nosizreq,          /*!< [0/1], Allow/avoid overwritings of sizes at required vertices (advanced usage) */
   MMGS_DPARAM_angleDetection,    /*!< [val], Threshold for angle detection */
   MMGS_DPARAM_hmin,              /*!< [val], Minimal edge length */
   MMGS_DPARAM_hmax,              /*!< [val], Maximal edge length */
@@ -1236,15 +1236,15 @@ LIBMMGS_EXPORT int  MMGS_Get_vertex(MMG5_pMesh mesh, double* c0, double* c1, dou
  * \brief Get the coordinates, references and attributes of all vertices in the mesh.
  *
  * \param mesh pointer to the mesh structure.
- * \param vertices pointer to the array of points coordinates.
+ * \param vertices pointer to the array of coordinates.
  * The coordinates of vertex \a i are stored in
  * vertices[(i-1)*3]\@3.
  * \param refs pointer to the array of vertex references.
  * The ref of vertex \a i is stored in refs[i-1].
  * \param areCorners pointer to the array of flags saying if
- * points are corners.
+ *   vertices are corners.
  * areCorners[i-1]=1 if vertex \a i is corner.
- * \param areRequired pointer to the table of flags saying if points
+ * \param areRequired pointer to the table of flags saying if vertices
  * are required. areRequired[i-1]=1 if vertex \a i is required.
  * \return 1.
  *
@@ -1737,7 +1737,7 @@ LIBMMGS_EXPORT int MMGS_loadVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  * \param filename name of the file to load.
  * \return 0 on failure, 1 otherwise.
  *
- * Read a mesh and optionally one data field at MSH file format (.msh extension). We read
+ * Read a mesh and optionally one data field in MSH file format (.msh extension). We read
  * only low-order vertices, edges, triangles, quadrangles, tetrahedra and prisms.
  *
  * \remark Fortran interface:
@@ -1759,7 +1759,7 @@ LIBMMGS_EXPORT int MMGS_loadMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * \param filename name of the file to load.
  * \return 0 on failure, 1 otherwise.
  *
- * Read a mesh and multiple data at MSH file format (.msh extension). We read only
+ * Read a mesh and multiple data in MSH file format (.msh extension). We read only
  * low-order vertices, edges, triangles, quadrangles, tetrahedra and prisms.
  *
  * \remark Fortran interface:
@@ -1846,7 +1846,7 @@ LIBMMGS_EXPORT int MMGS_saveMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * \return 0 on failure, 1 otherwise.
  *
  * This function saves a mesh and multiple data fields (that are considered as
- * solutions and not metrics, thus, we do nothing over the ridge points) in MSH
+ * solutions and not metrics, thus, we do nothing over the ridge vertices) in MSH
  * file format (.msh extension). The file is saved in ASCII format for .msh
  * extension and in binary format for a .mshb extension.
  *
@@ -2304,7 +2304,7 @@ LIBMMGS_EXPORT void  MMGS_setfunc(MMG5_pMesh mesh,MMG5_pSol met);
 /* Tools for the library */
 /**
  * \brief Compute an isotropic size map according to the mean of the length of the
- * edges passing through a point.
+ * edges passing through a vertex.
  *
  * \param mesh pointer to the mesh structure
  * \param met pointer to the sol structure
@@ -2446,7 +2446,7 @@ LIBMMGS_EXPORT int MMGS_Get_adjaTri(MMG5_pMesh mesh, MMG5_int kel, MMG5_int list
  * \param start index of a triangle holding \a ip.
  * \param lispoi pointer to an array of size MMGS_LMAX that will contain
  * the indices of adjacent vertices to the vertex \a ip.
- * \return nbpoi the number of adjacent points on success, 0 on failure.
+ * \return nbpoi the number of adjacent vertices on success, 0 on failure.
  *
  * Find the indices of the adjacent vertices of the vertex \a
  * ip of the triangle \a start.

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -21,6 +21,31 @@
 ** =============================================================================
 */
 
+/*
+ * This file defines the C and Fortran headers of the mmgs API, and
+ * their Doxygen documentation.
+ *
+ * NOTES FOR DEVELOPERS:
+ *
+ * - The Fortran headers are generated from comment lines that start with '* >'.
+ *   They must match the C declarations.
+ *
+ * - We cannot handle enum types in the Fortran version so enums are replaced
+ *   by ints in both versions.
+ *
+ * - To keep the genheader program working, don't break line between an enum
+ *   name and the opening brace (it creates errors under windows)
+ *
+ * - Since Mmg version 5,
+ * -- data structures and parameters that are common between mmg3d, mmg2d
+ *    and mmgs use the MMG5_ prefix;
+ * -- API functions should have an MMG3D_, MMG2D_, or MMGS_ prefix,
+ *    depending on the library; and
+ * -- some MMG5_ API functions exists but they are common to the
+ *    three libraries.
+ *
+ */
+
 /**
  * \file mmgs/libmmgs.h
  * \brief API headers for the mmgs library
@@ -28,8 +53,30 @@
  * \version 5
  * \date 01 2014
  * \copyright GNU Lesser General Public License.
- * \warning To keep the genheader working, don't break line between the enum
- * name and the opening brace (it creates errors under windows)
+ *
+ * These are the API functions for the mmgs library. These functions allow to
+ * load and save meshes and data defined on meshes; add, extract, or modify mesh
+ * data; and to call the library functions that perform remeshing and level-set
+ * discretization.
+ *
+ * Meshes are here defined in terms of vertices and two-dimensional objects:
+ * triangles and quadrangles, which live in 3D space. Edges can also be
+ * represented. All of these \a entities can have a \a reference: an integer
+ * value that can serve as a group identifier. In addition mesh entities can
+ * have \a attributes such as "required" or "corner".
+ *
+ * Data defined on meshes can be for example functions that are meant for
+ * level-set discretization and metric tensors that will govern edge
+ * lengths. These data can be scalar, vector, or (symmetric) tensor-valued; and
+ * there can be more than one data item associated with a mesh entity. These
+ * data are often referred to as \a solutions.
+ *
+ * Two of the functions here are referred to as "programs", because they perform
+ * the tasks for which mmgs is meant: meshing and level-set discretization.  The
+ * other functions merely serve to load and save data and to perform pre- and
+ * post-processing. These programs actually behave much like independent
+ * programs: they send diagnostic output to stdout and in rare cases they may
+ * call the exit() function.
  *
  */
 

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -160,7 +160,7 @@ enum MMGS_Param {
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppLs,
  * &your_level_set,MMG5_ARG_end).
  *
- * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
+ * Here, \a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
  * are \ref MMG5_pSol.
  *
  * \return 1 on success, 0 on failure
@@ -710,7 +710,7 @@ LIBMMGS_EXPORT int  MMGS_Set_requiredEdge(MMG5_pMesh mesh, MMG5_int k);
  * \param mesh pointer to the mesh structure.
  * \param edges pointer to an array of edges.
  *   The vertices of edge i are stored in edges[(i-1)*2] and edges[(i-1)*2+1].
- * \param refs edges references. refs[i-1] is the ref of the \f$i^{th}\f$ edge.
+ * \param refs edge references. refs[i-1] is the reference of edge \a i.
  * \param areRidges 1 if the edge is a ridge, 0 otherwise.
  * \param areRequired 1 if the edge is required, 0 otherwise.
  * \return 0 on failure, 1 otherwise.
@@ -912,7 +912,7 @@ LIBMMGS_EXPORT int MMGS_Set_tensorSols(MMG5_pSol met, double *sols);
  * \return 0 on failure, 1 otherwise.
  *
  * Set values of the solution at field \a i of the solution array and at
- * position \pos (\a pos from 1 to the number of vertices included and i from 1
+ * position \pos (\a pos from 1 to the number of vertices included and \a i from 1
  * to the number of solutions). The type of solution is determined from \a sol.
  *
  * \remark Fortran interface:
@@ -954,15 +954,16 @@ LIBMMGS_EXPORT int MMGS_Set_tensorSols(MMG5_pSol met, double *sols);
 
 /* check init */
 /**
- * \brief Check if the number of given entities match with mesh and sol size and
- * check mesh data.
+ * \brief Check if the numbers of given entities match with mesh and solution
+ * size and check mesh data.
  *
  * \param mesh pointer to the mesh structure.
- * \param met pointer to the sol structure.
+ * \param met pointer to the solution structure.
  * \return 0 on failure, 1 otherwise.
  *
- * This function checks if the number of given entities match with mesh and sol
- * size and checks the mesh data. Use of this function is not mandatory.
+ * This function checks if the numbers of given entities match with the mesh and
+ * solution sizes and checks the mesh data. Use of this function is not
+ * mandatory.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_CHK_MESHDATA(mesh,met,retval)\n
@@ -1514,9 +1515,10 @@ LIBMMGS_EXPORT int MMGS_Get_tensorSols(MMG5_pSol met, double *sols);
  *
  * \return 0 on failure, 1 otherwise.
  *
- * Get values of the ith field of the solution array at vertex \a pos.  (\a pos
- * from 1 to the number of vertices included and \a i from 1 to the number of
- * solutions).
+ * This function retreives the value of field \a i of the solution array at
+ * vertex \a pos.  (\a pos from 1 to the number of vertices included and \a i
+ * from 1 to the number of solutions). It works for any type of solution; the
+ * types are inferred from \a sol.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_ITHSOL_INSOLSATVERTICES(sol,i,s,pos,retval)\n
@@ -1541,8 +1543,9 @@ LIBMMGS_EXPORT int MMGS_Get_tensorSols(MMG5_pSol met, double *sols);
  *
  * \return 0 on failure, 1 otherwise.
  *
- * Get values of the solution at the ith field of the solution array.
- * (\a i from 1 to \a the number of sols).
+ * This function retrieves the values of field \a i of the solution array \a sol
+ * (\a i from 1 to \a the number of solutions). It works for any type of solution;
+ * the type is inferred from \a sol.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_ITHSOLS_INSOLSATVERTICES(sol,i,s,retval)\n
@@ -1562,7 +1565,9 @@ LIBMMGS_EXPORT int MMGS_Get_tensorSols(MMG5_pSol met, double *sols);
  * \param iparam integer parameter to get (see \ref MMGS_Param structure).
  * \return The value of the parameter.
  *
- * This function retrieves the value of integer parameter \a iparam.
+ * This function retrieves the value of integer parameter \a iparam (see \ref
+ * MMGS_Param for a list of parameters). It returns the value of the parameter,
+ * or zero if the value of \a iparam is not recognized.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_IPARAMETER(mesh,iparam,retval)\n
@@ -1581,6 +1586,12 @@ LIBMMGS_EXPORT int MMGS_Get_iparameter(MMG5_pMesh mesh, MMG5_int iparam);
  * \param mesh pointer to the mesh structure.
  * \param filename name of the file to load.
  * \return 0 on failure, 1 otherwise.
+ *
+ * This function reads .mesh (ASCII) and .meshb (binary) files. If the name
+ * contains ".mesh" the file will be read as an ASCII file and if the name
+ * contains .meshb it be read as a binary file. If the file contains neither of
+ * these strings the function will first try to open "[filename].meshb"
+ * and if this fails it will try "[filename].mesh".
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADMESH(mesh,filename,strlen0,retval)\n
@@ -1615,7 +1626,8 @@ LIBMMGS_EXPORT int  MMGS_loadMesh(MMG5_pMesh mesh, const char* filename);
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_loadVtpMesh(MMG5_pMesh mesh, MMG5_pSol met, MMG5_pSol sol, const char *filename);
+LIBMMGS_EXPORT int MMGS_loadVtpMesh(MMG5_pMesh mesh, MMG5_pSol met, MMG5_pSol sol,
+                                    const char *filename);
 
 /**
  * \brief Load a mesh and multiple solutions in VTP (VTK) format from file.
@@ -1637,7 +1649,8 @@ LIBMMGS_EXPORT int MMGS_loadVtpMesh(MMG5_pMesh mesh, MMG5_pSol met, MMG5_pSol so
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_loadVtpMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_loadVtpMesh_and_allData(MMG5_pMesh mesh, MMG5_pSol *sol,
+                                                const char *filename);
 
 /**
  * \brief Load a mesh and possibly data in VTU (VTK) format from file.
@@ -1648,8 +1661,9 @@ LIBMMGS_EXPORT int MMGS_loadVtpMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  * \param filename name of the file to load.
  * \return 0 on failure, 1 otherwise.
  *
- * Read a mesh and optionally one data field in VTK vtu file format (.vtu extension). We
- * read only low-order vertices, edges, triangles and quadrangles.
+ * Read a mesh and optionally one data field in VTK vtu file format (.vtu
+ * extension). We read only low-order vertices, edges, triangles and
+ * quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADVTUMESH(mesh,met,sol,filename,strlen0,retval)\n
@@ -1660,7 +1674,7 @@ LIBMMGS_EXPORT int MMGS_loadVtpMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_loadVtuMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_loadVtuMesh(MMG5_pMesh mesh, MMG5_pSol met, MMG5_pSol sol, const char *filename);
 
 /**
  * \brief Load a mesh and multiple solutions in VTU (VTK) format from file.
@@ -1682,7 +1696,8 @@ LIBMMGS_EXPORT int MMGS_loadVtuMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_loadVtuMesh_and_allData(MMG5_pMesh mesh, MMG5_pSol *sol,
+                                                const char *filename);
 
 /**
  * \brief Load a mesh and possibly data in VTK format from file.
@@ -1705,7 +1720,8 @@ LIBMMGS_EXPORT int MMGS_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_loadVtkMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_loadVtkMesh(MMG5_pMesh mesh, MMG5_pSol met, MMG5_pSol sol,
+                                    const char *filename);
 
 /**
  * \brief Load a mesh and multiple solutions in VTK format from file.
@@ -1727,7 +1743,8 @@ LIBMMGS_EXPORT int MMGS_loadVtkMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_loadVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_loadVtkMesh_and_allData(MMG5_pMesh mesh, MMG5_pSol *sol,
+                                                const char *filename);
 
 /**
  * \brief Load a mesh and possibly a solution in .msh format from file.
@@ -1749,7 +1766,7 @@ LIBMMGS_EXPORT int MMGS_loadVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_loadMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_loadMshMesh(MMG5_pMesh mesh, MMG5_pSol sol, const char *filename);
 
 /**
  * \brief Load a mesh and all data from a file in MSH format.
@@ -1771,7 +1788,7 @@ LIBMMGS_EXPORT int MMGS_loadMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_loadMshMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_loadMshMesh_and_allData(MMG5_pMesh mesh, MMG5_pSol *sol, const char *filename);
 
 /**
  * \brief Load a mesh and all data from a file. The format will be guessed from the filename extension.
@@ -1791,7 +1808,8 @@ LIBMMGS_EXPORT int MMGS_loadMshMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_loadGenericMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_loadGenericMesh(MMG5_pMesh mesh, MMG5_pSol met, MMG5_pSol sol,
+                                        const char *filename);
 
 /**
  * \brief Save a mesh in .mesh or .meshb format.
@@ -1834,7 +1852,7 @@ LIBMMGS_EXPORT int  MMGS_saveMesh(MMG5_pMesh mesh, const char *filename);
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_saveMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_saveMshMesh(MMG5_pMesh mesh, MMG5_pSol sol, const char *filename);
 
 /**
  * \brief Save a mesh and multiple data fields in MSH format, ascii or binary
@@ -1859,7 +1877,7 @@ LIBMMGS_EXPORT int MMGS_saveMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_saveMshMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_saveMshMesh_and_allData(MMG5_pMesh mesh, MMG5_pSol *sol, const char *filename);
 
 /**
  * \brief Write mesh and optionally one data field in Vtk file format (.vtk extension).
@@ -1878,7 +1896,7 @@ LIBMMGS_EXPORT int MMGS_saveMshMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_saveVtkMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_saveVtkMesh(MMG5_pMesh mesh, MMG5_pSol sol, const char *filename);
 
 /**
  * \brief Save a mesh and multiple data fields in VTK format.
@@ -1899,7 +1917,7 @@ LIBMMGS_EXPORT int MMGS_saveVtkMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_saveVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_saveVtkMesh_and_allData(MMG5_pMesh mesh, MMG5_pSol *sol, const char *filename);
 
 /**
  * \brief Write mesh and optionally one data field vtu Vtk file format (.vtu extension).
@@ -1918,7 +1936,7 @@ LIBMMGS_EXPORT int MMGS_saveVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh, MMG5_pSol sol, const char *filename);
 
 /**
  * \brief Write a mesh and multiple data fields in vtu Vtk file format (.vtu extension).
@@ -1960,7 +1978,8 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * >   END SUBROUTINE\n
  *
  */
-  LIBMMGS_EXPORT int MMGS_saveVtpMesh(MMG5_pMesh mesh, MMG5_pSol sol, const char *filename);
+  LIBMMGS_EXPORT int MMGS_saveVtpMesh(MMG5_pMesh mesh, MMG5_pSol sol,
+                                      const char *filename);
 
 /**
  * \brief Save a mesh and multiple data fields in VTP format.
@@ -2001,7 +2020,8 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * >   END SUBROUTINE\n
  *
  */
-  LIBMMGS_EXPORT int MMGS_saveGenericMesh(MMG5_pMesh mesh, MMG5_pSol sol, const char *filename);
+  LIBMMGS_EXPORT int MMGS_saveGenericMesh(MMG5_pMesh mesh, MMG5_pSol sol,
+                                          const char *filename);
 
 /**
  * \brief Load a metric field (or other solution) in medit's .sol format.
@@ -2042,7 +2062,8 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int  MMGS_loadAllSols(MMG5_pMesh mesh, MMG5_pSol *sol, const char* filename);
+LIBMMGS_EXPORT int  MMGS_loadAllSols(MMG5_pMesh mesh, MMG5_pSol *sol,
+                                     const char* filename);
 
 /**
  * \brief Write an isotropic or anisotropic metric in medit file format.
@@ -2061,7 +2082,8 @@ LIBMMGS_EXPORT int  MMGS_loadAllSols(MMG5_pMesh mesh, MMG5_pSol *sol, const char
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int  MMGS_saveSol(MMG5_pMesh mesh, MMG5_pSol met, const char *filename);
+LIBMMGS_EXPORT int  MMGS_saveSol(MMG5_pMesh mesh, MMG5_pSol met,
+                                 const char *filename);
 
 /**
  * \brief Save one or more solutions in a solution file in medit file format.
@@ -2080,7 +2102,8 @@ LIBMMGS_EXPORT int  MMGS_saveSol(MMG5_pMesh mesh, MMG5_pSol met, const char *fil
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_saveAllSols(MMG5_pMesh mesh, MMG5_pSol *sol, const char *filename);
+LIBMMGS_EXPORT int MMGS_saveAllSols(MMG5_pMesh mesh, MMG5_pSol *sol,
+                                    const char *filename);
 
 /**
  * \brief Deallocate an array of solution fields
@@ -2115,7 +2138,7 @@ LIBMMGS_EXPORT int MMGS_Free_allSols(MMG5_pMesh mesh,MMG5_pSol *sol);
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppLs,
  * &your_level_set,MMG5_ARG_end).
  *
- * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
+ * Here, \a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
  * are \ref MMG5_pSol.
  *
  * \return 0 on failure, 1 on success
@@ -2144,11 +2167,8 @@ LIBMMGS_EXPORT int MMGS_Free_all(const int starter,...);
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppLs,
  * &your_level_set,MMG5_ARG_end).
  *
- * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
- * are \ref MMG5_pSol.
- *
  * Here, \a your_mesh is a pointer to \ref MMG5_pMesh and \a your_metric and
- * \a your_level_set a pointer to \ref MMG5_pSol.
+ * \a your_level_set are pointers to \ref MMG5_pSol.
  *
  * \return 0 on failure, 1 on success
  *
@@ -2176,7 +2196,7 @@ LIBMMGS_EXPORT int MMGS_Free_structures(const int starter,...);
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppLs,
  * &your_level_set,MMG5_ARG_end).
  *
- * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
+ * Here, \a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
  * are \ref MMG5_pSol.
  *
  * \return 0 on failure, 1 on success
@@ -2371,7 +2391,7 @@ LIBMMGS_EXPORT int MMGS_usage(char *prog);
 LIBMMGS_EXPORT int  MMGS_parsar(int argc,char *argv[],MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol);
 
 /**
- * \brief Print the default parameters values.
+ * \brief Print the default parameter values.
  *
  * \param mesh pointer to the mesh structure.
  * \return 0 on failure, 1 on success.
@@ -2416,11 +2436,12 @@ LIBMMGS_EXPORT int MMGS_stockOptions(MMG5_pMesh mesh, MMG5_Info *info);
 LIBMMGS_EXPORT void MMGS_destockOptions(MMG5_pMesh mesh, MMG5_Info *info);
 
 /**
- * \brief Return adjacent elements of a triangle.
+ * \brief Return adjacent triangles of a triangle.
+ *
  * \param mesh pointer to the mesh structure.
  * \param kel triangle index.
  * \param listri pointer to the array of indices of the three adjacent
- * triangles of the elt \a kel (the index is 0 if there is no adjacent).
+ * triangles of triangle \a kel (the index is 0 if there is no adjacent triangle).
  * \return 1.
  *
  * Find the indices of the 3 adjacent elements of triangle \a
@@ -2439,7 +2460,7 @@ LIBMMGS_EXPORT void MMGS_destockOptions(MMG5_pMesh mesh, MMG5_Info *info);
 LIBMMGS_EXPORT int MMGS_Get_adjaTri(MMG5_pMesh mesh, MMG5_int kel, MMG5_int listri[3]);
 
 /**
- * \brief Find adjacent elements of a triangle.
+ * \brief Find adjacent vertices of a triangle.
  *
  * \param mesh pointer to the mesh structure.
  * \param ip vertex index.
@@ -2463,20 +2484,23 @@ LIBMMGS_EXPORT int MMGS_Get_adjaTri(MMG5_pMesh mesh, MMG5_int kel, MMG5_int list
 LIBMMGS_EXPORT int MMGS_Get_adjaVerticesFast(MMG5_pMesh mesh, MMG5_int ip,MMG5_int start, MMG5_int lispoi[MMGS_LMAX]);
 
 /**
- * \brief Compute the real eigenvalues and eigenvectors of a symetric matrix
+ * \brief Compute the real eigenvalues and eigenvectors of a symmetric matrix
  *
- * \param m upper part of a symetric matric diagonalizable in |R
- * \param lambda array of the metric eigenvalues
- * \param vp array of the metric eigenvectors
+ * \param m upper part of a symmetric matrix diagonalizable in |R
+ * \param lambda array of eigenvalues
+ * \param vp array of eigenvectors
  *
  * \return the order of the eigenvalues
  *
- * Compute the real eigenvalues and eigenvectors of a symetric matrice m whose
+ * Compute the real eigenvalues and eigenvectors of a symmetric matrix m whose
  * upper part is provided (m11, m12, m13, m22, m23, m33 in this order).
+ *
  * lambda[0] is the eigenvalue associated to the eigenvector ( v[0][0], v[0,1], v[0,2] )
  * in C and to the eigenvector v(1,:) in fortran
+ *
  * lambda[1] is the eigenvalue associated to the eigenvector ( v[1][0], v[1,1], v[1,2] )
  * in C and to the eigenvector v(2,:) in fortran
+ *
  * lambda[2] is the eigenvalue associated to the eigenvector ( v[2][0], v[2,1], v[2,2] )
  * in C and to the eigenvector v(3,:) in fortran
  *
@@ -2507,7 +2531,7 @@ LIBMMGS_EXPORT void MMGS_Free_solutions(MMG5_pMesh mesh,MMG5_pSol sol);
 /**
  * \brief Clean data (triangles and edges) linked to isosurface.
  *
- * \param mesh pointer to mesh sructure
+ * \param mesh pointer to mesh structure
  *
  * \return 1 if successful, 0 otherwise.
  *

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -115,9 +115,9 @@ enum MMGS_Param {
   MMGS_IPARAM_isoref,            /*!< [0/n], Iso-surface boundary material reference */
   MMGS_IPARAM_keepRef,           /*!< [1/0], Preserve the initial domain references in level-set mode */
   MMGS_IPARAM_optim,             /*!< [1/0], Optimize mesh keeping its initial edge sizes */
-  MMGS_IPARAM_noinsert,          /*!< [1/0], Avoid/allow point insertion */
+  MMGS_IPARAM_noinsert,          /*!< [1/0], Avoid/allow vertex insertion */
   MMGS_IPARAM_noswap,            /*!< [1/0], Avoid/allow edge or face flipping */
-  MMGS_IPARAM_nomove,            /*!< [1/0], Avoid/allow point relocation */
+  MMGS_IPARAM_nomove,            /*!< [1/0], Avoid/allow vertex relocation */
   MMGS_IPARAM_nreg,              /*!< [0/1], Disable/enable regularization of normals */
   MMGS_IPARAM_xreg,              /*!< [0/1], Disable/enable regularization by moving vertices */
   MMGS_IPARAM_numberOfLocalParam,/*!< [n], Number of local parameters */
@@ -171,10 +171,10 @@ enum MMGS_Param {
 LIBMMGS_EXPORT int MMGS_Init_mesh(const int starter,...);
 
 /**
+ * \brief Initialize file names to their default values.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure.
- *
- * Initialize file names to their default values.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_INIT_FILENAMES(mesh,sol)\n
@@ -183,7 +183,10 @@ LIBMMGS_EXPORT int MMGS_Init_mesh(const int starter,...);
  *
  */
 LIBMMGS_EXPORT void  MMGS_Init_fileNames(MMG5_pMesh mesh, MMG5_pSol sol);
+
 /**
+ * \brief Initialize the input parameters.
+ *
  * \param mesh pointer to the mesh structure.
  *
  * Initialization of the input parameters (stored in the Info structure).
@@ -198,11 +201,11 @@ LIBMMGS_EXPORT void  MMGS_Init_parameters(MMG5_pMesh mesh);
 
 /* init file names */
 /**
+ * \brief Set the name of the input mesh.
+ *
  * \param mesh pointer to the mesh structure.
  * \param meshin input mesh name.
  * \return 1.
- *
- * Set the name of input mesh.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_INPUTMESHNAME(mesh,meshin,strlen0,retval)\n
@@ -214,12 +217,13 @@ LIBMMGS_EXPORT void  MMGS_Init_parameters(MMG5_pMesh mesh);
  *
  */
 LIBMMGS_EXPORT int  MMGS_Set_inputMeshName(MMG5_pMesh mesh, const char* meshin);
+
 /**
+ * \brief Set the name of the output mesh file.
+ *
  * \param mesh pointer to the mesh structure.
  * \param meshout name of the output mesh file.
  * \return 1.
- *
- * Set the name of output mesh file.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_OUTPUTMESHNAME(mesh,meshout,strlen0,retval)\n
@@ -231,13 +235,14 @@ LIBMMGS_EXPORT int  MMGS_Set_inputMeshName(MMG5_pMesh mesh, const char* meshin);
  *
  */
 LIBMMGS_EXPORT int  MMGS_Set_outputMeshName(MMG5_pMesh mesh, const char* meshout);
+
 /**
+ * \brief Set the name of the input solution file.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure.
  * \param solin name of the input solution file.
  * \return 1.
- *
- * Set the name of input solution file.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_INPUTSOLNAME(mesh,sol,solin,strlen0,retval)\n
@@ -249,13 +254,14 @@ LIBMMGS_EXPORT int  MMGS_Set_outputMeshName(MMG5_pMesh mesh, const char* meshout
  *
  */
 LIBMMGS_EXPORT int  MMGS_Set_inputSolName(MMG5_pMesh mesh,MMG5_pSol sol, const char* solin);
+
 /**
+ * \brief Set the name of the output solution file.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure.
  * \param solout name of the output solution file.
  * \return 0 on failure, 1 otherwise.
- *
- *  Set the name of output solution file.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_OUTPUTSOLNAME(mesh,sol,solout,strlen0,retval)\n
@@ -267,12 +273,13 @@ LIBMMGS_EXPORT int  MMGS_Set_inputSolName(MMG5_pMesh mesh,MMG5_pSol sol, const c
  *
  */
 LIBMMGS_EXPORT int  MMGS_Set_outputSolName(MMG5_pMesh mesh,MMG5_pSol sol, const char* solout);
+
 /**
+ * \brief Set the name of the input parameter file.
+ *
  * \param mesh pointer to the mesh structure.
  * \param fparamin name of the input parameter file.
  * \return 1.
- *
- * Set the name of input parameter file.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_INPUTPARAMNAME(mesh,fparamin,strlen0,retval)\n
@@ -287,15 +294,16 @@ LIBMMGS_EXPORT int  MMGS_Set_inputParamName(MMG5_pMesh mesh, const char* fparami
 
 /* init structure sizes */
 /**
+ * \brief Initialize an array of solution fields: set dimension, types and
+ * number of fields.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure.
- * \param typEntity type of solutions entities (vertices, triangles...).
+ * \param typEntity types of solution entities (vertices, triangles...).
  * \param np number of solutions.
- * \param typSol type of solution (scalar, vectorial...).
+ * \param typSol type of solution (scalar, vectorial, ..., see \ref MMG5_type for possible values)
  * \return 0 on failure, 1 otherwise.
  *
- * Initialize an array of solution field: set dimension, types and number of
- * data.
  * To use to initialize an array of solution fields (not used by Mmg itself).
  *
  * \remark Fortran interface:
@@ -308,17 +316,19 @@ LIBMMGS_EXPORT int  MMGS_Set_inputParamName(MMG5_pMesh mesh, const char* fparami
  *
  */
  LIBMMGS_EXPORT int  MMGS_Set_solSize(MMG5_pMesh mesh, MMG5_pSol sol, int typEntity, MMG5_int np, int typSol);
+
 /**
+ * \brief Initialize an array of solution fields defined at vertices: set
+ * dimension, types and number of fields.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to an allocatable sol structure.
  * \param nsols number of solutions per entity
  * \param nentities number of entities
  * \param typSol    Array of size nsol listing the type of the solutions
- *                  (scalar, vectorial...).
+ *                  (scalar, vectorial, ..., see \ref MMG5_type for possible values)
  * \return 0 on failure, 1 otherwise.
  *
- * Initialize an array of solution field defined at vertices: set dimension,
- * types and number of data.
  * To use to initialize an array of solution fields (not used by Mmg itself).
  *
  * \remark Fortran interface:
@@ -333,16 +343,19 @@ LIBMMGS_EXPORT int  MMGS_Set_inputParamName(MMG5_pMesh mesh, const char* fparami
  */
 LIBMMGS_EXPORT int MMGS_Set_solsAtVerticesSize(MMG5_pMesh mesh, MMG5_pSol *sol,int nsols,
                                                MMG5_int nentities, int *typSol);
+
 /**
+ * \brief Set the number of vertices, triangles and edges of the
+ * mesh and allocate the associated tables.
+ *
  * \param mesh pointer to the mesh structure.
  * \param np number of vertices.
  * \param nt number of triangles.
  * \param na number of edges.
  * \return 0 on failure, 1 otherwise.
  *
- * Set the number of vertices, triangles and edges of the
- * mesh and allocate the associated tables. If call twice, reset the
- * whole mesh to realloc it at the new size
+ * If called again, this function resets the
+ * whole mesh to reallocate it at the new size
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_MESHSIZE(mesh,np,nt,na,retval)\n
@@ -354,18 +367,21 @@ LIBMMGS_EXPORT int MMGS_Set_solsAtVerticesSize(MMG5_pMesh mesh, MMG5_pSol *sol,i
  */
 LIBMMGS_EXPORT int  MMGS_Set_meshSize(MMG5_pMesh mesh, MMG5_int np, MMG5_int nt, MMG5_int na);
 
-/* init structure datas */
+/* init structure data */
 /**
+ * \brief Set the coordinates of a single vertex.
+ *
  * \param mesh pointer to the mesh structure.
- * \param c0 coordinate of the point along the first dimension.
- * \param c1 coordinate of the point along the second dimension.
- * \param c2 coordinate of the point along the third dimension.
- * \param ref point reference.
- * \param pos position of the point in the mesh.
+ * \param c0 coordinate of the vertex along the first dimension.
+ * \param c1 coordinate of the vertex along the second dimension.
+ * \param c2 coordinate of the vertex along the third dimension.
+ * \param ref vertex reference.
+ * \param pos position of the vertex in the mesh.
  * \return 1.
  *
- * Set vertex of coordinates \a c0, \a c1,\a c2 and reference \a ref
- * at position \a pos in mesh structure (\a pos from 1 to nb_vertices included).
+ * \brief Set vertex coordinates \a c0, \a c1,\a c2 and reference \a ref at
+ * position \a pos in the mesh structure (\a pos from 1 to the number of
+ * vertices included).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_VERTEX(mesh,c0,c1,c2,ref,pos,retval)\n
@@ -377,17 +393,17 @@ LIBMMGS_EXPORT int  MMGS_Set_meshSize(MMG5_pMesh mesh, MMG5_int np, MMG5_int nt,
  *
  */
 LIBMMGS_EXPORT int  MMGS_Set_vertex(MMG5_pMesh mesh, double c0, double c1,
-                     double c2, MMG5_int ref,MMG5_int pos);
+                     double c2, MMG5_int ref, MMG5_int pos);
+
 /**
- * \param mesh pointer to the mesh structure.
- * \param vertices table of the points coor.
- * The coordinates of the \f$i^{th}\f$ point are stored in
- * vertices[(i-1)*3]\@3.
- * \param refs table of points references.
- * The ref of the \f$i^th\f$ point is stored in refs[i-1].
- * \return 1.
+ * \brief Set the coordinates and references of all vertices in a mesh
  *
- * Set vertices coordinates and references in mesh structure
+ * \param mesh pointer to the mesh structure.
+ * \param vertices array of vertex coordinates in the order
+ * \f$[x_1, y_1, z_1, x_2, \ldots, z_N]\f$ where \f$N\f$ is the number of vertices.
+ * \param refs array of references.
+ * The reference of vertex \f$i\f$ is stored in refs[\f$i-1\f$].
+ * \return 1.
  *
  * \remark Fortran interface: (commentated in order to allow to pass
  * \%val(0) instead of the refs array)
@@ -400,7 +416,10 @@ LIBMMGS_EXPORT int  MMGS_Set_vertex(MMG5_pMesh mesh, double c0, double c1,
  *
  */
  LIBMMGS_EXPORT int  MMGS_Set_vertices(MMG5_pMesh mesh, double *vertices,MMG5_int *refs);
+
 /**
+ * \brief Set the coordinates and reference of a single triangle.
+ *
  * \param mesh pointer to the mesh structure.
  * \param v0 first vertex of triangle.
  * \param v1 second vertex of triangle.
@@ -409,8 +428,9 @@ LIBMMGS_EXPORT int  MMGS_Set_vertex(MMG5_pMesh mesh, double c0, double c1,
  * \param pos triangle position in the mesh.
  * \return 0 on failure, 1 otherwise.
  *
- * Set triangle of vertices \a v0, \a v1, \a v2 and reference \a ref
- * at position \a pos in mesh structure.(\a pos from 1 to nb_triangles included).
+ * This function sets a triangle with vertices \a v0, \a v1, \a v2 and reference
+ * \a ref at position \a pos in the mesh structure (\a pos from 1 to the number
+ * of triangles included).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_TRIANGLE(mesh,v0,v1,v2,ref,pos,retval)\n
@@ -422,15 +442,16 @@ LIBMMGS_EXPORT int  MMGS_Set_vertex(MMG5_pMesh mesh, double c0, double c1,
  */
 LIBMMGS_EXPORT int  MMGS_Set_triangle(MMG5_pMesh mesh, MMG5_int v0, MMG5_int v1,
                                       MMG5_int v2, MMG5_int ref,MMG5_int pos);
+
 /**
- * \param mesh pointer to the mesh structure.
- * \param tria pointer to the table of the triangles vertices
- * Vertices of the \f$i^{th}\f$ triangles are stored in tria[(i-1)*3]\@3.
- * \param refs pointer to the table of the triangle references.
- * refs[i-1] is the ref of the \f$i^{th}\f$ tria.
- * \return 0 on failure, 1 otherwise.
+ * \brief Set the vertices and references of all triangles in the mesh.
  *
- * Set vertices and references of the mesh triangles.
+ * \param mesh pointer to the mesh structure.
+ * \param tria pointer to an array of vertex numbers
+ * Vertices of the \f$i^{th}\f$ triangles are stored in tria[(i-1)*3]\@3.
+ * \param refs pointer to an array of triangle references.
+ * refs[i-1] is the reference of the \f$i^{th}\f$ triangle.
+ * \return 0 on failure, 1 otherwise.
  *
  * \remark Fortran interface: (commentated in order to allow to pass
  * \%val(0) instead of the refs array)
@@ -442,7 +463,10 @@ LIBMMGS_EXPORT int  MMGS_Set_triangle(MMG5_pMesh mesh, MMG5_int v0, MMG5_int v1,
  *
  */
   LIBMMGS_EXPORT int  MMGS_Set_triangles(MMG5_pMesh mesh, MMG5_int *tria, MMG5_int *refs);
+
 /**
+ * \brief Set the vertices and reference of one edge in the mesh.
+ *
  * \param mesh pointer to the mesh structure.
  * \param v0 first extremity of the edge.
  * \param v1 second extremity of the edge.
@@ -450,8 +474,8 @@ LIBMMGS_EXPORT int  MMGS_Set_triangle(MMG5_pMesh mesh, MMG5_int v0, MMG5_int v1,
  * \param pos edge position in the mesh.
  * \return 0 on failure, 1 otherwise.
  *
- * Set edges of extremities \a v0, \a v1 and reference \a ref at
- * position \a pos in mesh structure (\a pos from 1 to nb_edges included).
+ * Assigns vertices \a v0, \a v1 and reference \a ref to the edge at position \a
+ * pos in the mesh structure (\a pos from 1 to the number of edges included).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_EDGE(mesh,v0,v1,ref,pos,retval)\n
@@ -462,12 +486,16 @@ LIBMMGS_EXPORT int  MMGS_Set_triangle(MMG5_pMesh mesh, MMG5_int v0, MMG5_int v1,
  *
  */
 LIBMMGS_EXPORT int  MMGS_Set_edge(MMG5_pMesh mesh, MMG5_int v0, MMG5_int v1, MMG5_int ref,MMG5_int pos);
+
 /**
+ * \brief Assign the "corner" attribute to a vertex.
+ *
  * \param mesh pointer to the mesh structure.
- * \param k vertex index.
+ * \param k vertex number.
  * \return 1.
  *
- * Set corner at point \a pos (\a pos from 1 to nb_vertices included).
+ * This function sets the corner attribute at vertex \a pos (\a pos from 1 to
+ * the number of vertices included).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_CORNER(mesh,k,retval)\n
@@ -478,12 +506,16 @@ LIBMMGS_EXPORT int  MMGS_Set_edge(MMG5_pMesh mesh, MMG5_int v0, MMG5_int v1, MMG
  *
  */
 LIBMMGS_EXPORT int  MMGS_Set_corner(MMG5_pMesh mesh, MMG5_int k);
+
 /**
+ * \brief Remove the "corner" attribute from a vertex.
+ *
  * \param mesh pointer to the mesh structure.
- * \param k vertex index.
+ * \param k vertex number.
  * \return 1.
  *
- * Remove corner attribute at point \a pos (from 1 to nb_vertices included).
+ * This function removes the corner attribute from vertex \a pos (from 1 to the
+ * number of vertices included).
  *
  * \remark Fortran interface
  *
@@ -495,12 +527,16 @@ LIBMMGS_EXPORT int  MMGS_Set_corner(MMG5_pMesh mesh, MMG5_int k);
  *
  */
 LIBMMGS_EXPORT int  MMGS_Unset_corner(MMG5_pMesh mesh, MMG5_int k);
+
 /**
+ * \brief Assign the "required" attribute to a vertex.
+ *
  * \param mesh pointer to the mesh structure.
- * \param k vertex index.
+ * \param k vertex number.
  * \return 1.
  *
- * Set point \a k as required.
+ * This function sets the required attribute at vertex \a k.
+ * Vertices with this attribute will not be modified by the remesher.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_REQUIREDVERTEX(mesh,k,retval)\n
@@ -511,12 +547,15 @@ LIBMMGS_EXPORT int  MMGS_Unset_corner(MMG5_pMesh mesh, MMG5_int k);
  *
  */
  LIBMMGS_EXPORT int  MMGS_Set_requiredVertex(MMG5_pMesh mesh, MMG5_int k);
+
 /**
+ * \brief Remove the "required" attribute from a vertex.
+ *
  * \param mesh pointer to the mesh structure.
- * \param k vertex index.
+ * \param k vertex number.
  * \return 1.
  *
- * Remove required attribute from point \a k.
+ * This function removes the required attribute from vertex \a k.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_UNSET_REQUIREDVERTEX(mesh,k,retval)\n
@@ -529,11 +568,13 @@ LIBMMGS_EXPORT int  MMGS_Unset_corner(MMG5_pMesh mesh, MMG5_int k);
   LIBMMGS_EXPORT int  MMGS_Unset_requiredVertex(MMG5_pMesh mesh, MMG5_int k);
 
 /**
+ * \brief Assign the "required" attribute to a triangle.
+ *
  * \param mesh pointer to the mesh structure.
  * \param k triangle index.
  * \return 1.
  *
- * Set triangle \a k as required.
+ * This function sets the required attribute at triangle \a k.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_REQUIREDTRIANGLE(mesh,k,retval)\n
@@ -546,11 +587,13 @@ LIBMMGS_EXPORT int  MMGS_Unset_corner(MMG5_pMesh mesh, MMG5_int k);
 LIBMMGS_EXPORT int  MMGS_Set_requiredTriangle(MMG5_pMesh mesh, MMG5_int k);
 
 /**
+ * \brief Remove the "required" attribute from a vertex.
+ *
  * \param mesh pointer to the mesh structure.
  * \param k triangle index.
  * \return 1.
  *
- * Remove required attribute from triangle \a k.
+ * This function removes the required attribute from triangle \a k.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_UNSET_REQUIREDTRIANGLE(mesh,k,retval)\n
@@ -563,11 +606,14 @@ LIBMMGS_EXPORT int  MMGS_Set_requiredTriangle(MMG5_pMesh mesh, MMG5_int k);
  LIBMMGS_EXPORT int  MMGS_Unset_requiredTriangle(MMG5_pMesh mesh, MMG5_int k);
 
 /**
+ * \brief Assign the "ridge" attribute to an edge.
+ *
  * \param mesh pointer to the mesh structure.
  * \param k edge index.
  * \return 1.
  *
- * Set ridge at edge \a k.
+ * This function gives the ridge attribute to edge \a k. This influences how
+ * this edge is treated by the remesher.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_RIDGE(mesh,k,retval)\n
@@ -580,11 +626,13 @@ LIBMMGS_EXPORT int  MMGS_Set_requiredTriangle(MMG5_pMesh mesh, MMG5_int k);
 LIBMMGS_EXPORT int  MMGS_Set_ridge(MMG5_pMesh mesh, MMG5_int k);
 
 /**
+ * \brief Remove the "ridge" attribute from an edge.
+ *
  * \param mesh pointer to the mesh structure.
  * \param k edge index.
  * \return 1.
  *
- * Remove ridge attribute at edge \a k.
+ * This function removes the ridge attribute from edge \a k.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_UNSET_RIDGE(mesh,k,retval)\n
@@ -597,11 +645,14 @@ LIBMMGS_EXPORT int  MMGS_Set_ridge(MMG5_pMesh mesh, MMG5_int k);
 LIBMMGS_EXPORT int  MMGS_Unset_ridge(MMG5_pMesh mesh, MMG5_int k);
 
 /**
+ * \brief Assign the "required" attribute to an edge.
+ *
  * \param mesh pointer to the mesh structure.
  * \param k edge index.
  * \return 1.
  *
- * Set edge \a k as required.
+ * This function makes edge \a k a required edge. Required edges will not be
+ * modified by the remesher.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_REQUIREDEDGE(mesh,k,retval)\n
@@ -614,11 +665,13 @@ LIBMMGS_EXPORT int  MMGS_Unset_ridge(MMG5_pMesh mesh, MMG5_int k);
 LIBMMGS_EXPORT int  MMGS_Set_requiredEdge(MMG5_pMesh mesh, MMG5_int k);
 
 /**
+ * \brief Remove the "required" attribute from an edge.
+ *
  * \param mesh pointer to the mesh structure.
  * \param k edge index.
  * \return 1.
  *
- * Remove required attribute from edge \a k.
+ * This function removes the "required" attribute from edge \a k.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_UNSET_REQUIREDEDGE(mesh,k,retval)\n
@@ -631,13 +684,15 @@ LIBMMGS_EXPORT int  MMGS_Set_requiredEdge(MMG5_pMesh mesh, MMG5_int k);
   LIBMMGS_EXPORT int  MMGS_Unset_requiredEdge(MMG5_pMesh mesh, MMG5_int k);
 
 /**
- * \param mesh pointer to the mesh structure.
- * \param edges pointer to the array of edges.
- * Vertices of the \f$i^{th}\f$ edge are stored in edge[(i-1)*2]\@2.
- * \param refs edges references. refs[i-1] is the ref of the \f$i^{th}\f$ edge.
- * \return 0 on failure, 1 otherwise.
+ * \brief Set the vertices and references of all edges in a mesh.
  *
- * Set vertices and references of the mesh edges.
+ * \param mesh pointer to the mesh structure.
+ * \param edges pointer to an array of edges.
+ *              The vertices of edge i should be given in
+ *              edges[(i-1)*2] and edges[(i-1)*2+1].
+ * \param refs pointer to an array of references.
+ *             refs[i-1] is the reference of edge i.
+ * \return 0 on failure, 1 otherwise.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_EDGES(mesh,edges,refs,retval)\n
@@ -648,16 +703,17 @@ LIBMMGS_EXPORT int  MMGS_Set_requiredEdge(MMG5_pMesh mesh, MMG5_int k);
  *
  */
  LIBMMGS_EXPORT int MMGS_Set_edges(MMG5_pMesh mesh, MMG5_int *edges, MMG5_int* refs);
+
 /**
+ * \brief Get vertices, references and attributes of all edges in the mesh.
+ *
  * \param mesh pointer to the mesh structure.
- * \param edges pointer to the array of edges.
- * Vertices of the \f$i^{th}\f$ edge are stored in edge[(i-1)*2]\@2.
+ * \param edges pointer to an array of edges.
+ *   The vertices of edge i are stored in edges[(i-1)*2] and edges[(i-1)*2+1].
  * \param refs edges references. refs[i-1] is the ref of the \f$i^{th}\f$ edge.
  * \param areRidges 1 if the edge is a ridge, 0 otherwise.
  * \param areRequired 1 if the edge is required, 0 otherwise.
  * \return 0 on failure, 1 otherwise.
- *
- * Get vertices and references of the mesh edges.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_EDGES(mesh,edges,refs,areRidges,areRequired,retval)\n
@@ -672,15 +728,17 @@ LIBMMGS_EXPORT int  MMGS_Set_requiredEdge(MMG5_pMesh mesh, MMG5_int k);
                                    int *areRidges,int *areRequired);
 
 /**
+ * \brief Set the normal orientation at a single vertex.
+ *
  * \param mesh pointer to the mesh structure.
- * \param k point index
- * \param n0 x componant of the normal at point \a k.
- * \param n1 y componant of the normal at point \a k.
- * \param n2 z componant of the normal at point \a k.
+ * \param k vertex index
+ * \param n0 x componant of the normal at vertex \a k.
+ * \param n1 y componant of the normal at vertex \a k.
+ * \param n2 z componant of the normal at vertex \a k.
  *
  * \return 1 on success.
  *
- * Set normals (n0,n1,n2) at point \a k.
+ * Set normal (n0,n1,n2) at vertex \a k.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_NORMALATVERTEX(mesh,k,n0,n1,n2,retval)\n
@@ -694,12 +752,12 @@ LIBMMGS_EXPORT int  MMGS_Set_requiredEdge(MMG5_pMesh mesh, MMG5_int k);
 LIBMMGS_EXPORT int  MMGS_Set_normalAtVertex(MMG5_pMesh mesh, MMG5_int k, double n0, double n1, double n2) ;
 
 /**
+ * \brief Get the quality measure of a triangle.
+ *
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure.
  * \param k index of the triangle for which we want to get the quality.
- * \return the computed quality or 0. on failure.
- *
- * Get quality of triangles \a k.
+ * \return the computed quality or 0 on failure.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_TRIANGLEQUALITY(mesh,met,k,retval)\n
@@ -709,16 +767,18 @@ LIBMMGS_EXPORT int  MMGS_Set_normalAtVertex(MMG5_pMesh mesh, MMG5_int k, double 
  * >   END SUBROUTINE\n
  *
  */
-  double MMGS_Get_triangleQuality(MMG5_pMesh mesh,MMG5_pSol met, MMG5_int k);
+  double MMGS_Get_triangleQuality(MMG5_pMesh mesh, MMG5_pSol met, MMG5_int k);
 
 /**
+ * \brief Set a single element of a scalar solution structure.
+ *
  * \param met pointer to the sol structure.
  * \param s solution scalar value.
  * \param pos position of the solution in the mesh.
  * \return 0 on failure, 1 otherwise.
  *
- * Set scalar value \a s at position \a pos in solution structure
- * (\a pos from 1 to nb_vertices included).
+ * This function sets the scalar value \a s at position \a pos in the solution
+ * structure (\a pos from 1 to the number of vertices included).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_SCALARSOL(met,s,pos,retval)\n
@@ -729,14 +789,15 @@ LIBMMGS_EXPORT int  MMGS_Set_normalAtVertex(MMG5_pMesh mesh, MMG5_int k, double 
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int  MMGS_Set_scalarSol(MMG5_pSol met, double s,MMG5_int pos);
+LIBMMGS_EXPORT int  MMGS_Set_scalarSol(MMG5_pSol met, double s, MMG5_int pos);
+
 /**
- * \param met pointer to the sol structure.
- * \param s table of the scalar solutions values.
- * s[i-1] is the solution at vertex i.
- * \return 0 on failure, 1 otherwise.
+ * \brief Set the values of all elements of a scalar solution structure.
  *
- * Set scalar solutions at mesh vertices.
+ * \param met pointer to the sol structure.
+ * \param s array of scalar solutions values.
+ *  s[i-1] is the solution at vertex i.
+ * \return 0 on failure, 1 otherwise.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_SCALARSOLS(met,s,retval)\n
@@ -747,7 +808,10 @@ LIBMMGS_EXPORT int  MMGS_Set_scalarSol(MMG5_pSol met, double s,MMG5_int pos);
  *
  */
 LIBMMGS_EXPORT int  MMGS_Set_scalarSols(MMG5_pSol met, double *s);
+
 /**
+ * \brief Set a single element of a vector solution structure.
+ *
  * \param met pointer to the sol structure.
  * \param vx x value of the vectorial solution.
  * \param vy y value of the vectorial solution.
@@ -755,9 +819,9 @@ LIBMMGS_EXPORT int  MMGS_Set_scalarSols(MMG5_pSol met, double *s);
  * \param pos position of the solution in the mesh (begin to 1).
  * \return 0 on failure, 1 otherwise.
  *
- * Set vectorial value \f$(v_x,v_y,v_z)\f$ at position \a pos in solution
- * structure.
- * (\a pos from 1 to nb_vertices included).
+ * This function sets the vectorial value \f$(v_x,v_y,v_z)\f$ at position \a pos
+ * in the solution structure (\a pos from 1 to the number of vertices
+ * included).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_VECTORSOL(met,vx,vy,vz,pos,retval)\n
@@ -769,13 +833,17 @@ LIBMMGS_EXPORT int  MMGS_Set_scalarSols(MMG5_pSol met, double *s);
  *
  */
 LIBMMGS_EXPORT int MMGS_Set_vectorSol(MMG5_pSol met, double vx,double vy, double vz, MMG5_int pos);
+
 /**
+ * \brief Set all elements of a vector solution structure.
+ *
  * \param met pointer to the sol structure.
- * \param sols table of the vectorial solutions
+ * \param sols array of vectorial solutions
  * sols[3*(i-1)]\@3 is the solution at vertex i
  * \return 0 on failure, 1 otherwise.
  *
- * Set vectorial solutions at mesh vertices
+ * This function sets a vector-valued solution at each element of solution
+ * structure.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_VECTORSOLS(met,sols,retval)\n
@@ -786,7 +854,10 @@ LIBMMGS_EXPORT int MMGS_Set_vectorSol(MMG5_pSol met, double vx,double vy, double
  *
  */
 LIBMMGS_EXPORT int MMGS_Set_vectorSols(MMG5_pSol met, double *sols);
+
 /**
+ * \brief Set a single element of a tensor solution structure.
+ *
  * \param met pointer to the sol structure.
  * \param m11 value of the tensorial solution at position (1,1) in the tensor.
  * \param m12 value of the tensorial solution at position (1,2) in the tensor.
@@ -797,9 +868,8 @@ LIBMMGS_EXPORT int MMGS_Set_vectorSols(MMG5_pSol met, double *sols);
  * \param pos position of the solution in the mesh (begin to 1).
  * \return 0 on failure, 1 otherwise.
  *
- * Set tensorial values at position \a pos in solution
- * structure.
- * (\a pos from 1 to nb_vertices included).
+ * This function sets a tensor value at position \a pos in solution
+ * structure (\a pos from 1 to the number of vertices included).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_TENSORSOL(met,m11,m12,m13,m22,m23,m33,pos,retval)\n
@@ -812,13 +882,14 @@ LIBMMGS_EXPORT int MMGS_Set_vectorSols(MMG5_pSol met, double *sols);
  */
 LIBMMGS_EXPORT int MMGS_Set_tensorSol(MMG5_pSol met, double m11,double m12, double m13,
                                       double m22,double m23, double m33, MMG5_int pos);
+
 /**
+ * \brief Set all elements of a tensor solution structure.
+ *
  * \param met pointer to the sol structure.
- * \param sols table of the tensorial solutions.
+ * \param sols array of tensorial solutions.
  * sols[6*(i-1)]\@6 is the solution at vertex i
  * \return 0 on failure, 1 otherwise.
- *
- * Set tensorial values by array.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_TENSORSOLS(met,sols,retval)\n
@@ -829,7 +900,10 @@ LIBMMGS_EXPORT int MMGS_Set_tensorSol(MMG5_pSol met, double m11,double m12, doub
  *
  */
 LIBMMGS_EXPORT int MMGS_Set_tensorSols(MMG5_pSol met, double *sols);
+
 /**
+ * \brief Set a single element of one out of multiple solution fields that are defined on vertices.
+ *
  * \param sol pointer to the array of solutions
  * \param i position of the solution field that we want to set.
  * \param s solution(s) at mesh vertex \a pos.
@@ -837,8 +911,9 @@ LIBMMGS_EXPORT int MMGS_Set_tensorSols(MMG5_pSol met, double *sols);
  *
  * \return 0 on failure, 1 otherwise.
  *
- * Set values of the solution at the ith field of the solution array and at
- * position \pos (\a pos from 1 to nb_vertices included and i from 1 to nb_sols).
+ * Set values of the solution at field \a i of the solution array and at
+ * position \pos (\a pos from 1 to the number of vertices included and i from 1
+ * to the number of solutions). The type of solution is determined from \a sol.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_ITHSOL_INSOLSATVERTICES(sol,i,s,pos,retval)\n
@@ -850,18 +925,21 @@ LIBMMGS_EXPORT int MMGS_Set_tensorSols(MMG5_pSol met, double *sols);
  * >   END SUBROUTINE\n
  *
  */
-  LIBMMGS_EXPORT int  MMGS_Set_ithSol_inSolsAtVertices(MMG5_pSol sol,int i, double* s,MMG5_int pos);
+  LIBMMGS_EXPORT int  MMGS_Set_ithSol_inSolsAtVertices(MMG5_pSol sol, int i, double* s, MMG5_int pos);
+
 /**
+ * \brief Set all elements of one out of multiple solution fields that are defined on vertices.
+ *
  * \param sol pointer to the array of solutions
  * \param i position of the solution field that we want to set.
- * \param s table of the solutions at mesh vertices. The solution at vertex \a k
+ * \param s array of solutions at mesh vertices. The solution at vertex \a k
  * is given by s[k-1] for a scalar sol, s[3*(k-1)]\@3 for a vectorial solution
  * and s[6*(k-1)]\@6 for a tensor solution.
  *
  * \return 0 on failure, 1 otherwise.
  *
- * Set values of the solution at the ith field of the solution array (\a i from
- * 1 to nb_sols).
+ * Set values of the solution at field \a i of the solution array (\a i from
+ * 1 to the number of solutions). The type of solution is determined from \a sol.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_ITHSOLS_INSOLSATVERTICES(sol,i,s,retval)\n
@@ -876,12 +954,15 @@ LIBMMGS_EXPORT int MMGS_Set_tensorSols(MMG5_pSol met, double *sols);
 
 /* check init */
 /**
+ * \brief Check if the number of given entities match with mesh and sol size and
+ * check mesh data.
+ *
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the sol structure.
  * \return 0 on failure, 1 otherwise.
  *
- * Check if the number of given entities match with mesh and sol size
- * (not mandatory) and check mesh datas.
+ * This function checks if the number of given entities match with mesh and sol
+ * size and checks the mesh data. Use of this function is not mandatory.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_CHK_MESHDATA(mesh,met,retval)\n
@@ -894,13 +975,16 @@ LIBMMGS_EXPORT int MMGS_Chk_meshData(MMG5_pMesh mesh, MMG5_pSol met);
 
 /** functions to set parameters */
 /**
+ * \brief set an integer parameter of the remesher
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure (unused).
- * \param iparam integer parameter to set (see \ref MMGS_Param structure).
+ * \param iparam integer parameter to set (see \ref MMGS_Param for a
+ *   list of parameters that can be set).
  * \param val value for the parameter.
  * \return 0 on failure, 1 otherwise.
  *
- * Set integer parameter \a iparam at value \a val.
+ * This function sets integer parameter \a iparam to value \a val.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_IPARAMETER(mesh,sol,iparam,val,retval)\n
@@ -913,14 +997,18 @@ LIBMMGS_EXPORT int MMGS_Chk_meshData(MMG5_pMesh mesh, MMG5_pSol met);
  *
  */
 LIBMMGS_EXPORT int  MMGS_Set_iparameter(MMG5_pMesh mesh,MMG5_pSol sol, int iparam, MMG5_int val);
+
 /**
+ * \brief set a real-valued parameter of the remesher
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure (unused).
- * \param dparam double parameter to set (see \ref MMGS_Param structure).
+ * \param dparam double parameter to set (see \ref MMGS_Param for a
+ *    list of parameters that can be set).
  * \param val value of the parameter.
  * \return 0 on failure, 1 otherwise.
  *
- * Set double parameter \a dparam at value \a val.
+ * This function sets the double parameter \a dparam to value \a val.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_DPARAMETER(mesh,sol,dparam,val,retval)\n
@@ -933,18 +1021,21 @@ LIBMMGS_EXPORT int  MMGS_Set_iparameter(MMG5_pMesh mesh,MMG5_pSol sol, int ipara
  *
  */
 LIBMMGS_EXPORT int  MMGS_Set_dparameter(MMG5_pMesh mesh,MMG5_pSol sol, int dparam, double val);
+
 /**
+ * \brief set a local parameter
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure.
  * \param typ type of entity (triangle, edge,...).
  * \param ref reference of the entity.
- * \param hmin minimal edge size.
- * \param hmax maximal edge size.
- * \param hausd value of the Hausdorff number.
+ * \param hmin minimal edge length.
+ * \param hmax maximal edge length.
+ * \param Hausdorff distance.
  * \return 0 on failure, 1 otherwise.
  *
- * Set local parameters: set the hausdorff value at \a hausd, the minmal edge
- * size value at \a hmin and the maximal edge size value at \a hmax for all
+ * Set local parameters: set the hausdorff distance at \a hausd, the minmal edge
+ * length at \a hmin and the maximal edge length at \a hmax for all
  * elements of type \a typ and reference \a ref.
  *
  * \remark Fortran interface:
@@ -961,15 +1052,21 @@ LIBMMGS_EXPORT int  MMGS_Set_localParameter(MMG5_pMesh mesh, MMG5_pSol sol, int 
                                             double hmin, double hmax, double hausd);
 
 /**
+ * \brief Set the reference mapping for the elements of reference
+ *  \a ref in level-set discretization mode.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure.
- * \param ref input tetra reference.
- * \param split MMG5_MMAT_NoSplit if the entity must not be splitted, MMG5_MMAT_Split otherwise
+ * \param ref input triangle reference.
+ * \param split MMG5_MMAT_NoSplit if the entity must not be split, MMG5_MMAT_Split otherwise
  * \param rmin reference for the negative side after LS discretization
  * \param rplus reference for the positive side after LS discretization
  * \return 0 on failure, 1 otherwise.
  *
- * Set the reference mapping for the elements of ref \a ref in ls discretization mode.
+ * With this function you can determine which references will be given to the
+ * triangles on both sides of the level set, after discretization. Negative and
+ * positive here refer to areas where the function is smaller or larger,
+ * respectively, than the isovalue of the level set.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_MULTIMAT(mesh,sol,ref,split,rmin,rplus,retval)\n
@@ -979,23 +1076,20 @@ LIBMMGS_EXPORT int  MMGS_Set_localParameter(MMG5_pMesh mesh, MMG5_pSol sol, int 
  * >     INTEGER, INTENT(OUT)          :: retval\n
  * >   END SUBROUTINE\n
  *
- * With this function you can determine which references will be given to the
- * triangles on both sides of the level set, after discretization. Negative and
- * positive here refer to areas where the function is smaller or larger,
- * respectively, than the isovalue of the level set.
- *
  */
   LIBMMGS_EXPORT int  MMGS_Set_multiMat(MMG5_pMesh mesh, MMG5_pSol sol,MMG5_int ref,
                                         int split,MMG5_int rmin, MMG5_int rplus);
 
 /**
+ * \brief Set a new level-set base reference.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure.
  * \param br new level-set base reference.
  * \return 0 on failure, 1 otherwise.
  *
- * Set a new level-set base reference of ref \a br in ls discretization
- * mode. Based references are boundary conditions to which implicit domain can
+ * Set a new level-set base reference of ref \a br in level-set discretization
+ * mode. Base references are boundary conditions to which an implicit domain can
  * be attached. All implicit volumes that are not attached to listed base
  * references are deleted as spurious volumes by the \a rmc option.
  *
@@ -1009,15 +1103,15 @@ LIBMMGS_EXPORT int  MMGS_Set_localParameter(MMG5_pMesh mesh, MMG5_pSol sol, int 
  */
 LIBMMGS_EXPORT int  MMGS_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MMG5_int br);
 
-/** recover datas */
+/** recover data */
 /**
+ * \brief Get the number of vertices, triangles, and edges of the mesh.
+ *
  * \param mesh pointer to the mesh structure.
  * \param np pointer to the number of vertices.
  * \param nt pointer to the number of triangles.
  * \param na pointer to the number of edges.
  * \return 1.
- *
- * Get the number of vertices, triangles and edges of the mesh.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_MESHSIZE(mesh,np,nt,na,retval)\n
@@ -1028,15 +1122,17 @@ LIBMMGS_EXPORT int  MMGS_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MMG5
  *
  */
 LIBMMGS_EXPORT int  MMGS_Get_meshSize(MMG5_pMesh mesh, MMG5_int* np, MMG5_int* nt, MMG5_int* na);
+
 /**
+ * \brief Get the number of elements, dimension, and type of a solution.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure.
  * \param typEntity pointer to the type of entities to which solutions are applied.
- * \param np pointer to the number of solutions.
- * \param typSol pointer to the type of the solutions (scalar, vectorial...)
+ * \param np pointer to the number of elements in the solution.
+ * \param typSol pointer to the type of the solution (\ref MMG5_Scalar, \ref MMG5_Vector,
+ *    \ref MMG5_Tensor, \ref MMG5_Notype)
  * \return 1.
- *
- * Get the solution number, dimension and type.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_SOLSIZE(mesh,sol,typEntity,np,typSol,retval)\n
@@ -1049,17 +1145,18 @@ LIBMMGS_EXPORT int  MMGS_Get_meshSize(MMG5_pMesh mesh, MMG5_int* np, MMG5_int* n
  */
 LIBMMGS_EXPORT int  MMGS_Get_solSize(MMG5_pMesh mesh, MMG5_pSol sol, int* typEntity, MMG5_int* np,
                                      int* typSol);
+
 /**
+ * \brief Get the number of elements, type, and dimensions of several solutions defined on vertices.
+ *
  * \param mesh pointer to the mesh structure.
- * \param sol pointer to an array of sol structure.
+ * \param sol pointer to an array of sol structures.
  * \param nsols number of solutions per entity
  * \param nentities pointer to the number of entities.
  * \param typSol array of size MMG5_NSOL_MAX to store type of each solution
- * (scalar, vector..).
+ * (scalar, vectorial, ..., see \ref MMG5_type for possible values).
  *
  * \return 1.
- *
- * Get the solution number, dimension and type.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_SOLSATVERTICESSIZE(mesh,sol,nsols,nentities,typSol,retval)\n
@@ -1075,17 +1172,23 @@ LIBMMGS_EXPORT int  MMGS_Get_solSize(MMG5_pMesh mesh, MMG5_pSol sol, int* typEnt
                                                   MMG5_int* nentities,int* typSol);
 
 /**
+ * \brief Get the coordinates \a c0, \a c1,\a c2 and reference \a ref of the
+ * next vertex of \a mesh.
+ *
  * \param mesh pointer to the mesh structure.
- * \param c0 pointer to the coordinate of the point along the first dimension.
- * \param c1 pointer to the coordinate of the point along the second dimension.
- * \param c2 pointer to the coordinate of the point along the third dimension.
- * \param ref pointer to the point reference.
- * \param isCorner pointer to the flag saying if point is corner.
- * \param isRequired pointer to the flag saying if point is required.
+ * \param c0 pointer to the coordinate of the vertex along the first dimension.
+ * \param c1 pointer to the coordinate of the vertex along the second dimension.
+ * \param c2 pointer to the coordinate of the vertex along the third dimension.
+ * \param ref pointer to the vertex reference.
+ * \param isCorner pointer to the flag saying if the vertex is corner.
+ * \param isRequired pointer to the flag saying if the vertex is required.
  * \return 1.
  *
- * Get coordinates \a c0, \a c1,\a c2 and reference \a ref of next
- * vertex of mesh.
+ * This function retrieves the coordinates \a c0, \a c1,\a c2, reference \a ref,
+ * and attributes of the next vertex of a mesh. It is meant to be used in a loop
+ * over all vertices. When this function has been called as many times as there
+ * are vertices, the internal loop counter will be reset. To obtain data for a
+ * specific vertex, the \ref MMGS_GetByIdx_vertex function can be used instead.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_VERTEX(mesh,c0,c1,c2,ref,isCorner,isRequired,retval)\n
@@ -1099,19 +1202,22 @@ LIBMMGS_EXPORT int  MMGS_Get_solSize(MMG5_pMesh mesh, MMG5_pSol sol, int* typEnt
  */
 LIBMMGS_EXPORT int  MMGS_Get_vertex(MMG5_pMesh mesh, double* c0, double* c1, double* c2, MMG5_int* ref,
                                     int* isCorner, int* isRequired);
+
 /**
+ * \brief Get the coordinates and reference of a specific vertex in the mesh.
+ *
  * \param mesh pointer to the mesh structure.
- * \param c0 pointer to the coordinate of the point along the first dimension.
- * \param c1 pointer to the coordinate of the point along the second dimension.
- * \param c2 pointer to the coordinate of the point along the third dimension.
- * \param ref pointer to the point reference.
- * \param isCorner pointer to the flag saying if point is corner.
- * \param isRequired pointer to the flag saying if point is required.
- * \param idx index of point to get.
+ * \param c0 pointer to the coordinate of the vertex along the first dimension.
+ * \param c1 pointer to the coordinate of the vertex along the second dimension.
+ * \param c2 pointer to the coordinate of the vertex along the third dimension.
+ * \param ref pointer to the vertex reference.
+ * \param isCorner pointer to the flag saying if the vertex is corner.
+ * \param isRequired pointer to the flag saying if the vertex is required.
+ * \param idx index of vertex to get.
  * \return 1.
  *
- * Get coordinates \a c0, \a c1, \a c2 and reference \a ref of
- * vertex \a idx of mesh.
+ * This function retrieves the coordinates \a c0, \a c1, \a c2 and reference \a ref of
+ * vertex \a idx of mesh, as well as its "corner" and "required" attributes.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GETBYIDX_VERTEX(mesh,c0,c1,c2,ref,isCorner,isRequired,idx,retval)\n
@@ -1127,20 +1233,20 @@ LIBMMGS_EXPORT int  MMGS_Get_vertex(MMG5_pMesh mesh, double* c0, double* c1, dou
                                           int* isCorner, int* isRequired,MMG5_int idx);
 
 /**
- * \param mesh pointer to the mesh structure.
- * \param vertices pointer to the table of the points coordinates.
- * The coordinates of the \f$i^{th}\f$ point are stored in
- * vertices[(i-1)*3]\@3.
- * \param refs pointer to the table of the point references.
- * The ref of the \f$i^th\f$ point is stored in refs[i-1].
- * \param areCorners pointer to the table of the flags saying if
- * points are corners.
- * areCorners[i-1]=1 if the \f$i^{th}\f$ point is corner.
- * \param areRequired pointer to the table of flags saying if points
- * are required. areRequired[i-1]=1 if the \f$i^{th}\f$ point is required.
- * \return 1.
+ * \brief Get the coordinates, references and attributes of all vertices in the mesh.
  *
- * Get the coordinates and references of the mesh vertices.
+ * \param mesh pointer to the mesh structure.
+ * \param vertices pointer to the array of points coordinates.
+ * The coordinates of vertex \a i are stored in
+ * vertices[(i-1)*3]\@3.
+ * \param refs pointer to the array of vertex references.
+ * The ref of vertex \a i is stored in refs[i-1].
+ * \param areCorners pointer to the array of flags saying if
+ * points are corners.
+ * areCorners[i-1]=1 if vertex \a i is corner.
+ * \param areRequired pointer to the table of flags saying if points
+ * are required. areRequired[i-1]=1 if vertex \a i is required.
+ * \return 1.
  *
  * \remark Fortran interface: (commentated in order to allow to pass
  * \%val(0) instead of the refs,areCorners and areRequired arrays)
@@ -1156,17 +1262,23 @@ LIBMMGS_EXPORT int  MMGS_Get_vertex(MMG5_pMesh mesh, double* c0, double* c1, dou
  */
 LIBMMGS_EXPORT int  MMGS_Get_vertices(MMG5_pMesh mesh, double* vertices, MMG5_int* refs,
                                       int* areCorners, int* areRequired);
+
 /**
+ * \brief Get the vertices, reference, and required attribute of the next
+ * triangle in the mesh.
+ *
  * \param mesh pointer to the mesh structure.
- * \param v0 pointer to the first vertex of triangle.
- * \param v1 pointer to the second vertex of triangle.
- * \param v2 pointer to the third vertex of triangle.
+ * \param v0 pointer to the first vertex of the triangle.
+ * \param v1 pointer to the second vertex of the triangle.
+ * \param v2 pointer to the third vertex of the triangle.
  * \param ref pointer to the triangle reference.
- * \param isRequired pointer to the flag saying if triangle is required.
+ * \param isRequired pointer to the flag saying if the triangle is required.
  * \return 0 on failure, 1 otherwise.
  *
- * Get vertices \a v0,\a v1,\a v2 and reference \a ref of next
- * triangle of mesh.
+ * This function retrieves the vertices \a v0, \a v1, \a v2, reference \a ref,
+ * and required attribute \a isRequired of the next triangle of \a mesh. It is
+ * meant to be called in a loop over all triangles. When it has been called as
+ * many times as there are triangles, the internal loop counter will be reset.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_TRIANGLE(mesh,v0,v1,v2,ref,isRequired,retval)\n
@@ -1177,20 +1289,22 @@ LIBMMGS_EXPORT int  MMGS_Get_vertices(MMG5_pMesh mesh, double* vertices, MMG5_in
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int  MMGS_Get_triangle(MMG5_pMesh mesh, MMG5_int* v0, MMG5_int* v1, MMG5_int* v2, MMG5_int* ref,
-                                      int* isRequired);
+LIBMMGS_EXPORT int  MMGS_Get_triangle(MMG5_pMesh mesh, MMG5_int* v0, MMG5_int* v1, MMG5_int* v2,
+                                       MMG5_int* ref, int* isRequired);
+
 /**
+ * \brief Get the vertices, references, and required attributes of all triangles
+ * in the mesh.
+ *
  * \param mesh pointer to the mesh structure.
- * \param tria pointer to the table of the triangles vertices
- * Vertices of the \f$i^{th}\f$ triangles are stored in tria[(i-1)*3]\@3.
- * \param refs pointer to the table of the triangles references.
- * refs[i-1] is the ref of the \f$i^{th}\f$ tria.
- * \param areRequired pointer to table of the flags saying if triangles
- * are required. areRequired[i-1]=1 if the \f$i^{th}\f$ tria
+ * \param tria pointer to an array of vertices
+ * Vertices of triangle \a i are stored in tria[(i-1)*3]\@3.
+ * \param refs pointer to the array of triangles references.
+ * refs[i-1] is the ref of triangle \a i.
+ * \param areRequired pointer to an array of flags saying if triangles
+ * are required. areRequired[i-1]=1 if triangle \a i
  * is required.
  * \return 0 on failure, 1 otherwise.
- *
- * Get vertices and references of the mesh triangles.
  *
  * \remark Fortran interface: (commentated in order to allow to pass
  * \%val(0) instead of the refs and areRequired arrays)
@@ -1206,15 +1320,20 @@ LIBMMGS_EXPORT int  MMGS_Get_triangle(MMG5_pMesh mesh, MMG5_int* v0, MMG5_int* v
 LIBMMGS_EXPORT int  MMGS_Get_triangles(MMG5_pMesh mesh, MMG5_int* tria, MMG5_int* refs,
                                        int* areRequired);
 /**
+ * \brief Get the vertices, reference, and attributes of the next edge in the mesh.
+ *
  * \param mesh pointer to the mesh structure.
- * \param e0 pointer to the first extremity of the edge.
- * \param e1 pointer to the second  extremity of the edge.
+ * \param e0 pointer to the index of the first vertex of the edge.
+ * \param e1 pointer to the index of the second  vertex of the edge.
  * \param ref pointer to the edge reference.
  * \param isRidge pointer to the flag saying if the edge is ridge.
  * \param isRequired pointer to the flag saying if the edge is required.
  * \return 0 on failure, 1 otherwise.
  *
- * Get extremities \a e0, \a e1 and reference \a ref of next edge of mesh.
+ * This function retrieves the extremities \a e0, \a e1, reference \a ref, and
+ * attributes of the next edge of \a mesh. It is meant to be called in a loop
+ * over all edges. When it has been called as many times as there are edges in
+ * the mesh, the internal edge counter will be reset.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_EDGE(mesh,e0,e1,ref,isRidge,isRequired,retval)\n
@@ -1230,15 +1349,17 @@ LIBMMGS_EXPORT int  MMGS_Get_edge(MMG5_pMesh mesh, MMG5_int* e0, MMG5_int* e1, M
                                   int* isRidge, int* isRequired);
 
 /**
+ * \brief Get the normal orientation at an edge.
+ *
  * \param mesh pointer to the mesh structure.
- * \param k point index
- * \param n0 x componant of the normal at point \a k.
- * \param n1 y componant of the normal at point \a k.
- * \param n2 z componant of the normal at point \a k.
+ * \param k vertex number
+ * \param n0 x componant of the normal at vertex \a k.
+ * \param n1 y componant of the normal at vertex \a k.
+ * \param n2 z componant of the normal at vertex \a k.
  *
  * \return 1 on success.
  *
- * Get normals (n0,n1,n2) at point \a k.
+ * This function retrieves the normal (n0,n1,n2) at vertex \a k.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_NORMALATVERTEX(mesh,k,n0,n1,n2,retval)\n
@@ -1252,11 +1373,16 @@ LIBMMGS_EXPORT int  MMGS_Get_edge(MMG5_pMesh mesh, MMG5_int* e0, MMG5_int* e1, M
 LIBMMGS_EXPORT int  MMGS_Get_normalAtVertex(MMG5_pMesh mesh, MMG5_int k, double *n0, double *n1, double *n2) ;
 
 /**
+ * \brief Get the next element of a scalar solution structure.
+ *
  * \param met pointer to the sol structure.
  * \param s pointer to the scalar solution value.
  * \return 0 on failure, 1 otherwise.
  *
- * Get solution \a s of next vertex of mesh.
+ * This function retrieves the next element \a s of the solution field \a
+ * met. It is meant to be called in a loop over all elements. When it has been
+ * called as many times as there are elements in the solution, the internal loop
+ * counter will be reset.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_SCALARSOL(met,s,retval)\n
@@ -1267,13 +1393,14 @@ LIBMMGS_EXPORT int  MMGS_Get_normalAtVertex(MMG5_pMesh mesh, MMG5_int k, double 
  *
  */
 LIBMMGS_EXPORT int  MMGS_Get_scalarSol(MMG5_pSol met, double* s);
+
 /**
- * \param met pointer to the sol structure.
- * \param s table of the scalar solutions at mesh vertices. s[i-1] is
+ * \brief Get all elements of a scalar solution structure.
+ *
+ * \param met pointer to the solution structure.
+ * \param s array of scalar solutions at mesh vertices. s[i-1] is
  * the solution at vertex i.
  * \return 0 on failure, 1 otherwise.
- *
- * Get solutions at mesh vertices.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_SCALARSOLS(met,s,retval)\n
@@ -1284,14 +1411,20 @@ LIBMMGS_EXPORT int  MMGS_Get_scalarSol(MMG5_pSol met, double* s);
  *
  */
 LIBMMGS_EXPORT int  MMGS_Get_scalarSols(MMG5_pSol met, double* s);
+
 /**
+ * \brief Get the next element of a vector solution structure.
+ *
  * \param met pointer to the sol structure.
  * \param vx x value of the vectorial solution.
  * \param vy y value of the vectorial solution.
  * \param vz z value of the vectorial solution.
  * \return 0 on failure, 1 otherwise.
  *
- * Get vectorial solution \f$(v_x,v_y,vz)\f$ of next vertex of mesh.
+ * This function retrieves the next vector-valued element \f$(v_x,v_y,vz)\f$ of
+ * a solution field. It is meant to be called in a loop over all elements.  When
+ * it has been called as many times as there are elements in the solution, the
+ * internal loop counter will be reset.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_VECTORSOL(met,vx,vy,vz,retval)\n
@@ -1302,13 +1435,16 @@ LIBMMGS_EXPORT int  MMGS_Get_scalarSols(MMG5_pSol met, double* s);
  *
  */
 LIBMMGS_EXPORT int MMGS_Get_vectorSol(MMG5_pSol met, double* vx, double* vy, double* vz);
+
 /**
+ * \brief Get all elements of a vector solution structure.
+ *
  * \param met pointer to the sol structure.
- * \param sols table of the solutions at mesh vertices. sols[3*(i-1)]\@3 is
+ * \param sols array of solutions at mesh vertices. sols[3*(i-1)]\@3 is
  * the solution at vertex i.
  * \return 0 on failure, 1 otherwise.
  *
- * Get vectorial solutions at mesh vertices
+ * This function retrieves all elements of a vector-valued solution field.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_VECTORSOLS(met,sols,retval)\n
@@ -1319,7 +1455,10 @@ LIBMMGS_EXPORT int MMGS_Get_vectorSol(MMG5_pSol met, double* vx, double* vy, dou
  *
  */
 LIBMMGS_EXPORT int MMGS_Get_vectorSols(MMG5_pSol met, double* sols);
+
 /**
+ * \brief Get the next element of a tensor solution structure.
+ *
  * \param met pointer to the sol structure.
  * \param m11 pointer to the position (1,1) in the solution tensor.
  * \param m12 pointer to the position (1,2) in the solution tensor.
@@ -1329,7 +1468,11 @@ LIBMMGS_EXPORT int MMGS_Get_vectorSols(MMG5_pSol met, double* sols);
  * \param m33 pointer to the position (3,3) in the solution tensor.
  * \return 0 on failure, 1 otherwise.
  *
- * Get tensorial solution of next vertex of mesh.
+ * This function retrieves the next element
+ * \f$(m_{11},m_{12},m_{13},m_{22},m_{23},m_{33})\f$ of a tensor-valued solution
+ * field.  It is meant to be called in a loop over all vertices. When it has
+ * been called as many times as there are elements in the solution, the internal
+ * loop counter will be reset.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_TENSORSOL(met,m11,m12,m13,m22,m23,m33,retval)\n
@@ -1339,15 +1482,16 @@ LIBMMGS_EXPORT int MMGS_Get_vectorSols(MMG5_pSol met, double* sols);
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_Get_tensorSol(MMG5_pSol met, double *m11,double *m12, double *m13,
-                                      double *m22,double *m23, double *m33);
+LIBMMGS_EXPORT int MMGS_Get_tensorSol(MMG5_pSol met, double *m11, double *m12, double *m13,
+                                                     double *m22, double *m23, double *m33);
+
 /**
- * \param met pointer to the sol structure.
- * \param sols table of the solutions at mesh vertices.
- * sols[6*(i-1)]\@6 is the solution at vertex i.
- * \return 0 on failure, 1 otherwise.
+ * \brief Get all elements of a tensor solution field.
  *
- * Get tensorial solutions at mesh vertices.
+ * \param met pointer to the sol structure.
+ * \param sols array of solution values.
+ *   sols[6*(i-1)]\@6 is the solution at vertex i.
+ * \return 0 on failure, 1 otherwise.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_TENSORSOLS(met,sols,retval)\n
@@ -1358,16 +1502,21 @@ LIBMMGS_EXPORT int MMGS_Get_tensorSol(MMG5_pSol met, double *m11,double *m12, do
  *
  */
 LIBMMGS_EXPORT int MMGS_Get_tensorSols(MMG5_pSol met, double *sols);
+
 /**
+ * \brief Get one out of several solutions at a specific vertex.
+ *
  * \param sol pointer to the array of solutions
- * \param i position of the solution field that we want to set.
- * \param s solution(s) at mesh vertex \a pos.
+ * \param i position of the solution field that we want to get.
+ * \param s solution(s) at mesh vertex \a pos. The required size
+ *   of this array depends on the type of solution.
  * \param pos index of the vertex on which we get the solution.
  *
  * \return 0 on failure, 1 otherwise.
  *
- * Get values of the ith field of the solution array at vertex \a pos.
- * (\a pos from 1 to nb_vertices included and \a i from 1 to nb_sols).
+ * Get values of the ith field of the solution array at vertex \a pos.  (\a pos
+ * from 1 to the number of vertices included and \a i from 1 to the number of
+ * solutions).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_ITHSOL_INSOLSATVERTICES(sol,i,s,pos,retval)\n
@@ -1379,18 +1528,21 @@ LIBMMGS_EXPORT int MMGS_Get_tensorSols(MMG5_pSol met, double *sols);
  * >   END SUBROUTINE\n
  *
  */
- LIBMMGS_EXPORT int  MMGS_Get_ithSol_inSolsAtVertices(MMG5_pSol sol,int i, double* s,MMG5_int pos);
+ LIBMMGS_EXPORT int  MMGS_Get_ithSol_inSolsAtVertices(MMG5_pSol sol, int i, double* s, MMG5_int pos);
+
 /**
+ * \brief Get one out of several solutions at all vertices in the mesh.
+ *
  * \param sol pointer to the array of solutions
  * \param i position of the solution field that we want to get.
- * \param s table of the solutions at mesh vertices. The solution at vertex \a k
+ * \param s array of solutions at mesh vertices. The solution at vertex \a k
  * is given by s[k-1] for a scalar sol, s[3*(k-1)]\@3 for a vectorial solution
  * and s[6*(k-1)]\@6 for a tensor solution.
  *
  * \return 0 on failure, 1 otherwise.
  *
  * Get values of the solution at the ith field of the solution array.
- * (\a i from 1 to \a nb_sols).
+ * (\a i from 1 to \a the number of sols).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_ITHSOLS_INSOLSATVERTICES(sol,i,s,retval)\n
@@ -1401,13 +1553,16 @@ LIBMMGS_EXPORT int MMGS_Get_tensorSols(MMG5_pSol met, double *sols);
  * >   END SUBROUTINE\n
  *
  */
-  LIBMMGS_EXPORT int  MMGS_Get_ithSols_inSolsAtVertices(MMG5_pSol sol,int i, double* s);
+  LIBMMGS_EXPORT int  MMGS_Get_ithSols_inSolsAtVertices(MMG5_pSol sol, int i, double* s);
+
 /**
- * \param mesh pointer to the mesh structure.
- * \param iparam integer parameter to set (see \ref MMGS_Param structure).
- * \return The value of integer parameter.
+ * \brief Get the value of an integer parameter of the remesher.
  *
- * Get the value of integer parameter \a iparam.
+ * \param mesh pointer to the mesh structure.
+ * \param iparam integer parameter to get (see \ref MMGS_Param structure).
+ * \return The value of the parameter.
+ *
+ * This function retrieves the value of integer parameter \a iparam.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_GET_IPARAMETER(mesh,iparam,retval)\n
@@ -1421,11 +1576,11 @@ LIBMMGS_EXPORT int MMGS_Get_iparameter(MMG5_pMesh mesh, MMG5_int iparam);
 
 /* input/output functions */
 /**
+ * \brief Load a mesh (in .mesh/.mesb format) from file.
+ *
  * \param mesh pointer to the mesh structure.
  * \param filename name of the file to load.
  * \return 0 on failure, 1 otherwise.
- *
- * Read mesh data.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADMESH(mesh,filename,strlen0,retval)\n
@@ -1439,14 +1594,17 @@ LIBMMGS_EXPORT int MMGS_Get_iparameter(MMG5_pMesh mesh, MMG5_int iparam);
 LIBMMGS_EXPORT int  MMGS_loadMesh(MMG5_pMesh mesh, const char* filename);
 
 /**
+ * \brief Load a mesh and optionally a solution in VTP (VTK) format from file.
+ *
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure or the NULL pointer.
  * \param sol pointer to the level-set structure or the NULL pointer.
  * \param filename name of the file to load.
  * \return 0 on failure, 1 otherwise.
  *
- * Read a mesh and optionally one data field in VTK vtp file format (.vtp extension). We
- * read only low-order vertices, edges, triangles and quadrangles.
+ * This function reads a mesh and optionally one data field in VTK vtp file
+ * format (.vtp extension). We read only low-order vertices, edges, triangles
+ * and quadrangles.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADVTPMESH(mesh,met,sol,filename,strlen0,retval)\n
@@ -1457,8 +1615,11 @@ LIBMMGS_EXPORT int  MMGS_loadMesh(MMG5_pMesh mesh, const char* filename);
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_loadVtpMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,const char *filename);
+LIBMMGS_EXPORT int MMGS_loadVtpMesh(MMG5_pMesh mesh, MMG5_pSol met, MMG5_pSol sol, const char *filename);
+
 /**
+ * \brief Load a mesh and multiple solutions in VTP (VTK) format from file.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
  * \param filename name of the file to load.
@@ -1477,7 +1638,10 @@ LIBMMGS_EXPORT int MMGS_loadVtpMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,
  *
  */
 LIBMMGS_EXPORT int MMGS_loadVtpMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
+
 /**
+ * \brief Load a mesh and possibly data in VTU (VTK) format from file.
+ *
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure or the NULL pointer.
  * \param sol pointer to the level-set structure or the NULL pointer.
@@ -1499,6 +1663,8 @@ LIBMMGS_EXPORT int MMGS_loadVtpMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
 LIBMMGS_EXPORT int MMGS_loadVtuMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,const char *filename);
 
 /**
+ * \brief Load a mesh and multiple solutions in VTU (VTK) format from file.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
  * \param filename name of the file to load.
@@ -1519,6 +1685,8 @@ LIBMMGS_EXPORT int MMGS_loadVtuMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,
 LIBMMGS_EXPORT int MMGS_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
 
 /**
+ * \brief Load a mesh and possibly data in VTK format from file.
+ *
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure or the NULL pointer.
  * \param sol pointer to the level-set structure or the NULL pointer.
@@ -1540,6 +1708,8 @@ LIBMMGS_EXPORT int MMGS_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
 LIBMMGS_EXPORT int MMGS_loadVtkMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,const char *filename);
 
 /**
+ * \brief Load a mesh and multiple solutions in VTK format from file.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
  * \param filename name of the file to load.
@@ -1560,6 +1730,8 @@ LIBMMGS_EXPORT int MMGS_loadVtkMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,
 LIBMMGS_EXPORT int MMGS_loadVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
 
 /**
+ * \brief Load a mesh and possibly a solution in .msh format from file.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
  * \param filename name of the file to load.
@@ -1580,6 +1752,8 @@ LIBMMGS_EXPORT int MMGS_loadVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
 LIBMMGS_EXPORT int MMGS_loadMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename);
 
 /**
+ * \brief Load a mesh and all data from a file in MSH format.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to a list of solution structures.
  * \param filename name of the file to load.
@@ -1600,13 +1774,13 @@ LIBMMGS_EXPORT int MMGS_loadMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
 LIBMMGS_EXPORT int MMGS_loadMshMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
 
 /**
+ * \brief Load a mesh and all data from a file. The format will be guessed from the filename extension.
+ *
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure or the NULL pointer.
  * \param sol pointer to the level-set structure or the NULL pointer.
  * \param filename name of the file to load.
  * \return 0 on failure, 1 otherwise.
- *
- * Read mesh data.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADGENERICMESH(mesh,met,sol,filename,strlen0,retval)\n
@@ -1620,11 +1794,14 @@ LIBMMGS_EXPORT int MMGS_loadMshMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
 LIBMMGS_EXPORT int MMGS_loadGenericMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol,const char *filename);
 
 /**
+ * \brief Save a mesh in .mesh or .meshb format.
+ *
  * \param mesh pointer to the mesh structure.
  * \param filename name of the file to load.
  * \return 0 on failure, 1 otherwise.
  *
- * Save mesh data.
+ * This function saves a mesh in .mesh or .meshb format (depending on the
+ * filename extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEMESH(mesh,filename,strlen0,retval)\n
@@ -1638,13 +1815,15 @@ LIBMMGS_EXPORT int MMGS_loadGenericMesh(MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol 
 LIBMMGS_EXPORT int  MMGS_saveMesh(MMG5_pMesh mesh, const char *filename);
 
 /**
+ * \brief Write mesh and optionally one data field in MSH  file format (.msh extension).
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
  * \param filename name of the file to load.
  * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and optionally one data field at MSH  file format (.msh extension).
- * Save file at ASCII format for .msh extension, at binary format for .mshb one.
+ * The file is saved in ASCII format for .msh extension, an in binary format for
+ * a .mshb extension.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEMSHMESH(mesh,sol,filename,strlen0,retval)\n
@@ -1658,15 +1837,18 @@ LIBMMGS_EXPORT int  MMGS_saveMesh(MMG5_pMesh mesh, const char *filename);
 LIBMMGS_EXPORT int MMGS_saveMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename);
 
 /**
+ * \brief Save a mesh and multiple data fields in MSH format, ascii or binary
+ * depending on the filename extension.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
  * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and multiple data fields (that are considered as solutions and
- * not metrics, thus, we do nothing over the ridge points) at MSH file format
- * (.msh extension).  Save file at ASCII format for .msh extension, at binary
- * format for .mshb one.
+ * This function saves a mesh and multiple data fields (that are considered as
+ * solutions and not metrics, thus, we do nothing over the ridge points) in MSH
+ * file format (.msh extension). The file is saved in ASCII format for .msh
+ * extension and in binary format for a .mshb extension.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEMSHMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1680,12 +1862,12 @@ LIBMMGS_EXPORT int MMGS_saveMshMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
 LIBMMGS_EXPORT int MMGS_saveMshMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
 
 /**
+ * \brief Write mesh and optionally one data field in Vtk file format (.vtk extension).
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
  * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
- *
- * Write mesh and optionally one data at Vtk file format (.vtk extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEVTKMESH(mesh,sol,filename,strlen0,retval)\n
@@ -1697,13 +1879,16 @@ LIBMMGS_EXPORT int MMGS_saveMshMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  *
  */
 LIBMMGS_EXPORT int MMGS_saveVtkMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename);
+
 /**
+ * \brief Save a mesh and multiple data fields in VTK format.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
  * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and multiple data fields at Vtk file format (.vtk extension).
+ * This function writes a mesh and a list of data fields in Vtk file format (.vtk extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEVTKMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1715,13 +1900,14 @@ LIBMMGS_EXPORT int MMGS_saveVtkMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  *
  */
 LIBMMGS_EXPORT int MMGS_saveVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
+
 /**
+ * \brief Write mesh and optionally one data field vtu Vtk file format (.vtu extension).
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
  * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
- *
- * Write mesh and optionally one data at vtu Vtk file format (.vtu extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEVTUMESH(mesh,sol,filename,strlen0,retval)\n
@@ -1733,13 +1919,14 @@ LIBMMGS_EXPORT int MMGS_saveVtkMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,c
  *
  */
 LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename);
+
 /**
+ * \brief Write a mesh and multiple data fields in vtu Vtk file format (.vtu extension).
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
  * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
- *
- * Write mesh and multiple data fields at vtu Vtk file format (.vtu extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEVTUMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1750,14 +1937,19 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * >   END SUBROUTINE\n
  *
  */
-  LIBMMGS_EXPORT int MMGS_saveVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
+  LIBMMGS_EXPORT int MMGS_saveVtuMesh_and_allData(MMG5_pMesh mesh, MMG5_pSol *sol,
+                                                  const char *filename);
+
 /**
+ * \brief Save a mesh and optionally one data field in VTP format.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
  * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and optionally one data in polydata Vtk file format (.vtp extension).
+ * This function writes a mesh and optionally one data in polydata Vtk file
+ * format (.vtp extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEVTPMESH(mesh,sol,filename,strlen0,retval)\n
@@ -1768,14 +1960,18 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * >   END SUBROUTINE\n
  *
  */
-  LIBMMGS_EXPORT int MMGS_saveVtpMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename);
+  LIBMMGS_EXPORT int MMGS_saveVtpMesh(MMG5_pMesh mesh, MMG5_pSol sol, const char *filename);
+
 /**
+ * \brief Save a mesh and multiple data fields in VTP format.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solution structure.
  * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
  *
- * Write mesh and multiple data fields in polydata Vtk file format (.vtp extension).
+ * This function writes a mesh and multiple data fields in polydata Vtk file
+ * format (.vtp extension).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEVTPMESH_AND_ALLDATA(mesh,sol,filename,strlen0,retval)\n
@@ -1786,14 +1982,15 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * >   END SUBROUTINE\n
  *
  */
-  LIBMMGS_EXPORT int MMGS_saveVtpMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol,const char *filename);
+  LIBMMGS_EXPORT int MMGS_saveVtpMesh_and_allData(MMG5_pMesh mesh, MMG5_pSol *sol,
+                                                  const char *filename);
 
 /**
+ * \brief Save mesh data in a file whose format depends on the filename extension.
+ *
  * \param mesh pointer to the mesh structure.
  * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
- *
- * Save mesh data in a file whose format depends on the filename extension.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEGENERICMESH(mesh,sol,filename,strlen0,retval)\n
@@ -1804,9 +2001,11 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * >   END SUBROUTINE\n
  *
  */
-  LIBMMGS_EXPORT int MMGS_saveGenericMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename);
+  LIBMMGS_EXPORT int MMGS_saveGenericMesh(MMG5_pMesh mesh, MMG5_pSol sol, const char *filename);
 
 /**
+ * \brief Load a metric field (or other solution) in medit's .sol format.
+ *
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the sol structure.
  * \param filename name of the file to load.
@@ -1824,14 +2023,15 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * >   END SUBROUTINE\n
  *
  */
-  LIBMMGS_EXPORT int  MMGS_loadSol(MMG5_pMesh mesh,MMG5_pSol met, const char* filename);
+  LIBMMGS_EXPORT int  MMGS_loadSol(MMG5_pMesh mesh, MMG5_pSol met, const char* filename);
+
 /**
+ * \brief Load one or more solutions in a solution file in medit file format.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solutions array
  * \param filename name of the file to load.
  * \return 0 on failure, 1 otherwise.
- *
- * Load 1 or more solutions in a solution file in medit file format.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_LOADALLSOLS(mesh,sol,filename,strlen0,retval)\n
@@ -1842,14 +2042,15 @@ LIBMMGS_EXPORT int MMGS_saveVtuMesh(MMG5_pMesh mesh,MMG5_pSol sol,const char *fi
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int  MMGS_loadAllSols(MMG5_pMesh mesh,MMG5_pSol *sol, const char* filename);
+LIBMMGS_EXPORT int  MMGS_loadAllSols(MMG5_pMesh mesh, MMG5_pSol *sol, const char* filename);
+
 /**
+ * \brief Write an isotropic or anisotropic metric in medit file format.
+ *
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the sol structure.
  * \param filename name of the file to write.
  * \return 0 on failure, 1 otherwise.
- *
- * Write isotropic or anisotropic metric in medit file format.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVESOL(mesh,met,filename,strlen0,retval)\n
@@ -1861,13 +2062,14 @@ LIBMMGS_EXPORT int  MMGS_loadAllSols(MMG5_pMesh mesh,MMG5_pSol *sol, const char*
  *
  */
 LIBMMGS_EXPORT int  MMGS_saveSol(MMG5_pMesh mesh, MMG5_pSol met, const char *filename);
+
 /**
+ * \brief Save one or more solutions in a solution file in medit file format.
+ *
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the solutions array
  * \param filename name of the solution file.
  * \return 0 or -1 on failure, 1 otherwise.
- *
- * Save 1 or more solutions in a solution file in medit file format.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SAVEALLSOLS(mesh,sol,filename,strlen0,retval)\n
@@ -1878,14 +2080,14 @@ LIBMMGS_EXPORT int  MMGS_saveSol(MMG5_pMesh mesh, MMG5_pSol met, const char *fil
  * >   END SUBROUTINE\n
  *
  */
-LIBMMGS_EXPORT int MMGS_saveAllSols(MMG5_pMesh  mesh,MMG5_pSol *sol ,const char *filename);
+LIBMMGS_EXPORT int MMGS_saveAllSols(MMG5_pMesh mesh, MMG5_pSol *sol, const char *filename);
 
 /**
- * \param mesh pointer to the mesh structure.
- * \param sol pointer to an array of solution structure (that stores solution fields).
- * \return 1
+ * \brief Deallocate an array of solution fields
  *
- * Deallocation of an array of solution fields
+ * \param mesh pointer to the mesh structure.
+ * \param sol pointer to an array of solution structures (that stores solution fields).
+ * \return 1
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_Free_allSols(mesh,sol,retval)\n
@@ -1898,15 +2100,17 @@ LIBMMGS_EXPORT int MMGS_Free_allSols(MMG5_pMesh mesh,MMG5_pSol *sol);
 
 /* deallocations */
 /**
+ * \brief Deallocations before return.
+ *
  * \param starter dummy argument used to initialize the variadic argument list.
  * \param ... variadic arguments.
  *
- * For the MMGS_mmgslib function, you need
+ * For the \ref MMGS_mmgslib function, you need
  * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppMet,
  * &your_metric,MMG5_ARG_end).
  *
- * For the MMGS_mmgsls function, you need
+ * For the \ref MMGS_mmgsls function, you need
  * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppLs,
  * &your_level_set,MMG5_ARG_end).
@@ -1915,8 +2119,6 @@ LIBMMGS_EXPORT int MMGS_Free_allSols(MMG5_pMesh mesh,MMG5_pSol *sol);
  * are \ref MMG5_pSol.
  *
  * \return 0 on failure, 1 on success
- *
- * Deallocations before return.
  *
  * \remark we pass the structures by reference in order to have argument
  * compatibility between the library call from a Fortran code and a C code.
@@ -1927,15 +2129,17 @@ LIBMMGS_EXPORT int MMGS_Free_allSols(MMG5_pMesh mesh,MMG5_pSol *sol);
 LIBMMGS_EXPORT int MMGS_Free_all(const int starter,...);
 
 /**
+ * \brief Structure deallocations before return.
+ *
  * \param starter dummy argument used to initialize the variadic argument list.
  * \param ... variadic arguments.
  *
- * For the MMGS_mmgslib function, you need
+ * For the \ref MMGS_mmgslib function, you need
  * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppMet,
  * &your_metric,MMG5_ARG_end).
  *
- * For the MMGS_mmgsls function, you need
+ * For the \ref MMGS_mmgsls function, you need
  * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppLs,
  * &your_level_set,MMG5_ARG_end).
@@ -1948,8 +2152,6 @@ LIBMMGS_EXPORT int MMGS_Free_all(const int starter,...);
  *
  * \return 0 on failure, 1 on success
  *
- * Structure deallocations before return.
- *
  * \remark we pass the structures by reference in order to have argument
  * compatibility between the library call from a Fortran code and a C code.
  *
@@ -1959,15 +2161,17 @@ LIBMMGS_EXPORT int MMGS_Free_all(const int starter,...);
 LIBMMGS_EXPORT int MMGS_Free_structures(const int starter,...);
 
 /**
+ * \brief Structure deallocations before return.
+ *
  * \param starter dummy argument used to initialize the variadic argument list.
  * \param ... variadic arguments.
  *
- * For the MMGS_mmgslib function, you need
+ * For the \ref MMGS_mmgslib function, you need
  * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppMet,
  * &your_metric,MMG5_ARG_end).
  *
- * For the MMGS_mmgsls function, you need
+ * For the \ref MMGS_mmgsls function, you need
  * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppLs,
  * &your_level_set,MMG5_ARG_end).
@@ -1976,8 +2180,6 @@ LIBMMGS_EXPORT int MMGS_Free_structures(const int starter,...);
  * are \ref MMG5_pSol.
  *
  * \return 0 on failure, 1 on success
- *
- * Structure deallocations before return.
  *
  * \remark we pass the structures by reference in order to have argument
  * compatibility between the library call from a Fortran code and a C code.
@@ -1989,6 +2191,8 @@ LIBMMGS_EXPORT int MMGS_Free_names(const int starter,...);
 
 /* library */
 /**
+ * \brief Main "program" for mesh adaptation.
+ *
  * \param mesh pointer to the mesh structure.  \param met pointer to the sol
  * (metric) structure.  \return \ref MMG5_SUCCESS on success, \ref
  * MMG5_LOWFAILURE in case there is a failure but a conform mesh can be returned
@@ -2006,6 +2210,8 @@ LIBMMGS_EXPORT int MMGS_Free_names(const int starter,...);
 LIBMMGS_EXPORT int  MMGS_mmgslib(MMG5_pMesh mesh, MMG5_pSol met);
 
 /**
+ * \brief Main "program" for level-set discretization.
+ *
  * \param mesh pointer to the mesh structure.  \param sol pointer to the sol
  * (level-set) structure.  \param met pointer to the sol (metric) structure
  * (optionnal).  \return \ref MMG5_SUCCESS on success, \ref MMG5_LOWFAILURE if
@@ -2027,10 +2233,10 @@ LIBMMGS_EXPORT int  MMGS_mmgsls(MMG5_pMesh mesh,  MMG5_pSol sol,MMG5_pSol met);
 
 /** To associate function pointers without calling MMGS_mmgslib */
 /**
+ * \brief Set function pointers for caltet, lenedg, defsiz and gradsiz.
+ *
  * \param mesh pointer to the mesh structure (unused).
  * \param met pointer to the sol structure (unused).
- *
- * Set function pointers for caltet, lenedg, defsiz and gradsiz.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SETFUNC(mesh,met)\n
@@ -2041,15 +2247,17 @@ LIBMMGS_EXPORT int  MMGS_mmgsls(MMG5_pMesh mesh,  MMG5_pSol sol,MMG5_pSol met);
 LIBMMGS_EXPORT void  MMGS_setfunc(MMG5_pMesh mesh,MMG5_pSol met);
 
 /**
+ * \brief Get the number of non-boundary edges.
+ *
  * \param mesh pointer to the mesh structure.
- * \param nb_edges pointer to the number of non boundary edges.
+ * \param the number of edges pointer to the number of non boundary edges.
  * \return 0 on failure, 1 otherwise.
  *
- * Get the number of non boundary edges (for DG methods for example). An edge is
+ * Get the number of non-boundary edges (for DG methods for example). An edge is
  * boundary if it is located at the interface of 2 domains with different
  * references, if it belongs to one triangle only or if it is a singular edge
  * (ridge or required).
- * Append these edges to the list of edge.
+ * Append these edges to the list of edges.
  *
  * \warning reallocate the edge array and append the internal edges. This may
  * modify the behaviour of other functions.
@@ -2065,16 +2273,18 @@ LIBMMGS_EXPORT void  MMGS_setfunc(MMG5_pMesh mesh,MMG5_pSol met);
  LIBMMGS_EXPORT int MMGS_Get_numberOfNonBdyEdges(MMG5_pMesh mesh, MMG5_int* nb_edges);
 
 /**
+ * \brief Get vertices and reference of a non-boundary edge.
+ *
  * \param mesh pointer to the mesh structure.
- * \param e0 pointer to the first extremity of the edge.
- * \param e1 pointer to the second  extremity of the edge.
+ * \param e0 pointer to the first extremity of the edge (a vertex number).
+ * \param e1 pointer to the second  extremity of the edge (a vertex number).
  * \param ref pointer to the edge reference.
- * \param idx index of the non boundary edge to get (between 1 and nb_edges)
+ * \param idx index of the non boundary edge to get (between 1 and the number of edges)
  * \return 0 on failure, 1 otherwise.
  *
- * Get extremities \a e0, \a e1 and reference \a ref of the idx^th non boundary
- * edge (for DG methods for example). An edge is boundary if it is located at
- * the interface of 2 domains witch different references, if it belongs to one
+ * This function returns the vertices \a e0, \a e1 and reference \a ref of the non boundary
+ * edge \a idx. An edge is boundary if it is located at
+ * the interface of 2 domains with different references, if it belongs to one
  * triangle only or if it is a singular edge (ridge or required).
  *
  * \remark Fortran interface:
@@ -2087,17 +2297,18 @@ LIBMMGS_EXPORT void  MMGS_setfunc(MMG5_pMesh mesh,MMG5_pSol met);
  * >   END SUBROUTINE\n
  *
  */
-  LIBMMGS_EXPORT int MMGS_Get_nonBdyEdge(MMG5_pMesh mesh, MMG5_int* e0, MMG5_int* e1, MMG5_int* ref, MMG5_int idx);
+  LIBMMGS_EXPORT int MMGS_Get_nonBdyEdge(MMG5_pMesh mesh, MMG5_int* e0, MMG5_int* e1,
+                                         MMG5_int* ref, MMG5_int idx);
 
 
 /* Tools for the library */
 /**
+ * \brief Compute an isotropic size map according to the mean of the length of the
+ * edges passing through a point.
+ *
  * \param mesh pointer to the mesh structure
  * \param met pointer to the sol structure
  * \return 1 on success
- *
- * Compute isotropic size map according to the mean of the length of the
- * edges passing through a point.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_DOSOL(mesh,met,retval)\n
@@ -2109,12 +2320,15 @@ LIBMMGS_EXPORT void  MMGS_setfunc(MMG5_pMesh mesh,MMG5_pSol met);
  LIBMMGS_EXPORT extern int (*MMGS_doSol)(MMG5_pMesh mesh,MMG5_pSol met);
 
 /**
+ * \brief Compute a constant size map.
+ *
  * \param mesh pointer to the mesh structure
  * \param met pointer to the sol structure
  * \return 1 on success
  *
- * Compute constant size map according to mesh->info.hsiz, mesh->info.hmin and
- * mesh->info.hmax. Update this 3 value if not compatible.
+ * This function computes a constant size map according to mesh->info.hsiz,
+ * mesh->info.hmin and mesh->info.hmax. It updates these 3 values if they are
+ * not compatible.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_SET_CONSTANTSIZE(mesh,met,retval)\n
@@ -2126,9 +2340,9 @@ LIBMMGS_EXPORT void  MMGS_setfunc(MMG5_pMesh mesh,MMG5_pSol met);
 LIBMMGS_EXPORT int MMGS_Set_constantSize(MMG5_pMesh mesh,MMG5_pSol met);
 
 /**
- * \param prog pointer to the program name.
+ * \brief Print help for mmgs options.
  *
- * Print help for mmgs options.
+ * \param prog pointer to the program name.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_USAGE(prog,strlen0,retval)\n
@@ -2139,7 +2353,10 @@ LIBMMGS_EXPORT int MMGS_Set_constantSize(MMG5_pMesh mesh,MMG5_pSol met);
  *
  */
 LIBMMGS_EXPORT int MMGS_usage(char *prog);
+
 /**
+ * \brief Store command line arguments.
+ *
  * \param argc number of command line arguments.
  * \param argv command line arguments.
  * \param mesh pointer to the mesh structure.
@@ -2148,17 +2365,16 @@ LIBMMGS_EXPORT int MMGS_usage(char *prog);
  *
  * \return 1.
  *
- * Store command line arguments.
- *
  * \remark no matching fortran function.
  *
  */
 LIBMMGS_EXPORT int  MMGS_parsar(int argc,char *argv[],MMG5_pMesh mesh,MMG5_pSol met,MMG5_pSol sol);
+
 /**
+ * \brief Print the default parameters values.
+ *
  * \param mesh pointer to the mesh structure.
  * \return 0 on failure, 1 on success.
- *
- * Print the default parameters values.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_DEFAULTVALUES(mesh,retval)\n
@@ -2168,12 +2384,13 @@ LIBMMGS_EXPORT int  MMGS_parsar(int argc,char *argv[],MMG5_pMesh mesh,MMG5_pSol 
  *
  */
 LIBMMGS_EXPORT int MMGS_defaultValues(MMG5_pMesh mesh);
+
 /**
+ * \brief Store the info structure in the mesh structure.
+ *
  * \param mesh pointer to the mesh structure.
  * \param info pointer to the info structure.
  * \return 1.
- *
- * Store the info structure in the mesh structure.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_STOCKOPTIONS(mesh,info,retval)\n
@@ -2183,11 +2400,12 @@ LIBMMGS_EXPORT int MMGS_defaultValues(MMG5_pMesh mesh);
  *
  */
 LIBMMGS_EXPORT int MMGS_stockOptions(MMG5_pMesh mesh, MMG5_Info *info);
+
 /**
+ * \brief Recover the info structure stored in the mesh structure.
+ *
  * \param mesh pointer to the mesh structure.
  * \param info pointer to the info structure.
- *
- * Recover the info structure stored in the mesh structure.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_DESTOCKOPTIONS(mesh,info)\n
@@ -2201,7 +2419,7 @@ LIBMMGS_EXPORT void MMGS_destockOptions(MMG5_pMesh mesh, MMG5_Info *info);
  * \brief Return adjacent elements of a triangle.
  * \param mesh pointer to the mesh structure.
  * \param kel triangle index.
- * \param listri pointer to the table of the indices of the three adjacent
+ * \param listri pointer to the array of indices of the three adjacent
  * triangles of the elt \a kel (the index is 0 if there is no adjacent).
  * \return 1.
  *
@@ -2221,7 +2439,8 @@ LIBMMGS_EXPORT void MMGS_destockOptions(MMG5_pMesh mesh, MMG5_Info *info);
 LIBMMGS_EXPORT int MMGS_Get_adjaTri(MMG5_pMesh mesh, MMG5_int kel, MMG5_int listri[3]);
 
 /**
- * \brief Return adjacent elements of a triangle.
+ * \brief Find adjacent elements of a triangle.
+ *
  * \param mesh pointer to the mesh structure.
  * \param ip vertex index.
  * \param start index of a triangle holding \a ip.
@@ -2244,6 +2463,8 @@ LIBMMGS_EXPORT int MMGS_Get_adjaTri(MMG5_pMesh mesh, MMG5_int kel, MMG5_int list
 LIBMMGS_EXPORT int MMGS_Get_adjaVerticesFast(MMG5_pMesh mesh, MMG5_int ip,MMG5_int start, MMG5_int lispoi[MMGS_LMAX]);
 
 /**
+ * \brief Compute the real eigenvalues and eigenvectors of a symetric matrix
+ *
  * \param m upper part of a symetric matric diagonalizable in |R
  * \param lambda array of the metric eigenvalues
  * \param vp array of the metric eigenvectors
@@ -2270,10 +2491,10 @@ LIBMMGS_EXPORT int MMGS_Get_adjaVerticesFast(MMG5_pMesh mesh, MMG5_int ip,MMG5_i
 LIBMMGS_EXPORT int MMGS_Compute_eigenv(double m[6],double lambda[3],double vp[3][3]);
 
 /**
+ * \brief Free a solution.
+ *
  * \param mesh pointer to the mesh structure
  * \param sol pointer to the solution structure
- *
- * Free the solution.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_FREE_SOLUTIONS(mesh,sol)\n
@@ -2284,11 +2505,11 @@ LIBMMGS_EXPORT int MMGS_Compute_eigenv(double m[6],double lambda[3],double vp[3]
 LIBMMGS_EXPORT void MMGS_Free_solutions(MMG5_pMesh mesh,MMG5_pSol sol);
 
 /**
+ * \brief Clean data (triangles and edges) linked to isosurface.
+ *
  * \param mesh pointer to mesh sructure
  *
  * \return 1 if successful, 0 otherwise.
- *
- * Clean data (triangles and edges) linked to isosurface.
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_CLEAN_ISOSURF(mesh,retval)\n
@@ -2300,7 +2521,7 @@ LIBMMGS_EXPORT void MMGS_Free_solutions(MMG5_pMesh mesh,MMG5_pSol sol);
  LIBMMGS_EXPORT int MMGS_Clean_isoSurf(MMG5_pMesh mesh);
 
 /**
- * Set common function pointers between mmgs and mmg3d to the matching mmgs
+ * \brief Set common function pointers between mmgs and mmg3d to the matching mmgs
  * functions.
  */
 LIBMMGS_EXPORT void MMGS_Set_commonFunc(void);

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -106,37 +106,37 @@ extern "C" {
  *
  */
 enum MMGS_Param {
-  MMGS_IPARAM_verbose,           /*!< [-1..10], Tune level of verbosity */
-  MMGS_IPARAM_mem,               /*!< [n/-1], Set memory size to n Mbytes or keep the default value */
+  MMGS_IPARAM_verbose,           /*!< [-1..10], Level of verbosity */
+  MMGS_IPARAM_mem,               /*!< [n/-1], Max memory size in MBytes or -1 to keep the default value */
   MMGS_IPARAM_debug,             /*!< [1/0], Turn on/off debug mode */
   MMGS_IPARAM_angle,             /*!< [1/0], Turn on/off angle detection */
-  MMGS_IPARAM_iso,               /*!< [1/0], Level-set meshing */
-  MMGS_IPARAM_isosurf,           /*!< [1/0], Level-set meshing on the surface part */
+  MMGS_IPARAM_iso,               /*!< [1/0], Enable level-set discretization */
+  MMGS_IPARAM_isosurf,           /*!< [1/0], Enable level-set discretization on the surface part */
   MMGS_IPARAM_isoref,            /*!< [0/n], Iso-surface boundary material reference */
   MMGS_IPARAM_keepRef,           /*!< [1/0], Preserve the initial domain references in level-set mode */
   MMGS_IPARAM_optim,             /*!< [1/0], Optimize mesh keeping its initial edge sizes */
   MMGS_IPARAM_noinsert,          /*!< [1/0], Avoid/allow point insertion */
   MMGS_IPARAM_noswap,            /*!< [1/0], Avoid/allow edge or face flipping */
   MMGS_IPARAM_nomove,            /*!< [1/0], Avoid/allow point relocation */
-  MMGS_IPARAM_nreg,              /*!< [0/1], Disabled/enabled normal regularization */
-  MMGS_IPARAM_xreg,              /*!< [0/1], Disabled/enabled coordinates regularization */
+  MMGS_IPARAM_nreg,              /*!< [0/1], Disable/enable regularization of normals */
+  MMGS_IPARAM_xreg,              /*!< [0/1], Disable/enable regularization by moving vertices */
   MMGS_IPARAM_numberOfLocalParam,/*!< [n], Number of local parameters */
   MMGS_IPARAM_numberOfLSBaseReferences, /*!< [n], Number of base references for bubble removal */
-  MMGS_IPARAM_numberOfMat,              /*!< [n], Number of material in ls mode */
-  MMGS_IPARAM_numsubdomain,      /*!< [0/n], Save the subdomain nb (0==all subdomain) */
-  MMGS_IPARAM_renum,             /*!< [1/0], Turn on/off point relocation with Scotch */
+  MMGS_IPARAM_numberOfMat,              /*!< [n], Number of material in level-set mode */
+  MMGS_IPARAM_numsubdomain,      /*!< [0/n], Save only subdomain n (0==all subdomains) */
+  MMGS_IPARAM_renum,             /*!< [1/0], Turn on/off renumbering with Scotch */
   MMGS_IPARAM_anisosize,         /*!< [1/0], Turn on/off anisotropic metric creation when no metric is provided */
-  MMGS_IPARAM_nosizreq,          /*!< [0/1], Allow/avoid overwritten of sizes at required points (advanced usage) */
-  MMGS_DPARAM_angleDetection,    /*!< [val], Value for angle detection */
-  MMGS_DPARAM_hmin,              /*!< [val], Minimal mesh size */
-  MMGS_DPARAM_hmax,              /*!< [val], Maximal mesh size */
-  MMGS_DPARAM_hsiz,              /*!< [val], Constant mesh size */
-  MMGS_DPARAM_hausd,             /*!< [val], Control global Hausdorff distance (on all the boundary surfaces of the mesh) */
-  MMGS_DPARAM_hgrad,             /*!< [val], Control gradation */
-  MMGS_DPARAM_hgradreq,          /*!< [val], Control gradation on required entites (advanced usage) */
-  MMGS_DPARAM_ls,                /*!< [val], Value of level-set */
-  MMGS_DPARAM_xreg,              /*!< [val], Value of relaxation parameter for coordinates regularization (0<val<1) */
-  MMGS_DPARAM_rmc,               /*!< [-1/val], Remove small connex componants in level-set mode */
+  MMGS_IPARAM_nosizreq,          /*!< [0/1], Allow/avoid overwritings of sizes at required points (advanced usage) */
+  MMGS_DPARAM_angleDetection,    /*!< [val], Threshold for angle detection */
+  MMGS_DPARAM_hmin,              /*!< [val], Minimal edge length */
+  MMGS_DPARAM_hmax,              /*!< [val], Maximal edge length */
+  MMGS_DPARAM_hsiz,              /*!< [val], Constant edge length */
+  MMGS_DPARAM_hausd,             /*!< [val], Global Hausdorff distance (on all the boundary surfaces of the mesh) */
+  MMGS_DPARAM_hgrad,             /*!< [val], Gradation */
+  MMGS_DPARAM_hgradreq,          /*!< [val], Gradation on required entites (advanced usage) */
+  MMGS_DPARAM_ls,                /*!< [val], Function value where the level set is to be discretized */
+  MMGS_DPARAM_xreg,              /*!< [val], Relaxation parameter for coordinate regularization (0<val<1) */
+  MMGS_DPARAM_rmc,               /*!< [-1/val], Remove small disconnected components in level-set mode */
   MMGS_PARAM_size,               /*!< [n], Number of parameters */
 };
 
@@ -148,17 +148,17 @@ enum MMGS_Param {
  * \param ... variadic arguments.
  *
  * For the MMGS_mmgslib function, you need
- * to call the \a MMGS_Init_mesh function with the following arguments :
+ * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppMet,
  * &your_metric,MMG5_ARG_end).
  *
- * For the MMGS_mmgsls function, you need
+ * For the \ref MMGS_mmgsls function, you need
  * to call the \a MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppLs,
  * &your_level_set,MMG5_ARG_end).
  *
- * Here,\a your_mesh is a \a MMG5_pMesh, \a your_metric and \a your_level_set
- * are \a MMG5_pSol.
+ * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
+ * are \ref MMG5_pSol.
  *
  * \return 1 if success, 0 if fail
  *
@@ -895,7 +895,7 @@ LIBMMGS_EXPORT int MMGS_Chk_meshData(MMG5_pMesh mesh, MMG5_pSol met);
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure (unused).
- * \param iparam integer parameter to set (see \a MMGS_Param structure).
+ * \param iparam integer parameter to set (see \ref MMGS_Param structure).
  * \param val value for the parameter.
  * \return 0 if failed, 1 otherwise.
  *
@@ -915,7 +915,7 @@ LIBMMGS_EXPORT int  MMGS_Set_iparameter(MMG5_pMesh mesh,MMG5_pSol sol, int ipara
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure (unused).
- * \param dparam double parameter to set (see \a MMGS_Param structure).
+ * \param dparam double parameter to set (see \ref MMGS_Param structure).
  * \param val value of the parameter.
  * \return 0 if failed, 1 otherwise.
  *
@@ -1403,7 +1403,7 @@ LIBMMGS_EXPORT int MMGS_Get_tensorSols(MMG5_pSol met, double *sols);
   LIBMMGS_EXPORT int  MMGS_Get_ithSols_inSolsAtVertices(MMG5_pSol sol,int i, double* s);
 /**
  * \param mesh pointer to the mesh structure.
- * \param iparam integer parameter to set (see \a MMGS_Param structure).
+ * \param iparam integer parameter to set (see \ref MMGS_Param structure).
  * \return The value of integer parameter.
  *
  * Get the value of integer parameter \a iparam.
@@ -1901,17 +1901,17 @@ LIBMMGS_EXPORT int MMGS_Free_allSols(MMG5_pMesh mesh,MMG5_pSol *sol);
  * \param ... variadic arguments.
  *
  * For the MMGS_mmgslib function, you need
- * to call the \a MMGS_Init_mesh function with the following arguments :
+ * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppMet,
  * &your_metric,MMG5_ARG_end).
  *
  * For the MMGS_mmgsls function, you need
- * to call the \a MMGS_Init_mesh function with the following arguments :
+ * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppLs,
  * &your_level_set,MMG5_ARG_end).
  *
- * Here,\a your_mesh is a \a MMG5_pMesh, \a your_metric and \a your_level_set
- * are \a MMG5_pSol.
+ * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
+ * are \ref MMG5_pSol.
  *
  * \return 0 if fail, 1 if success
  *
@@ -1930,20 +1930,20 @@ LIBMMGS_EXPORT int MMGS_Free_all(const int starter,...);
  * \param ... variadic arguments.
  *
  * For the MMGS_mmgslib function, you need
- * to call the \a MMGS_Init_mesh function with the following arguments :
+ * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppMet,
  * &your_metric,MMG5_ARG_end).
  *
  * For the MMGS_mmgsls function, you need
- * to call the \a MMGS_Init_mesh function with the following arguments :
+ * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppLs,
  * &your_level_set,MMG5_ARG_end).
  *
- * Here,\a your_mesh is a \a MMG5_pMesh, \a your_metric and \a your_level_set
- * are \a MMG5_pSol.
+ * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
+ * are \ref MMG5_pSol.
  *
- * Here, \a your_mesh is a pointer to \a MMG5_pMesh and \a your_metric and
- * \a your_level_set a pointer to \a MMG5_pSol.
+ * Here, \a your_mesh is a pointer to \ref MMG5_pMesh and \a your_metric and
+ * \a your_level_set a pointer to \ref MMG5_pSol.
  *
  * \return 0 if fail, 1 if success
  *
@@ -1962,17 +1962,17 @@ LIBMMGS_EXPORT int MMGS_Free_structures(const int starter,...);
  * \param ... variadic arguments.
  *
  * For the MMGS_mmgslib function, you need
- * to call the \a MMGS_Init_mesh function with the following arguments :
+ * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppMet,
  * &your_metric,MMG5_ARG_end).
  *
  * For the MMGS_mmgsls function, you need
- * to call the \a MMGS_Init_mesh function with the following arguments :
+ * to call the \ref MMGS_Init_mesh function with the following arguments :
  * MMGS_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh, MMG5_ARG_ppLs,
  * &your_level_set,MMG5_ARG_end).
  *
- * Here,\a your_mesh is a \a MMG5_pMesh, \a your_metric and \a your_level_set
- * are \a MMG5_pSol.
+ * Here,\a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
+ * are \ref MMG5_pSol.
  *
  * \return 0 if fail, 1 if success
  *


### PR DESCRIPTION
- Added a \brief for every function in libmmgs.h
- The usual language fixes
- used \ref to get links for types and functions that appear in documentation
- wrote a bit more detail about some functions
- workaround for a Doxygen problem in common/inout.c : it saw an if() with a long function call in the condition as a function call itself and added "if" to the call graphs as if it was a function. I think it's also easier to read now.
This should be my last grocery-list kind of PR, I'll get to more concentrated changes.
