### PR TITLE
avoid exits from MMG5_coltet()

### DIFF
--- a/src/mmg3d/boulep_3d.c
+++ b/src/mmg3d/boulep_3d.c
@@ -749,7 +749,7 @@ int MMG5_boulesurfvolp(MMG5_pMesh mesh,MMG5_int start,int ip,int iface,
 /**
  * \param mesh pointer to the mesh structure.
  * \param start index of the starting tetrahedron.
- * \param ip index in \a start of the looked point.
+ * \param ip index in \a start of the desired vertex.
  * \param iface index in \a start of the starting face.
  * \param listv pointer to the computed volumic ball.
  * \param ilistv pointer to the computed volumic ball size.
@@ -757,7 +757,7 @@ int MMG5_boulesurfvolp(MMG5_pMesh mesh,MMG5_int start,int ip,int iface,
  * \param ilists pointer to the computed surfacic ball size.
  * \param refmin return the reference of one of the two subdomains in presence
  * \param refplus return the reference of the other subdomain in presence
- * \param isnm is the looked point \a ip non-manifold?
+ * \param isnm is the vertex non-manifold?
  * \return 1 if succesful, a negative value if the ball cannot be computed:
  * -1 if a surface ball had too many elements,
  * -2 if there are more than two references around,
@@ -767,24 +767,24 @@ int MMG5_boulesurfvolp(MMG5_pMesh mesh,MMG5_int start,int ip,int iface,
  * is not possible, while -2 and -3 just mean the job could not be done.
  *
  * Compute the volumic ball of a SURFACE point \a p, as well as its surfacic
- * ball, starting from tetra \a start, with point \a ip, and face \a if in tetra
+ * ball, starting from tetra \a start, with point \a ip, and face \a if in the
  * volumic ball.
  * \a listv[k] = 4*number of tet + index of point surfacic ball.
  * \a lists[k] = 4*number of tet + index of face.
  *
  * \warning Doesn't work for a non-manifold point if \a start has an adjacent
- * through \a iface (for example : a non-manifold subdomain). Thus, if \a ip is
+ * through \a iface (for example: a non-manifold subdomain). Thus, if \a ip is
  * non-manifold, must be called only if \a start has no adjacent through iface.
  *
  */
-int MMG5_boulesurfvolpNom(MMG5_pMesh mesh,MMG5_int start,int ip,int iface,
-                          int64_t *listv,int *ilistv,MMG5_int *lists,int *ilists,
-                          MMG5_int *refmin,MMG5_int *refplus,int isnm)
+int MMG5_boulesurfvolpNom(MMG5_pMesh mesh, MMG5_int start, int ip, int iface,
+                          int64_t *listv, int *ilistv, MMG5_int *lists, int *ilists,
+                          MMG5_int *refmin, MMG5_int *refplus, int isnm)
 {
-  MMG5_pTetra   pt,pt1;
+  MMG5_pTetra   pt, pt1;
   MMG5_pxTetra  pxt;
-  MMG5_int      k,k1,nump,*adja,piv,na,nb,adj,cur,nvstart,fstart,aux,base;
-  int8_t        iopp,ipiv,i,j,l,isface;
+  MMG5_int      k, k1, nump, *adja, piv, na, nb, adj, cur, nvstart, fstart, aux, base;
+  int8_t        iopp, ipiv, i, j, l, isface;
   static int8_t mmgErr0=0, mmgErr1=0, mmgErr2=0;
 
   if ( isnm ) assert(!mesh->adja[4*(start-1)+iface+1]);

--- a/src/mmg3d/boulep_3d.c
+++ b/src/mmg3d/boulep_3d.c
@@ -763,8 +763,8 @@ int MMG5_boulesurfvolp(MMG5_pMesh mesh,MMG5_int start,int ip,int iface,
  * -2 if there are more than two references around,
  * -3 if an edge cannot be found, and
  * -4 if a volume ball had too many elements.
- * Among these, -1 and -4 can be taken as a sign that further remeshing
- * is not possible, while -2 and -3 just mean the job could not be done.
+ * Among these, -1, -3 and -4 can be taken as a sign that further remeshing
+ * is not possible, while -2 just mean the job could not be done.
  *
  * Compute the volumic ball of a SURFACE point \a p, as well as its surfacic
  * ball, starting from tetra \a start, with point \a ip, and face \a if in the

--- a/src/mmg3d/mmg3d1.c
+++ b/src/mmg3d/mmg3d1.c
@@ -1096,9 +1096,9 @@ static MMG5_int MMG5_coltet(MMG5_pMesh mesh,MMG5_pSol met,int8_t typchk) {
                 if ( mesh->adja[4*(k-1)+1+i] )  continue;
                 bsret = MMG5_boulesurfvolpNom(mesh,k,ip,i,
                                               list,&ilist,lists,&ilists,&refmin,&refplus,p0->tag & MG_NOM);
-                if(bsret==-1 || bsret==-4){
+                if(bsret==-1 || bsret==-3 || bsret==-4){
                   return -3;   // fatal
-                }else if(bsret==-2 || bsret==-3){
+                }else if(bsret==-2){
                   continue;    // ball computation failed: cannot handle this vertex
                 }
                 assert(bsret==1 && "unexpected return value from MMG5_boulesurfvolpNom");

--- a/src/mmg3d/mmg3d1.c
+++ b/src/mmg3d/mmg3d1.c
@@ -880,12 +880,12 @@ MMG5_int MMG5_movtet(MMG5_pMesh mesh,MMG5_pSol met, MMG3D_pPROctree PROctree,
  * \param mesh pointer to the mesh structure.
  * \param met pointer to the metric structure.
  * \param typchk type of checking permformed for edge length (hmin or LSHORT criterion).
- * \return -1 if failed, number of collapsed points otherwise.
+ * \return a negative value in case of failure, number of collapsed points otherwise.
  *
- * Attempt to collapse small edges.
+ * Attempt to collapse short edges.
  *
  */
-static int MMG5_coltet(MMG5_pMesh mesh,MMG5_pSol met,int8_t typchk) {
+static MMG5_int MMG5_coltet(MMG5_pMesh mesh,MMG5_pSol met,int8_t typchk) {
   MMG5_pTetra     pt,ptloc;
   MMG5_pxTetra    pxt;
   MMG5_pPoint     p0,p1;
@@ -897,7 +897,7 @@ static int MMG5_coltet(MMG5_pMesh mesh,MMG5_pSol met,int8_t typchk) {
   int             l,kk,isloc,ifac1;
   int16_t         tag,isnm,isnmint;
   int8_t          i,j,ip,iq;
-  int             ier;
+  int             ier, bsret;   // function return values/error codes
 
   nc = nnm = 0;
 
@@ -971,7 +971,7 @@ static int MMG5_coltet(MMG5_pMesh mesh,MMG5_pSol met,int8_t typchk) {
             else {
               if (MMG5_boulesurfvolp(mesh,k,ip,i,
                                      list,&ilist,lists,&ilists,p0->tag & MG_NOM) < 0 )
-                return -1;
+                return -2;
             }
           }
           else {
@@ -1094,15 +1094,20 @@ static int MMG5_coltet(MMG5_pMesh mesh,MMG5_pSol met,int8_t typchk) {
               }
               else {
                 if ( mesh->adja[4*(k-1)+1+i] )  continue;
-                if (MMG5_boulesurfvolpNom(mesh,k,ip,i,
-                                          list,&ilist,lists,&ilists,&refmin,&refplus,p0->tag & MG_NOM) < 0 )
-                  return -1;
+                bsret = MMG5_boulesurfvolpNom(mesh,k,ip,i,
+                                              list,&ilist,lists,&ilists,&refmin,&refplus,p0->tag & MG_NOM);
+                if(bsret==-1 || bsret==-4){
+                  return -3;   // fatal
+                }else if(bsret==-2 || bsret==-3){
+                  continue;    // ball computation failed: cannot handle this vertex
+                }
+                assert(bsret==1 && "unexpected return value from MMG5_boulesurfvolpNom");
               }
             }
             else {
               if (MMG5_boulesurfvolp(mesh,k,ip,i,
                                      list,&ilist,lists,&ilists,p0->tag & MG_NOM) < 0 )
-                return -1;
+                return -4;
             }
           }
           else {
@@ -1134,13 +1139,13 @@ static int MMG5_coltet(MMG5_pMesh mesh,MMG5_pSol met,int8_t typchk) {
 
         if ( ilist > 0 ) {
           ier = MMG5_colver(mesh,met,list,ilist,iq,typchk);
-          if ( ier < 0 ) return -1;
+          if ( ier < 0 ) return -5;
           else if ( ier ) {
             MMG3D_delPt(mesh,ier);
             break;
           }
         }
-        else if (ilist < 0 ) return -1;
+        else if (ilist < 0 ) return -6;
       }
       if ( ier ) {
         p1->flag = base;

--- a/src/mmg3d/mmg3d1.c
+++ b/src/mmg3d/mmg3d1.c
@@ -963,9 +963,15 @@ static MMG5_int MMG5_coltet(MMG5_pMesh mesh,MMG5_pSol met,int8_t typchk) {
               }
               else {
                 if ( mesh->adja[4*(k-1)+1+i] )  continue;
-                if (MMG5_boulesurfvolpNom(mesh,k,ip,i,
-                                          list,&ilist,lists,&ilists,&refmin,&refplus,p0->tag & MG_NOM) < 0 )
-                  return -1;
+
+                bsret = MMG5_boulesurfvolpNom(mesh,k,ip,i,
+                                              list,&ilist,lists,&ilists,&refmin,&refplus,p0->tag & MG_NOM);
+                if(bsret==-1 || bsret==-3 || bsret==-4){
+                  return -3;   // fatal
+                }else if(bsret==-2){
+                  continue;    // ball computation failed: cannot handle this vertex
+                }
+                assert(bsret==1 && "unexpected return value from MMG5_boulesurfvolpNom");
               }
             }
             else {


### PR DESCRIPTION
Complex meshes in the MICROCARD project currently have a 2/3 chance of remesher failure because MMG5_coltet() exit()s when MMG5_boulesurfvolpNom() returns a negative value, indicating that it cannot compute the ball of a given vertex. But extensive testing with a private branch has shown that we do not have to take all of these failures as critical. So I let the return values of MMG5_boulesurfvolpNom() distinguish between 4 different causes of failure, and let MMG5_coltet() continue instead of exit when the cause of failure is that (-2) there are more than two references in the ball (a common situation in the MICROCARD meshes) or (-3) an edge could not be found (only because I think Algiane said this is harmless too).

As a result of this change, edges involving a vertex with more than 2 references in its ball will simply not be collapsed, rather than causing an exit. Perhaps we never want such edges to be collapsed anyway.

What remains mysterious to me is that not all vertices with more than 2 references in their ball caused such exits: 3 references is common in all of our cases, and 4 or 5 also occurs.

I also don't understand why MMG5_boulesurfvolpNom() requires that there are just two references in the ball. Is this a leftover from before the introduction of multimaterial functionality - when the only surfaces were level sets? The "refmin" and "refmax" nomenclature in the function arguments suggests that.