### PR TITLE
Fix storage of tags in `MMG5_swap23`

### DIFF
--- a/src/mmg3d/chkmsh_3d.c
+++ b/src/mmg3d/chkmsh_3d.c
@@ -241,8 +241,10 @@ void MMG3D_chkmeshedgestags(MMG5_pMesh mesh) {
 
         if ( !ier ) {
            /* First time we meet the edge: store the its tag from the current
-            * tetra in the hash table */
-          int ier2 = MMG5_hEdge ( mesh,&hash,ip1,ip2,0,pxt->tag[i]);
+            * tetra in the hash table. Ignore OLDPARBDY tag because it is not
+            * consistent through meshes inside ParMmg and forbid the use of the
+            * current function to check tag consistency if not ignored. */
+          int ier2 = MMG5_hEdge ( mesh,&hash,ip1,ip2,0,(pxt->tag[i] & ~MG_OLDPARBDY));
           if ( !ier2 ) {
             /* Realloc error */
             fprintf(stderr,"Error: %s: %d: Unable to add to hash table the edge "
@@ -252,8 +254,12 @@ void MMG3D_chkmeshedgestags(MMG5_pMesh mesh) {
           }
         }
         else {
-          /* Edge tag has been stored from another tet: check consistency */
-          if ( tag != pxt->tag[i] ) {
+          /* Edge tag has been stored from another tet: check consistency.
+             Ignore OLDPARBDY tag because it is not
+            * consistent through meshes inside ParMmg and forbid the use of the
+            * current function to check tag consistency if not ignored.
+            */
+          if ( tag != (pxt->tag[i] & ~MG_OLDPARBDY) ) {
             fprintf(stderr,"Error: %s: %d: Non consistency at tet %" MMG5_PRId
                     " (%" MMG5_PRId "), edge %d:%" MMG5_PRId "--%" MMG5_PRId "\n ",
                   __func__,__LINE__,k,MMG3D_indElt(mesh,k),i,ip1,ip2);

--- a/src/mmg3d/swap_3d.c
+++ b/src/mmg3d/swap_3d.c
@@ -739,9 +739,20 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
   }
 
   /** Swap */
+  /* Store useful information from pt1 before overwrite by memcpy*/
   xt1 = pt1->xt;
 
   np    = pt1->v[tau1[0]];
+
+  MMG5_int ref[3] = {0};
+  int16_t  tag[3] = {0};
+  for (i=0;i<3;i++) {
+    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[i],&tag[i],&ref[i]) ) {
+      fprintf(stderr,"\n  ## Error: %s: %d. unable to get edge info.\n",__func__,i);
+      return 0;
+    }
+  }
+
   memcpy(pt1,pt0,sizeof(MMG5_Tetra));
 
   iel = MMG3D_newElt(mesh);
@@ -884,29 +895,15 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
      * xtetra is assigned to one of the neighbours of the tetra of the edge
      * shell). In consequence, we cannot simply use the stored tags. */
 
-    int16_t  tag0 = 0;
-    MMG5_int ref0 = 0;
-    int16_t  tag1 = 0;
-    MMG5_int ref1 = 0;
-
-
     /* xt[0] */
     xt[0].tag[taued0[0]] = 0;
 
-    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[2],&tag0,&ref0) ) {
-      fprintf(stderr,"\n  ## Error: %s: 1. unable to get edge info.\n",__func__);
-      return 0;
-    }
-    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[1],&tag1,&ref1) ) {
-      fprintf(stderr,"\n  ## Error: %s: 2. unable to get edge info.\n",__func__);
-      return 0;
-    }
-    xt[0].tag[taued0[3]] = tag0;
-    xt[0].tag[taued0[4]] = tag1;
+    xt[0].tag[taued0[3]] = tag[2];
+    xt[0].tag[taued0[4]] = tag[1];
 
     xt[0].edg[taued0[0]] = 0;
-    xt[0].edg[taued0[3]] = ref0;
-    xt[0].edg[taued0[4]] = ref1;
+    xt[0].edg[taued0[3]] = ref[2];
+    xt[0].edg[taued0[4]] = ref[1];
 
     xt[0].ref[ tau0[0]] = pxt1->ref[tau1[1]];
     xt[0].ref[ tau0[2]] = 0;
@@ -922,25 +919,12 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
     /* xt[1] */
     xt[1].tag[taued0[1]] = 0;
 
-    tag0 = 0;
-    ref0 = 0;
-    tag1 = 0;
-    ref1 = 0;
-    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[0],&tag0,&ref0) ) {
-      fprintf(stderr,"\n  ## Error: %s: 1. unable to get edge info.\n",__func__);
-      return 0;
-    }
-    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[1],&tag1,&ref1) ) {
-      fprintf(stderr,"\n  ## Error: %s: 2. unable to get edge info.\n",__func__);
-      return 0;
-    }
-
-    xt[1].tag[taued0[3]] = tag0;
-    xt[1].tag[taued0[5]] = tag1;
+    xt[1].tag[taued0[3]] = tag[0];
+    xt[1].tag[taued0[5]] = tag[1];
 
     xt[1].edg[taued0[1]] = 0;
-    xt[1].edg[taued0[3]] = ref0;
-    xt[1].edg[taued0[5]] = ref1;
+    xt[1].edg[taued0[3]] = ref[0];
+    xt[1].edg[taued0[5]] = ref[1];
 
     xt[1].ref[ tau0[0]] = pxt1->ref[tau1[3]];
     xt[1].ref[ tau0[1]] = 0;
@@ -956,24 +940,12 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
     /* xt[2] */
     xt[2].tag[taued0[2]] = 0;
 
-    tag0 = 0;
-    ref0 = 0;
-    tag1 = 0;
-    ref1 = 0;
-    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[0],&tag0,&ref0) ) {
-      fprintf(stderr,"\n  ## Error: %s: 1. unable to get edge info.\n",__func__);
-      return 0;
-    }
-    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[2],&tag1,&ref1) ) {
-      fprintf(stderr,"\n  ## Error: %s: 2. unable to get edge info.\n",__func__);
-      return 0;
-    }
-    xt[2].tag[taued0[4]] = tag0;
-    xt[2].tag[taued0[5]] = tag1;
+    xt[2].tag[taued0[4]] = tag[0];
+    xt[2].tag[taued0[5]] = tag[2];
 
     xt[2].edg[taued0[2]] = 0;
-    xt[2].edg[taued0[4]] = ref0;
-    xt[2].edg[taued0[5]] = ref1;
+    xt[2].edg[taued0[4]] = ref[0];
+    xt[2].edg[taued0[5]] = ref[2];
 
     xt[2].ref[ tau0[0]] = pxt1->ref[tau1[2]];
     xt[2].ref[ tau0[1]] = 0;

--- a/src/mmg3d/swap_3d.c
+++ b/src/mmg3d/swap_3d.c
@@ -902,11 +902,11 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
     /* xt[1] */
     xt[1].tag[taued0[1]] = 0;
     xt[1].tag[taued0[3]] = pxt1->tag[taued1[0]];
-    xt[1].tag[taued0[5]] = pxt1->tag[taued1[2]];
+    xt[1].tag[taued0[5]] = pxt1->tag[taued1[1]];
 
     xt[1].edg[taued0[1]] = 0;
     xt[1].edg[taued0[3]] =  pxt1->edg[taued1[0]];
-    xt[1].edg[taued0[5]] =  pxt1->edg[taued1[2]];
+    xt[1].edg[taued0[5]] =  pxt1->edg[taued1[1]];
 
     xt[1].ref[ tau0[0]] = pxt1->ref[tau1[3]];
     xt[1].ref[ tau0[1]] = 0;
@@ -922,11 +922,11 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
     /* xt[2] */
     xt[2].tag[taued0[2]] = 0;
     xt[2].tag[taued0[4]] = pxt1->tag[taued1[0]];
-    xt[2].tag[taued0[5]] = pxt1->tag[taued1[1]];
+    xt[2].tag[taued0[5]] = pxt1->tag[taued1[2]];
 
     xt[2].edg[taued0[2]] = 0;
     xt[2].edg[taued0[4]] = pxt1->edg[taued1[0]];
-    xt[2].edg[taued0[5]] = pxt1->edg[taued1[1]];
+    xt[2].edg[taued0[5]] = pxt1->edg[taued1[2]];
 
     xt[2].ref[ tau0[0]] = pxt1->ref[tau1[2]];
     xt[2].ref[ tau0[1]] = 0;

--- a/src/mmg3d/swap_3d.c
+++ b/src/mmg3d/swap_3d.c
@@ -879,14 +879,34 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
     pxt1 = &mesh->xtetra[xt1];
 
     /* Assignation of the xt fields to the appropriate tets */
+    /* Warning: after collapses, some boundary edges not connected to boundary
+     * faces may have a 0 tag inside a xtetra (see \ref MMG5_colver when a
+     * xtetra is assigned to one of the neighbours of the tetra of the edge
+     * shell). In consequence, we cannot simply use the stored tags. */
+
+    int16_t  tag0 = 0;
+    MMG5_int ref0 = 0;
+    int16_t  tag1 = 0;
+    MMG5_int ref1 = 0;
+
+
     /* xt[0] */
     xt[0].tag[taued0[0]] = 0;
-    xt[0].tag[taued0[3]] = pxt1->tag[taued1[2]];
-    xt[0].tag[taued0[4]] = pxt1->tag[taued1[1]];
+
+    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[2],&tag0,&ref0) ) {
+      fprintf(stderr,"\n  ## Error: %s: 1. unable to get edge info.\n",__func__);
+      return 0;
+    }
+    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[1],&tag1,&ref1) ) {
+      fprintf(stderr,"\n  ## Error: %s: 2. unable to get edge info.\n",__func__);
+      return 0;
+    }
+    xt[0].tag[taued0[3]] = tag0;
+    xt[0].tag[taued0[4]] = tag1;
 
     xt[0].edg[taued0[0]] = 0;
-    xt[0].edg[taued0[3]] =  pxt1->edg[taued1[2]];
-    xt[0].edg[taued0[4]] =  pxt1->edg[taued1[1]];
+    xt[0].edg[taued0[3]] = ref0;
+    xt[0].edg[taued0[4]] = ref1;
 
     xt[0].ref[ tau0[0]] = pxt1->ref[tau1[1]];
     xt[0].ref[ tau0[2]] = 0;
@@ -901,12 +921,26 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
 
     /* xt[1] */
     xt[1].tag[taued0[1]] = 0;
-    xt[1].tag[taued0[3]] = pxt1->tag[taued1[0]];
-    xt[1].tag[taued0[5]] = pxt1->tag[taued1[1]];
+
+    tag0 = 0;
+    ref0 = 0;
+    tag1 = 0;
+    ref1 = 0;
+    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[0],&tag0,&ref0) ) {
+      fprintf(stderr,"\n  ## Error: %s: 1. unable to get edge info.\n",__func__);
+      return 0;
+    }
+    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[1],&tag1,&ref1) ) {
+      fprintf(stderr,"\n  ## Error: %s: 2. unable to get edge info.\n",__func__);
+      return 0;
+    }
+
+    xt[1].tag[taued0[3]] = tag0;
+    xt[1].tag[taued0[5]] = tag1;
 
     xt[1].edg[taued0[1]] = 0;
-    xt[1].edg[taued0[3]] =  pxt1->edg[taued1[0]];
-    xt[1].edg[taued0[5]] =  pxt1->edg[taued1[1]];
+    xt[1].edg[taued0[3]] = ref0;
+    xt[1].edg[taued0[5]] = ref1;
 
     xt[1].ref[ tau0[0]] = pxt1->ref[tau1[3]];
     xt[1].ref[ tau0[1]] = 0;
@@ -921,12 +955,25 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
 
     /* xt[2] */
     xt[2].tag[taued0[2]] = 0;
-    xt[2].tag[taued0[4]] = pxt1->tag[taued1[0]];
-    xt[2].tag[taued0[5]] = pxt1->tag[taued1[2]];
+
+    tag0 = 0;
+    ref0 = 0;
+    tag1 = 0;
+    ref1 = 0;
+    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[0],&tag0,&ref0) ) {
+      fprintf(stderr,"\n  ## Error: %s: 1. unable to get edge info.\n",__func__);
+      return 0;
+    }
+    if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[2],&tag1,&ref1) ) {
+      fprintf(stderr,"\n  ## Error: %s: 2. unable to get edge info.\n",__func__);
+      return 0;
+    }
+    xt[2].tag[taued0[4]] = tag0;
+    xt[2].tag[taued0[5]] = tag1;
 
     xt[2].edg[taued0[2]] = 0;
-    xt[2].edg[taued0[4]] = pxt1->edg[taued1[0]];
-    xt[2].edg[taued0[5]] = pxt1->edg[taued1[2]];
+    xt[2].edg[taued0[4]] = ref0;
+    xt[2].edg[taued0[5]] = ref1;
 
     xt[2].ref[ tau0[0]] = pxt1->ref[tau1[2]];
     xt[2].ref[ tau0[1]] = 0;

--- a/src/mmg3d/swap_3d.c
+++ b/src/mmg3d/swap_3d.c
@@ -745,7 +745,7 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
   np    = pt1->v[tau1[0]];
 
   MMG5_int ref[3] = {0};
-  int16_t  tag[3] = {0};
+  uint16_t  tag[3] = {0};
   for (i=0;i<3;i++) {
     if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[i],&tag[i],&ref[i]) ) {
       fprintf(stderr,"\n  ## Error: %s: %d. unable to get edge info.\n",__func__,i);


### PR DESCRIPTION
This update fixes the way tags are applied to newly created tetras in `MMG5_swap23`. Several calls of `MMG3D_get_shellEdgeTag` are added in order to provide complete data to new tetras. These calls must be performed before the call of `memcpy` function since this call overwrites data about the initial tetra.
This update is motivated by the need to improve the behaviour of `parMmg` continuous integration tests.