### PR TITLE
Feature/required vertices preservation

### DIFF
--- a/cmake/testing/code/req-vert-3d.c
+++ b/cmake/testing/code/req-vert-3d.c
@@ -1,0 +1,135 @@
+/* =============================================================================
+**  This file is part of the mmg software package for the tetrahedral
+**  mesh modification.
+**  Copyright (c) Bx INP/Inria/UBordeaux/UPMC, 2004- .
+**
+**  mmg is free software: you can redistribute it and/or modify it
+**  under the terms of the GNU Lesser General Public License as published
+**  by the Free Software Foundation, either version 3 of the License, or
+**  (at your option) any later version.
+**
+**  mmg is distributed in the hope that it will be useful, but WITHOUT
+**  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+**  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+**  License for more details.
+**
+**  You should have received a copy of the GNU Lesser General Public
+**  License and of the GNU General Public License along with mmg (in
+**  files COPYING.LESSER and COPYING). If not, see
+**  <http://www.gnu.org/licenses/>. Please read their terms carefully and
+**  use this copy of the mmg distribution only if you accept them.
+** =============================================================================
+*/
+
+/**
+ * Test preservation of required vertex: vertex 1 is required and shoule not move.
+ *
+ * \author Charles Dapogny (LJLL, UPMC)
+ * \author Cécile Dobrzynski (Inria / IMB, Université de Bordeaux)
+ * \author Pascal Frey (LJLL, UPMC)
+ * \author Algiane Froehly (Inria / IMB, Université de Bordeaux)
+ * \version 5
+ * \copyright GNU Lesser General Public License.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <string.h>
+#include <ctype.h>
+#include <math.h>
+#include <float.h>
+
+/** Include the mmg3d library hader file */
+// if the header file is in the "include" directory
+// #include "libmmg3d.h"
+// if the header file is in "include/mmg/mmg3d"
+#include "libmmg3d_private.h"
+#include "mmg/mmg3d/libmmg3d.h"
+
+int main(int argc,char *argv[]) {
+  MMG5_pMesh      mesh;
+  MMG5_pSol       sol;
+  char            *file;
+  double          c[3];
+  int             k,ier;
+
+  fprintf(stdout,"  -- CHECK PRESERVATION OF REQUIRED VERTICES \n");
+
+  if ( argc != 2 ) {
+    printf(" Usage: %s filein \n",argv[0]);
+    return(1);
+  }
+
+  /* Name and path of the mesh file */
+  file = (char *) calloc(strlen(argv[1]) + 1, sizeof(char));
+  if ( file == NULL ) {
+    perror("  ## Memory problem: calloc");
+    exit(EXIT_FAILURE);
+  }
+  strcpy(file,argv[1]);
+
+  /** Read mesh */
+  mesh = NULL;
+  sol  = NULL;
+  MMG3D_Init_mesh(MMG5_ARG_start,
+                  MMG5_ARG_ppMesh,&mesh,
+                  MMG5_ARG_ppMet,&sol,
+                  MMG5_ARG_end);
+
+  if ( MMG3D_loadMesh(mesh,file) != 1 )  {
+    fprintf(stderr,"Error: %s: %d: File not found %s\n.",__func__,__LINE__,file);
+    exit(EXIT_FAILURE);
+  }
+
+  /** Check that vertex number 1 is required and store its coordinates */
+  if ( !(mesh->point[1].tag & MG_REQ) ) {
+    fprintf(stderr,"Error: %s: %d: This test expects that vertex of index 1 is required\n.",__func__,__LINE__);
+    exit(EXIT_FAILURE);
+  }
+  c[0] = mesh->point[1].c[0];
+  c[1] = mesh->point[1].c[1];
+  c[2] = mesh->point[1].c[2];
+
+  /** Enable vertex regularisation */
+  if ( MMG3D_Set_iparameter(mesh,sol,MMG3D_IPARAM_xreg,1) != 1 )
+    exit(EXIT_FAILURE);
+
+  /** remesh function */
+  ier = MMG3D_mmg3dlib(mesh,sol);
+
+
+  /** Check that coordinates of vertex 1 (that is required) have not changed. */
+  double dd[3];
+  dd[0] =  c[0] -  mesh->point[1].c[0];
+  dd[1] =  c[1] -  mesh->point[1].c[1];
+  dd[2] =  c[2] -  mesh->point[1].c[2];
+
+
+  int j;
+  for (j=0; j<3; ++j) {
+    printf("%.15lf %.15lf\n",c[j],mesh->point[1].c[j]);
+    if ( fabs(c[j]- mesh->point[1].c[j]) > 1e-5 ) {
+      fprintf(stderr,"Error: %s: %d:"
+              " Modification of coordinates of vertex 1 (required):"
+              "   input  coor: %15lf %15lf %15lf\n"
+              "   output coor: %15lf %15lf %15lf\n",__func__,__LINE__,
+                  c[0],c[1],c[2], mesh->point[1].c[0], mesh->point[1].c[1], mesh->point[1].c[2]);
+      exit(EXIT_FAILURE);
+    }
+  }
+
+  fprintf(stdout,"MMG3D: REQUIRED VERTEX SUCCESFULLY PRESERVED.\n");
+
+  /** 3) Free the MMG3D5 structures */
+  MMG3D_Free_all(MMG5_ARG_start,
+                 MMG5_ARG_ppMesh,&mesh,
+                 MMG5_ARG_ppMet,&sol,
+                 MMG5_ARG_end);
+
+  free(file);
+  file = NULL;
+
+  return 0;
+}

--- a/cmake/testing/code/req-vert-s.c
+++ b/cmake/testing/code/req-vert-s.c
@@ -1,0 +1,135 @@
+/* =============================================================================
+**  This file is part of the mmg software package for the tetrahedral
+**  mesh modification.
+**  Copyright (c) Bx INP/Inria/UBordeaux/UPMC, 2004- .
+**
+**  mmg is free software: you can redistribute it and/or modify it
+**  under the terms of the GNU Lesser General Public License as published
+**  by the Free Software Foundation, either version 3 of the License, or
+**  (at your option) any later version.
+**
+**  mmg is distributed in the hope that it will be useful, but WITHOUT
+**  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+**  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+**  License for more details.
+**
+**  You should have received a copy of the GNU Lesser General Public
+**  License and of the GNU General Public License along with mmg (in
+**  files COPYING.LESSER and COPYING). If not, see
+**  <http://www.gnu.org/licenses/>. Please read their terms carefully and
+**  use this copy of the mmg distribution only if you accept them.
+** =============================================================================
+*/
+
+/**
+ * Test preservation of required vertex: vertex 1 is required and shoule not move.
+ *
+ * \author Charles Dapogny (LJLL, UPMC)
+ * \author Cécile Dobrzynski (Inria / IMB, Université de Bordeaux)
+ * \author Pascal Frey (LJLL, UPMC)
+ * \author Algiane Froehly (Inria / IMB, Université de Bordeaux)
+ * \version 5
+ * \copyright GNU Lesser General Public License.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <string.h>
+#include <ctype.h>
+#include <math.h>
+#include <float.h>
+
+/** Include the mmg3d library hader file */
+// if the header file is in the "include" directory
+// #include "libmmg3d.h"
+// if the header file is in "include/mmg/mmg3d"
+#include "libmmgs_private.h"
+#include "mmg/mmgs/libmmgs.h"
+
+int main(int argc,char *argv[]) {
+  MMG5_pMesh      mesh;
+  MMG5_pSol       sol;
+  char            *file;
+  double          c[3];
+  int             k,ier;
+
+  fprintf(stdout,"  -- CHECK PRESERVATION OF REQUIRED VERTICES \n");
+
+  if ( argc != 2 ) {
+    printf(" Usage: %s filein \n",argv[0]);
+    return(1);
+  }
+
+  /* Name and path of the mesh file */
+  file = (char *) calloc(strlen(argv[1]) + 1, sizeof(char));
+  if ( file == NULL ) {
+    perror("  ## Memory problem: calloc");
+    exit(EXIT_FAILURE);
+  }
+  strcpy(file,argv[1]);
+
+  /** Read mesh */
+  mesh = NULL;
+  sol  = NULL;
+  MMGS_Init_mesh(MMG5_ARG_start,
+                 MMG5_ARG_ppMesh,&mesh,
+                 MMG5_ARG_ppMet,&sol,
+                 MMG5_ARG_end);
+
+  if ( MMGS_loadMesh(mesh,file) != 1 )  {
+    fprintf(stderr,"Error: %s: %d: File not found %s\n.",__func__,__LINE__,file);
+    exit(EXIT_FAILURE);
+  }
+
+  /** Check that vertex number 1 is required and store its coordinates */
+  if ( !(mesh->point[1].tag & MG_REQ) ) {
+    fprintf(stderr,"Error: %s: %d: This test expects that vertex of index 1 is required\n.",__func__,__LINE__);
+    exit(EXIT_FAILURE);
+  }
+  c[0] = mesh->point[1].c[0];
+  c[1] = mesh->point[1].c[1];
+  c[2] = mesh->point[1].c[2];
+
+  /** Enable vertex regularisation */
+  if ( MMGS_Set_iparameter(mesh,sol,MMGS_IPARAM_xreg,1) != 1 )
+    exit(EXIT_FAILURE);
+
+  /** remesh function */
+  ier = MMGS_mmgslib(mesh,sol);
+
+
+  /** Check that coordinates of vertex 1 (that is required) have not changed. */
+  double dd[3];
+  dd[0] =  c[0] -  mesh->point[1].c[0];
+  dd[1] =  c[1] -  mesh->point[1].c[1];
+  dd[2] =  c[2] -  mesh->point[1].c[2];
+
+
+  int j;
+  for (j=0; j<3; ++j) {
+    printf("%.15lf %.15lf\n",c[j],mesh->point[1].c[j]);
+    if ( fabs(c[j]- mesh->point[1].c[j]) > 1e-5 ) {
+      fprintf(stderr,"Error: %s: %d:"
+              " Modification of coordinates of vertex 1 (required):"
+              "   input  coor: %15lf %15lf %15lf\n"
+              "   output coor: %15lf %15lf %15lf\n",__func__,__LINE__,
+                  c[0],c[1],c[2], mesh->point[1].c[0], mesh->point[1].c[1], mesh->point[1].c[2]);
+      exit(EXIT_FAILURE);
+    }
+  }
+
+  fprintf(stdout,"MMGS: REQUIRED VERTEX SUCCESFULLY PRESERVED.\n");
+
+  /** 3) Free the MMG structures */
+  MMGS_Free_all(MMG5_ARG_start,
+                MMG5_ARG_ppMesh,&mesh,
+                MMG5_ARG_ppMet,&sol,
+                MMG5_ARG_end);
+
+  free(file);
+  file = NULL;
+
+  return 0;
+}

--- a/cmake/testing/libmmg3d_tests.cmake
+++ b/cmake/testing/libmmg3d_tests.cmake
@@ -53,6 +53,7 @@ IF ( MMG3D_CI AND NOT ONLY_VERY_SHORT_TESTS )
     # headers, it will ask to sort the needed source files too). Added here, we
     # can use the ADD_LIBRARY_TEST macro...
     test_compare-para-tria
+    test_req-vert-3d
     )
 ENDIF ( )
 
@@ -86,6 +87,7 @@ IF ( MMG3D_CI AND NOT ONLY_VERY_SHORT_TESTS )
     ${MMG3D_CI_TESTS}/API_tests/vtk2mesh.c
     # Following pieces of code are left in repo to take advantage of versionning
     ${PROJECT_SOURCE_DIR}/cmake/testing/code/compare-para-tria.c
+    ${PROJECT_SOURCE_DIR}/cmake/testing/code/req-vert-3d.c
     )
 ENDIF( )
 
@@ -300,6 +302,11 @@ IF ( MMG3D_CI AND NOT ONLY_VERY_SHORT_TESTS )
     )
   SET_TESTS_PROPERTIES ( test_ridge_preservation_in_ls_mode
     PROPERTIES FIXTURES_REQUIRED mmg3d_OptLs_NM_ridge )
+
+  ADD_TEST(NAME test_req-vert-3d
+    COMMAND ${EXECUTABLE_OUTPUT_PATH}/test_req-vert-3d
+    ${MMG3D_CI_TESTS}/test_req_vert/cube.mesh
+    )
 
 ENDIF()
 

--- a/cmake/testing/libmmgs_tests.cmake
+++ b/cmake/testing/libmmgs_tests.cmake
@@ -54,6 +54,24 @@ SET ( MMGS_LIB_TESTS_MAIN_PATH
   ${PROJECT_SOURCE_DIR}/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main.c
   )
 
+# Additional tests that needs to download ci meshes
+IF ( MMGS_CI AND NOT ONLY_VERY_SHORT_TESTS )
+  LIST ( APPEND MMGS_LIB_TESTS
+    # Remark: not clean -> next tests don't need the library in fact (moving them
+    # in app tests will ask to clean the installation of public and private
+    # headers, it will ask to sort the needed source files too). Added here, we
+    # can use the ADD_LIBRARY_TEST macro...
+    test_req-vert-s
+  )
+
+  LIST ( APPEND MMGS_LIB_TESTS_MAIN_PATH
+    # Following pieces of code are left in repo to take advantage of versionning
+    ${PROJECT_SOURCE_DIR}/cmake/testing/code/req-vert-s.c
+
+  )
+ENDIF ( )
+
+
 IF ( LIBMMGS_STATIC )
   SET ( lib_name lib${PROJECT_NAME}s_a )
   SET ( lib_type "STATIC" )
@@ -148,6 +166,13 @@ ADD_TEST(NAME libmmgs_lsAndMetric
   "${PROJECT_SOURCE_DIR}/libexamples/mmgs/IsosurfDiscretization_lsOnly/multi-mat-sol.sol"
   "${CTEST_OUTPUT_DIR}/libmmgs_lsAndMetric_multimat.o"
   )
+
+IF ( MMGS_CI AND NOT ONLY_VERY_SHORT_TESTS )
+  ADD_TEST(NAME test_req-vert-s
+    COMMAND ${EXECUTABLE_OUTPUT_PATH}/test_req-vert-s
+    ${MMGS_CI_TESTS}/test_req_vert/cube.mesh
+    )
+ENDIF ( )
 
 IF ( CMAKE_Fortran_COMPILER AND PERL_FOUND ) 
   SET(LIBMMGS_EXECFORTRAN_a ${EXECUTABLE_OUTPUT_PATH}/libmmgs_fortran_a)

--- a/src/mmg3d/analys_3d.c
+++ b/src/mmg3d/analys_3d.c
@@ -1008,7 +1008,7 @@ int MMG3D_regver(MMG5_pMesh mesh) {
       tabl[iad+1] = ppt->c[1];
       tabl[iad+2] = ppt->c[2];
       if ( !MG_VOK(ppt) )  continue;
-      if ( ppt->tag & MG_CRN || ppt->tag & MG_NOM || MG_EDG(ppt->tag) ) continue;
+      if ( MG_SIN(ppt->tag) || ppt->tag & MG_NOM || MG_EDG(ppt->tag) ) continue;
 
       iel = ppt->s;
       if ( !iel ) continue; // Mmg3d
@@ -1048,7 +1048,7 @@ int MMG3D_regver(MMG5_pMesh mesh) {
       ppt = &mesh->point[k];
 
       if ( !MG_VOK(ppt) )  continue;
-      if ( ppt->tag & MG_CRN || ppt->tag & MG_NOM || MG_EDG(ppt->tag) ) continue;
+      if ( MG_SIN(ppt->tag) || ppt->tag & MG_NOM || MG_EDG(ppt->tag) ) continue;
 
       iel = ppt->s;
       if ( !iel ) continue; // Mmg3d

--- a/src/mmgs/analys_s.c
+++ b/src/mmgs/analys_s.c
@@ -854,7 +854,7 @@ int MMGS_regver(MMG5_pMesh mesh) {
       tabl[iad+2] = ppt->c[2];
 
       if ( !MG_VOK(ppt) )  continue;
-      if ( ppt->tag & MG_CRN || ppt->tag & MG_NOM || MG_EDG(ppt->tag) ) continue;
+      if ( MG_SIN(ppt->tag) || ppt->tag & MG_NOM || MG_EDG(ppt->tag) ) continue;
 
       iel = ppt->s;
 
@@ -893,7 +893,7 @@ int MMGS_regver(MMG5_pMesh mesh) {
       ppt = &mesh->point[k];
 
       if ( !MG_VOK(ppt) )  continue;
-      if ( ppt->tag & MG_CRN || ppt->tag & MG_NOM || MG_EDG(ppt->tag) ) continue;
+      if ( MG_SIN(ppt->tag) || ppt->tag & MG_NOM || MG_EDG(ppt->tag) ) continue;
 
       iel = ppt->s;
 


### PR DESCRIPTION
The `xreg` option (regularization of the position of boundary vertices) was not preserving required vertices. The current PR:
  1. adds a continuous intgration test that test the preservation of an input vertex (in `cmake/testing/code/req-vert-3d.c`)
  2. adds the check of required vertices in the `xreq` option.

