### PR TITLE
Ensure that required triangles are preserved

### DIFF
--- a/src/mmg3d/hash_3d.c
+++ b/src/mmg3d/hash_3d.c
@@ -1387,7 +1387,8 @@ int MMG5_bdryTria(MMG5_pMesh mesh, MMG5_int ntmesh) {
                     so we remove the tags MG_NOSURF and MG_REQ only if the edge is identified as MG_NOSURF */
                 if ( ptt->tag[j] & MG_PARBDY ) {
                   ptt->tag[j] &= ~MG_PARBDY;
-                  /* a truly required entity does not have MG_NOSURF tag so reapply MG_REQ tag */
+                  /* a truly required entity does not have MG_NOSURF tag so don't remove MG_REQ tag */
+                  /* if MG_NOSURF tag, then also remove MG_REQ and MG_SURF tags */
                   if( ptt->tag[j] & MG_NOSURF ) {
                     ptt->tag[j] &= ~MG_NOSURF;
                     ptt->tag[j] &= ~MG_REQ;


### PR DESCRIPTION
**This PR**
1. Fix a bug introduced by PR #239
2. Improve comments

**Explanations of 1.** 
A bug was introduced by PR #239: triangles required by the user in the input mesh were not preserved anymore.

Indeed, in PR #239, if the face was not `MG_PARALLEL`, then the tags `MG_REQ+MG_SURF` were removed, while only `MG_SURF` should have been removed if the triangle was initially required by the user.

Now, i.e. in this PR, the tag `MG_REQ` of edges is removed only if the edge is `MG_PARALLEL` and `MG_SURF`.
By convention in ParMmg (see tag_pmmg.c in ParMmg), if an entity is
- parallel + not required: the tags are `MG_PARBDY+MG_NOSURF+MG_REQ`;
- parallel + truly required by the user: the tags are `MG_PARBDY+MG_REQ`;

so we remove the tags `MG_NOSURF` and `MG_REQ` only if the edge is effectively `MG_PARALLEL` and identified as `MG_NOSURF`.