### PR TITLE
Fix wrong integer conversion when computing xpmax in norver function

### DIFF
--- a/src/mmg3d/analys_3d.c
+++ b/src/mmg3d/analys_3d.c
@@ -685,7 +685,7 @@ int MMG5_norver(MMG5_pMesh mesh) {
   }
 
   /** Step 2: Allocate memory to store normals for boundary points */
-  mesh->xpmax  = MG_MAX( (long long)(1.5*mesh->xp),mesh->npmax);
+  mesh->xpmax  = MG_MAX( (MMG5_int)(1.5*mesh->xp),mesh->npmax);
 
   MMG5_ADD_MEM(mesh,(mesh->xpmax+1)*sizeof(MMG5_xPoint),"boundary points",return 0);
   MMG5_SAFE_CALLOC(mesh->xpoint,mesh->xpmax+1,MMG5_xPoint,return 0);


### PR DESCRIPTION
As `mesh->xpmax, mesh->xp and mesh->npmax` are `MMG5_int` (since the adding of `int64_t` integers support), we have to cast the double value computed into a `MMG5_int` value and not a `long long` one.