### PR TITLE
Correctly find dependencies when installed

### DIFF
--- a/cmake/config/mmgConfig.cmake.in
+++ b/cmake/config/mmgConfig.cmake.in
@@ -3,11 +3,11 @@
 include(CMakeFindDependencyMacro)
 
 # Allows us to use all .cmake files in this directory
-# required for `find_package({SCOTCH,VTK}) to work.
+# required for `find_dependency({SCOTCH,VTK}) to work.
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}")
 
-find_package(SCOTCH)
-find_package(VTK)
+find_dependency(SCOTCH)
+find_dependency(VTK)
 
 if (NOT TARGET Mmg::mmg )
   include(${CMAKE_CURRENT_LIST_DIR}/MmgTargets.cmake)


### PR DESCRIPTION
Use `find_dependency` instead of `find_package` in installed CMake config to correctly propagate `QUIET` and `REQUIRED` flags to users.