### PR TITLE
Modification of tag transmission from edges to faces in analysis

### DIFF
--- a/src/mmg3d/analys_3d.c
+++ b/src/mmg3d/analys_3d.c
@@ -1471,6 +1471,10 @@ int MMG3D_analys(MMG5_pMesh mesh) {
   /* define geometry for non manifold points */
   if ( !MMG3D_nmgeom(mesh) ) return 0;
 
+#ifndef NDEBUG
+  MMG3D_chkfacetags(mesh);
+#endif
+
 #ifdef USE_POINTMAP
   /* Initialize source point with input index */
   MMG5_int ip;

--- a/src/mmg3d/chkmsh_3d.c
+++ b/src/mmg3d/chkmsh_3d.c
@@ -307,6 +307,31 @@ void MMG3D_chkedgetag(MMG5_pMesh mesh, MMG5_int ip1, MMG5_int ip2, int tag) {
 
 /**
  * \param mesh pointer to the mesh
+ *
+ * Check that faces do not have nonsensical tags (MG_GEO, MG_NOM, MG_CRN).
+ *
+ */
+void MMG3D_chkfacetags(MMG5_pMesh mesh) {
+  MMG5_pTetra  pt;
+  MMG5_pxTetra pxt;
+  MMG5_int     k;
+  int          i, tag;
+
+  for (k=1; k<=mesh->ne; k++) {
+    pt = &mesh->tetra[k];
+    if ( !MG_EOK(pt) )  continue;
+    if ( !pt->xt ) continue;
+
+    pxt = &mesh->xtetra[pt->xt];
+    for (i=0; i<4; i++) {
+      tag = pxt->ftag[i];
+      assert(!(tag & (MG_GEO & MG_NOM & MG_CRN)) && "Nonsensical tag on face");
+    }
+  }
+}
+
+/**
+ * \param mesh pointer to the mesh
  * \param ppt pointer to unconsistent point
  * \param k tetra index
  * \param i local index of edge in tetra \a k
@@ -482,6 +507,9 @@ int MMG5_mmg3dChkmsh(MMG5_pMesh mesh,int severe,MMG5_int base) {
 
   /* Check edge tag consistency (between xtetra) */
   MMG3D_chkmeshedgestags(mesh);
+
+  /* Check that faces do not have nonsensical tags*/
+  MMG3D_chkfacetags(mesh);
 
   /* Check point tags consistency with edge tag */
   MMG3D_chkpointtag(mesh);

--- a/src/mmg3d/chkmsh_3d.c
+++ b/src/mmg3d/chkmsh_3d.c
@@ -325,7 +325,7 @@ void MMG3D_chkfacetags(MMG5_pMesh mesh) {
     pxt = &mesh->xtetra[pt->xt];
     for (i=0; i<4; i++) {
       tag = pxt->ftag[i];
-      assert(!(tag & (MG_GEO & MG_NOM & MG_CRN)) && "Nonsensical tag on face");
+      assert(!(tag & (MG_GEO | MG_NOM | MG_CRN)) && "Nonsensical tag on face");
     }
   }
 }

--- a/src/mmg3d/hash_3d.c
+++ b/src/mmg3d/hash_3d.c
@@ -2058,6 +2058,8 @@ int MMG5_bdrySet(MMG5_pMesh mesh) {
         pxt->ref[i]   = ptt->ref;
         pxt->ftag[i] |= MG_BDY;
 
+        /* here we may wrongfully add MG_REF and/or MG_BDY face tags to internal triangles
+        in opnbdy mode */
         /* Store tags that are common to the 3 edges of the triangles */
         tag = (ptt->tag[0] & ptt->tag[1] & ptt->tag[2]);
 

--- a/src/mmg3d/hash_3d.c
+++ b/src/mmg3d/hash_3d.c
@@ -2014,7 +2014,17 @@ int MMG5_bdrySet(MMG5_pMesh mesh) {
           pxt = &mesh->xtetra[pt->xt];
           pxt->ref[i]   = ptt->ref;
           pxt->ftag[i] |= MG_BDY;
-          pxt->ftag[i] |= (ptt->tag[0] & ptt->tag[1] & ptt->tag[2]);
+
+          /* Store tags that are common to the 3 edges of the triangles */
+          tag = (ptt->tag[0] & ptt->tag[1] & ptt->tag[2]);
+
+          /* Remove infos that make no sense along faces */
+          tag &= ~MG_GEO;
+          tag &= ~MG_NOM;
+          assert(  !(tag & MG_CRN) && "MG_CRN tag has no sense along edges" );
+
+          /* Assign tag to the face */
+          pxt->ftag[i] |= tag;
         }
       }
     }
@@ -2047,7 +2057,17 @@ int MMG5_bdrySet(MMG5_pMesh mesh) {
         pxt = &mesh->xtetra[mesh->xt];
         pxt->ref[i]   = ptt->ref;
         pxt->ftag[i] |= MG_BDY;
-        pxt->ftag[i] |= (ptt->tag[0] & ptt->tag[1] & ptt->tag[2]);
+
+        /* Store tags that are common to the 3 edges of the triangles */
+        tag = (ptt->tag[0] & ptt->tag[1] & ptt->tag[2]);
+
+        /* Remove infos that make no sense along faces */
+        tag &= ~MG_GEO;
+        tag &= ~MG_NOM;
+        assert(  !(tag & MG_CRN) && "MG_CRN tag has no sense along edges" );
+
+        /* Assign tag to the face */
+        pxt->ftag[i] |= tag;
       }
     }
   }

--- a/src/mmg3d/hash_3d.c
+++ b/src/mmg3d/hash_3d.c
@@ -2228,7 +2228,17 @@ int MMG5_bdrySet(MMG5_pMesh mesh) {
       pxp = &mesh->xprism[mesh->xpr];
       pxp->ref[i]   = ptt->ref;
       pxp->ftag[i] |= MG_BDY;
-      pxp->ftag[i] |= (ptt->tag[0] & ptt->tag[1] & ptt->tag[2]);
+
+      /* Store tags that are common to the 3 edges of the triangles */
+      tag = (ptt->tag[0] & ptt->tag[1] & ptt->tag[2]);
+
+      /* Remove infos that make no sense along faces */
+      tag &= ~MG_GEO;
+      tag &= ~MG_NOM;
+      assert(  !(tag & MG_CRN) && "MG_CRN tag has no sense along edges" );
+
+      /* Assign tag to the face */
+      pxp->ftag[i] |= tag;
 
       for (j=0; j<3; j++) {
         pxp->tag[MMG5_iarf[i][j]] |= pxp->ftag[i] | ptt->tag[j];

--- a/src/mmg3d/libmmg3d_private.h
+++ b/src/mmg3d/libmmg3d_private.h
@@ -466,6 +466,7 @@ MMG5_int  MMG3D_indPt(MMG5_pMesh mesh,MMG5_int kp);
 void MMG5_printTetra(MMG5_pMesh mesh,char* fileName);
 void MMG3D_chkpointtag(MMG5_pMesh mesh);
 void MMG3D_chkmeshedgestags(MMG5_pMesh mesh);
+void MMG3D_chkfacetags(MMG5_pMesh mesh);
 int MMG3D_chk_shellEdgeTag(MMG5_pMesh  mesh,MMG5_int start, int8_t ia,int16_t tag,MMG5_int ref);
 
 #ifdef USE_SCOTCH


### PR DESCRIPTION
In function `MMG5_bdrySet`, if all three edges of a face share a given tag, this tag is given to the face (field `xt->ftag[]`). Some edge tags do not make sense when applied to a face (MG_GEO or/and MG_NOM). This could cause bugs in splits when a newly create edge wrongly received such tags from a face. This update removes such nonsensical tags.