### PR TITLE
Create a dedicated job for coverage submission to codecov

### DIFF
--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -377,7 +377,7 @@ jobs:
     - name: Download coverage artifact
       uses: actions/download-artifact@v4
       with:
-        pattern: build-*
+        pattern: build-ubuntu-*
 
     - name: Upload coverage to Codecov
       if: inputs.code_coverage == true

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -26,7 +26,7 @@ on:
 # job
 jobs:
   ci:
-    if: ! contains(github.event.head_commit.message, '[skip ci]')
+    if: "! contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ${{ matrix.os }}
 
     # Launch a matrix of jobs
@@ -192,7 +192,7 @@ jobs:
           NJOBS: "2"
 
       - name: Set environment variables for output comparison
-        if: ! contains(github.event.head_commit.message, '[skip output comparison]')
+        if: "! contains(github.event.head_commit.message, '[skip output comparison]')"
         run: |
           echo "C_FLG=-DMMG_COMPARABLE_OUTPUT" >> "$GITHUB_ENV"
           echo "MMG_ERROR_RULE=\"COMMAND_ERROR_IS_FATAL ANY\"" >> "$GITHUB_ENV"

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -376,7 +376,7 @@ jobs:
         pattern: build-*
 
     - name: Upload coverage to Codecov
-      if: matrix.os == 'ubuntu-20.04' && inputs.code_coverage == true
+      if: inputs.code_coverage == true
       uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -261,50 +261,50 @@ jobs:
         with:
           path: mmg
 
-      - name: Test compilation with shared libs linkage
-        run: |
-          cmake -Smmg -Bbuild_shared \
-          ${{ env.CMAKE_C_FLG }} \
-          ${{ env.FORT_FLG }} \
-            -DCI_CONTEXT=ON \
-            -DBUILD_TESTING=ON \
-            -DUSE_POINTMAP=${{ matrix.pointmap }} \
-            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
-            -DMMG_PATTERN=${{ matrix.pattern }} \
-            -DUSE_SCOTCH=${{ matrix.scotch }} \
-            -DSCOTCH_DIR=scotch-install \
-            -DUSE_VTK=${{ matrix.vtk }} \
-            -DMMG5_INT=${{ matrix.int }} \
-            -DBUILD_SHARED_LIBS=ON \
-            -DTEST_LIBMMG=ON \
-            -DTEST_LIBMMGS=ON \
-            -DTEST_LIBMMG2D=ON \
-            -DTEST_LIBMMG3D=ON \
-            ${{ inputs.add_cmake_cfg_args }}
-            cmake --build build_shared --config ${{ env.BUILD_TYPE }} -j ${{ env.NJOBS }}
-        shell: bash
+     #- name: Test compilation with shared libs linkage
+     #  run: |
+     #    cmake -Smmg -Bbuild_shared \
+     #    ${{ env.CMAKE_C_FLG }} \
+     #    ${{ env.FORT_FLG }} \
+     #      -DCI_CONTEXT=ON \
+     #      -DBUILD_TESTING=ON \
+     #      -DUSE_POINTMAP=${{ matrix.pointmap }} \
+     #      -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+     #      -DMMG_PATTERN=${{ matrix.pattern }} \
+     #      -DUSE_SCOTCH=${{ matrix.scotch }} \
+     #      -DSCOTCH_DIR=scotch-install \
+     #      -DUSE_VTK=${{ matrix.vtk }} \
+     #      -DMMG5_INT=${{ matrix.int }} \
+     #      -DBUILD_SHARED_LIBS=ON \
+     #      -DTEST_LIBMMG=ON \
+     #      -DTEST_LIBMMGS=ON \
+     #      -DTEST_LIBMMG2D=ON \
+     #      -DTEST_LIBMMG3D=ON \
+     #      ${{ inputs.add_cmake_cfg_args }}
+     #      cmake --build build_shared --config ${{ env.BUILD_TYPE }} -j ${{ env.NJOBS }}
+     #  shell: bash
 
-      - name: Test compilation without library linkage
-        run: |
-          cmake -Smmg -Bbuild_nolibs \
-          ${{ env.CMAKE_C_FLG }} \
-          ${{ env.FORT_FLG }} \
-            -DCI_CONTEXT=ON \
-            -DBUILD_TESTING=ON \
-            -DUSE_POINTMAP=${{ matrix.pointmap }} \
-            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
-            -DMMG_PATTERN=${{ matrix.pattern }} \
-            -DUSE_SCOTCH=${{ matrix.scotch }} \
-            -DSCOTCH_DIR=scotch-install \
-            -DUSE_VTK=${{ matrix.vtk }} \
-            -DMMG5_INT=${{ matrix.int }} \
-            -DLIBMMG_STATIC=OFF \
-            -DLIBMMGS_STATIC=OFF \
-            -DLIBMMG2D_STATIC=OFF \
-            -DLIBMMG3D_STATIC=OFF \
-            ${{ inputs.add_cmake_cfg_args }}
-            cmake --build build_nolibs --config ${{ env.BUILD_TYPE }} -j ${{ env.NJOBS }}
-        shell: bash
+     #- name: Test compilation without library linkage
+     #  run: |
+     #    cmake -Smmg -Bbuild_nolibs \
+     #    ${{ env.CMAKE_C_FLG }} \
+     #    ${{ env.FORT_FLG }} \
+     #      -DCI_CONTEXT=ON \
+     #      -DBUILD_TESTING=ON \
+     #      -DUSE_POINTMAP=${{ matrix.pointmap }} \
+     #      -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+     #      -DMMG_PATTERN=${{ matrix.pattern }} \
+     #      -DUSE_SCOTCH=${{ matrix.scotch }} \
+     #      -DSCOTCH_DIR=scotch-install \
+     #      -DUSE_VTK=${{ matrix.vtk }} \
+     #      -DMMG5_INT=${{ matrix.int }} \
+     #      -DLIBMMG_STATIC=OFF \
+     #      -DLIBMMGS_STATIC=OFF \
+     #      -DLIBMMG2D_STATIC=OFF \
+     #      -DLIBMMG3D_STATIC=OFF \
+     #      ${{ inputs.add_cmake_cfg_args }}
+     #      cmake --build build_nolibs --config ${{ env.BUILD_TYPE }} -j ${{ env.NJOBS }}
+     #  shell: bash
 
       - name: Configure Mmg with static libs (default behaviour)
         run: |
@@ -321,11 +321,7 @@ jobs:
             -DSCOTCH_DIR=scotch-install \
             -DUSE_VTK=${{ matrix.vtk }} \
             -DMMG5_INT=${{ matrix.int }} \
-            -DTEST_LIBMMG=ON \
-            -DTEST_LIBMMGS=ON \
-            -DTEST_LIBMMG2D=ON \
-            -DTEST_LIBMMG3D=ON \
-            ${{ inputs.add_cmake_cfg_args }}
+            -DONLY_VERY_SHORT_TESTS=ON
         shell: bash
 
       - name: Build Mmg

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -26,7 +26,7 @@ on:
 # job
 jobs:
   ci:
-    if: "! contains(github.event.head_commit.message, '[skip ci]')"
+    if: ! contains(github.event.head_commit.message, '[skip ci]')
     runs-on: ${{ matrix.os }}
 
     # Launch a matrix of jobs
@@ -192,7 +192,7 @@ jobs:
           NJOBS: "2"
 
       - name: Set environment variables for output comparison
-        if: "! contains(github.event.head_commit.message, '[skip output comparison]')"
+        if: ! contains(github.event.head_commit.message, '[skip output comparison]')
         run: |
           echo "C_FLG=-DMMG_COMPARABLE_OUTPUT" >> "$GITHUB_ENV"
           echo "MMG_ERROR_RULE=\"COMMAND_ERROR_IS_FATAL ANY\"" >> "$GITHUB_ENV"

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -261,50 +261,50 @@ jobs:
         with:
           path: mmg
 
-     #- name: Test compilation with shared libs linkage
-     #  run: |
-     #    cmake -Smmg -Bbuild_shared \
-     #    ${{ env.CMAKE_C_FLG }} \
-     #    ${{ env.FORT_FLG }} \
-     #      -DCI_CONTEXT=ON \
-     #      -DBUILD_TESTING=ON \
-     #      -DUSE_POINTMAP=${{ matrix.pointmap }} \
-     #      -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
-     #      -DMMG_PATTERN=${{ matrix.pattern }} \
-     #      -DUSE_SCOTCH=${{ matrix.scotch }} \
-     #      -DSCOTCH_DIR=scotch-install \
-     #      -DUSE_VTK=${{ matrix.vtk }} \
-     #      -DMMG5_INT=${{ matrix.int }} \
-     #      -DBUILD_SHARED_LIBS=ON \
-     #      -DTEST_LIBMMG=ON \
-     #      -DTEST_LIBMMGS=ON \
-     #      -DTEST_LIBMMG2D=ON \
-     #      -DTEST_LIBMMG3D=ON \
-     #      ${{ inputs.add_cmake_cfg_args }}
-     #      cmake --build build_shared --config ${{ env.BUILD_TYPE }} -j ${{ env.NJOBS }}
-     #  shell: bash
+      - name: Test compilation with shared libs linkage
+        run: |
+          cmake -Smmg -Bbuild_shared \
+          ${{ env.CMAKE_C_FLG }} \
+          ${{ env.FORT_FLG }} \
+            -DCI_CONTEXT=ON \
+            -DBUILD_TESTING=ON \
+            -DUSE_POINTMAP=${{ matrix.pointmap }} \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -DMMG_PATTERN=${{ matrix.pattern }} \
+            -DUSE_SCOTCH=${{ matrix.scotch }} \
+            -DSCOTCH_DIR=scotch-install \
+            -DUSE_VTK=${{ matrix.vtk }} \
+            -DMMG5_INT=${{ matrix.int }} \
+            -DBUILD_SHARED_LIBS=ON \
+            -DTEST_LIBMMG=ON \
+            -DTEST_LIBMMGS=ON \
+            -DTEST_LIBMMG2D=ON \
+            -DTEST_LIBMMG3D=ON \
+            ${{ inputs.add_cmake_cfg_args }}
+            cmake --build build_shared --config ${{ env.BUILD_TYPE }} -j ${{ env.NJOBS }}
+        shell: bash
 
-     #- name: Test compilation without library linkage
-     #  run: |
-     #    cmake -Smmg -Bbuild_nolibs \
-     #    ${{ env.CMAKE_C_FLG }} \
-     #    ${{ env.FORT_FLG }} \
-     #      -DCI_CONTEXT=ON \
-     #      -DBUILD_TESTING=ON \
-     #      -DUSE_POINTMAP=${{ matrix.pointmap }} \
-     #      -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
-     #      -DMMG_PATTERN=${{ matrix.pattern }} \
-     #      -DUSE_SCOTCH=${{ matrix.scotch }} \
-     #      -DSCOTCH_DIR=scotch-install \
-     #      -DUSE_VTK=${{ matrix.vtk }} \
-     #      -DMMG5_INT=${{ matrix.int }} \
-     #      -DLIBMMG_STATIC=OFF \
-     #      -DLIBMMGS_STATIC=OFF \
-     #      -DLIBMMG2D_STATIC=OFF \
-     #      -DLIBMMG3D_STATIC=OFF \
-     #      ${{ inputs.add_cmake_cfg_args }}
-     #      cmake --build build_nolibs --config ${{ env.BUILD_TYPE }} -j ${{ env.NJOBS }}
-     #  shell: bash
+      - name: Test compilation without library linkage
+        run: |
+          cmake -Smmg -Bbuild_nolibs \
+          ${{ env.CMAKE_C_FLG }} \
+          ${{ env.FORT_FLG }} \
+            -DCI_CONTEXT=ON \
+            -DBUILD_TESTING=ON \
+            -DUSE_POINTMAP=${{ matrix.pointmap }} \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -DMMG_PATTERN=${{ matrix.pattern }} \
+            -DUSE_SCOTCH=${{ matrix.scotch }} \
+            -DSCOTCH_DIR=scotch-install \
+            -DUSE_VTK=${{ matrix.vtk }} \
+            -DMMG5_INT=${{ matrix.int }} \
+            -DLIBMMG_STATIC=OFF \
+            -DLIBMMGS_STATIC=OFF \
+            -DLIBMMG2D_STATIC=OFF \
+            -DLIBMMG3D_STATIC=OFF \
+            ${{ inputs.add_cmake_cfg_args }}
+            cmake --build build_nolibs --config ${{ env.BUILD_TYPE }} -j ${{ env.NJOBS }}
+        shell: bash
 
       - name: Configure Mmg with static libs (default behaviour)
         run: |
@@ -321,7 +321,11 @@ jobs:
             -DSCOTCH_DIR=scotch-install \
             -DUSE_VTK=${{ matrix.vtk }} \
             -DMMG5_INT=${{ matrix.int }} \
-            -DONLY_VERY_SHORT_TESTS=ON
+            -DTEST_LIBMMG=ON \
+            -DTEST_LIBMMGS=ON \
+            -DTEST_LIBMMG2D=ON \
+            -DTEST_LIBMMG3D=ON \
+            ${{ inputs.add_cmake_cfg_args }}
         shell: bash
 
       - name: Build Mmg

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -360,56 +360,8 @@ jobs:
             build
 
   upload_coverage:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     needs: ci
-
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-        pattern: [on,off]
-        pointmap: [off]
-        scotch: [on,off]
-        vtk: [off]
-        int: [int32_t]
-
-        include:
-          # test vtk only without scotch
-          - os: ubuntu-20.04
-            pattern: off
-            pointmap: off
-            scotch: off
-            vtk: on
-            int: int32_t
-
-          # Test pointmap with scotch excep
-          - os: ubuntu-20.04
-            pattern: off
-            pointmap: on
-            scotch: on
-            vtk: off
-            int: int32_t
-
-          # Test int64_t build on all archi
-          - os: ubuntu-20.04
-            pattern: on
-            pointmap: on
-            scotch: on
-            vtk: on
-            int: int64_t
-
-          - os: ubuntu-20.04
-            pattern: off
-            pointmap: off
-            scotch: on
-            vtk: on
-            int: int64_t
-
-          - os: ubuntu-20.04
-            pattern: off
-            pointmap: off
-            scotch: off
-            vtk: off
-            int: int64_t
 
     steps:
     - name: Checkout repository
@@ -421,8 +373,7 @@ jobs:
     - name: Download coverage artifact
       uses: actions/download-artifact@v4
       with:
-        name: build-${{ matrix.os }}-${{ matrix.pattern }}-${{ matrix.pointmap }}-${{ matrix.scotch }}-${{ matrix.vtk }}-${{ matrix.int }}
-        path: build
+        pattern: build-*
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-20.04' && inputs.code_coverage == true

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -331,13 +331,6 @@ jobs:
         run: |
           cmake --build build --target install --config ${{ env.BUILD_TYPE }} -j ${{ env.NJOBS }}
 
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: Mmg-bin-${{ matrix.os }}-${{ matrix.pattern }}-${{ matrix.pointmap }}-${{ matrix.scotch }}-${{ matrix.vtk }}-${{ matrix.int }}
-          path: |
-            build/bin
-
       - name: Test Mmg with in32_t integers
         # Run long tests only with vtk off and int32_t integers
         if: matrix.vtk == 'off' && matrix.int == 'int32_t'
@@ -358,20 +351,85 @@ jobs:
           cd build
           ctest -R "msh|vtk" -VV -C ${{ env.BUILD_TYPE }} -j ${{ env.NJOBS }}
 
-      - name: Archive production artifacts for tests
+      - name: Archive production artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: Mmg-tests-${{ matrix.os }}-${{ matrix.pattern }}-${{ matrix.pointmap }}-${{ matrix.scotch }}-${{ matrix.vtk }}-${{ matrix.int }}
+          name: build-${{ matrix.os }}-${{ matrix.pattern }}-${{ matrix.pointmap }}-${{ matrix.scotch }}-${{ matrix.vtk }}-${{ matrix.int }}
           path: |
-            build/TEST_OUTPUTS
+            build
 
-      - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-20.04' && inputs.code_coverage == true
-        uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: true
-          root_dir: .
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  upload_coverage:
+    runs-on: ${{ matrix.os }}
+    needs: ci
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        pattern: [on,off]
+        pointmap: [off]
+        scotch: [on,off]
+        vtk: [off]
+        int: [int32_t]
+
+        include:
+          # test vtk only without scotch
+          - os: ubuntu-20.04
+            pattern: off
+            pointmap: off
+            scotch: off
+            vtk: on
+            int: int32_t
+
+          # Test pointmap with scotch excep
+          - os: ubuntu-20.04
+            pattern: off
+            pointmap: on
+            scotch: on
+            vtk: off
+            int: int32_t
+
+          # Test int64_t build on all archi
+          - os: ubuntu-20.04
+            pattern: on
+            pointmap: on
+            scotch: on
+            vtk: on
+            int: int64_t
+
+          - os: ubuntu-20.04
+            pattern: off
+            pointmap: off
+            scotch: on
+            vtk: on
+            int: int64_t
+
+          - os: ubuntu-20.04
+            pattern: off
+            pointmap: off
+            scotch: off
+            vtk: off
+            int: int64_t
+
+    steps:
+    - name: Checkout repository
+      # Codecov need the source code to pair with coverage
+      uses: actions/checkout@v4
+      with:
+        path: mmg
+
+    - name: Download coverage artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: build-${{ matrix.os }}-${{ matrix.pattern }}-${{ matrix.pointmap }}-${{ matrix.scotch }}-${{ matrix.vtk }}-${{ matrix.int }}
+        path: build
+
+    - name: Upload coverage to Codecov
+      if: matrix.os == 'ubuntu-20.04' && inputs.code_coverage == true
+      uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: true
+        root_dir: .
+        verbose: true
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This PR allows to have two jobs that can be triggered independently in case of failure:
  - the Mmg configuration, build and tests;
  - the coverage submission.

As the coverage submission randomly fails with no reason, it allows to retry the submission from the github interface without running the entire Mmg tests.