### PR TITLE
Fix another issue with wrong edge tag update in `swap23`.

### DIFF
--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -50,7 +50,7 @@ jobs:
                 vtk: on
                 int: int32_t
 
-              - os: macos-12
+              - os: macos-14
                 pattern: off
                 pointmap: off
                 scotch: off
@@ -118,7 +118,7 @@ jobs:
                 vtk: off
                 int: int64_t
 
-              - os: macos-12
+              - os: macos-14
                 pattern: on
                 pointmap: on
                 scotch: on
@@ -342,7 +342,7 @@ jobs:
           cd build
           ctest --timeout 7200 -VV -C ${{ env.BUILD_TYPE }} -j ${{ env.NJOBS }}
 
-      - name: Test Mmg with in64_t integers
+      - name: Test Mmg with int64_t integers
         # Run long tests only on ubuntu with pattern off, scotch on, vtk on and int64_t integers
         if: matrix.os == 'ubuntu-20.04' && matrix.pattern == 'off' && matrix.scotch == 'on' && matrix.vtk == 'on' && matrix.int == 'int64_t'
         run: |

--- a/src/mmg3d/chkmsh_3d.c
+++ b/src/mmg3d/chkmsh_3d.c
@@ -223,6 +223,8 @@ void MMG3D_chkmeshedgestags(MMG5_pMesh mesh) {
   /* Travel mesh edges and hash boundary ones */
   MMG5_hNew(mesh,&hash,nt,3*nt);
 
+  uint16_t ignored_tag = (~MG_PARBDYBDY) & (~MG_OLDPARBDY);
+
   for (k=1; k<=mesh->ne; k++) {
     pt = &mesh->tetra[k];
     if ( !MG_EOK(pt) )  continue;
@@ -241,10 +243,11 @@ void MMG3D_chkmeshedgestags(MMG5_pMesh mesh) {
 
         if ( !ier ) {
            /* First time we meet the edge: store the its tag from the current
-            * tetra in the hash table. Ignore OLDPARBDY tag because it is not
-            * consistent through meshes inside ParMmg and forbid the use of the
-            * current function to check tag consistency if not ignored. */
-          int ier2 = MMG5_hEdge ( mesh,&hash,ip1,ip2,0,(pxt->tag[i] & ~MG_OLDPARBDY));
+            * tetra in the hash table. Ignore OLDPARBDY and PARBDYBDY tags
+            * because they are not consistent through meshes inside ParMmg and
+            * forbid the use of the current function to check tag consistency if
+            * not ignored. */
+          int ier2 = MMG5_hEdge ( mesh,&hash,ip1,ip2,0,(pxt->tag[i] & ignored_tag));
           if ( !ier2 ) {
             /* Realloc error */
             fprintf(stderr,"Error: %s: %d: Unable to add to hash table the edge "
@@ -255,11 +258,11 @@ void MMG3D_chkmeshedgestags(MMG5_pMesh mesh) {
         }
         else {
           /* Edge tag has been stored from another tet: check consistency.
-             Ignore OLDPARBDY tag because it is not
-            * consistent through meshes inside ParMmg and forbid the use of the
-            * current function to check tag consistency if not ignored.
+             Ignore OLDPARBDY and PARBDYBDY tags because they are not *
+             consistent through meshes inside ParMmg and forbid the use of the *
+             current function to check tag consistency if not ignored.
             */
-          if ( tag != (pxt->tag[i] & ~MG_OLDPARBDY) ) {
+          if ( tag != (pxt->tag[i] & ignored_tag) ) {
             fprintf(stderr,"Error: %s: %d: Non consistency at tet %" MMG5_PRId
                     " (%" MMG5_PRId "), edge %d:%" MMG5_PRId "--%" MMG5_PRId "\n ",
                   __func__,__LINE__,k,MMG3D_indElt(mesh,k),i,ip1,ip2);

--- a/src/mmg3d/swap_3d.c
+++ b/src/mmg3d/swap_3d.c
@@ -744,9 +744,9 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
 
   np    = pt1->v[tau1[0]];
 
-  MMG5_int ref[3] = {0};
-  uint16_t  tag[3] = {0};
-  for (i=0;i<3;i++) {
+  MMG5_int ref[6] = {0};
+  uint16_t  tag[6] = {0};
+  for (i=0;i<6;i++) {
     if ( !MMG3D_get_shellEdgeTag(mesh,k1,taued1[i],&tag[i],&ref[i]) ) {
       fprintf(stderr,"\n  ## Error: %s: %d. unable to get edge info.\n",__func__,i);
       return 0;
@@ -900,10 +900,15 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
 
     xt[0].tag[taued0[3]] = tag[2];
     xt[0].tag[taued0[4]] = tag[1];
+    /* As the edge tag of tetra 0 may be erroneous if the edge doesn't belong to
+     * a boundary face */
+    xt[0].tag[taued0[5]] = tag[5];
+
 
     xt[0].edg[taued0[0]] = 0;
     xt[0].edg[taued0[3]] = ref[2];
     xt[0].edg[taued0[4]] = ref[1];
+    xt[0].edg[taued0[5]] = ref[5];
 
     xt[0].ref[ tau0[0]] = pxt1->ref[tau1[1]];
     xt[0].ref[ tau0[2]] = 0;
@@ -922,9 +927,14 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
     xt[1].tag[taued0[3]] = tag[0];
     xt[1].tag[taued0[5]] = tag[1];
 
+    /* As the edge tag of tetra 0 may be erroneous if the edge doesn't belong to
+     * a boundary face */
+    xt[1].tag[taued0[4]] = tag[3];
+
     xt[1].edg[taued0[1]] = 0;
     xt[1].edg[taued0[3]] = ref[0];
     xt[1].edg[taued0[5]] = ref[1];
+    xt[1].edg[taued0[4]] = ref[3];
 
     xt[1].ref[ tau0[0]] = pxt1->ref[tau1[3]];
     xt[1].ref[ tau0[1]] = 0;
@@ -943,9 +953,14 @@ int MMG3D_swap23(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,int8_t metRidTyp,
     xt[2].tag[taued0[4]] = tag[0];
     xt[2].tag[taued0[5]] = tag[2];
 
+    /* As the edge tag of tetra 0 may be erroneous if the edge doesn't belong to
+     * a boundary face */
+    xt[2].tag[taued0[3]] = tag[4];
+
     xt[2].edg[taued0[2]] = 0;
     xt[2].edg[taued0[4]] = ref[0];
     xt[2].edg[taued0[5]] = ref[2];
+    xt[2].edg[taued0[3]] = ref[4];
 
     xt[2].ref[ tau0[0]] = pxt1->ref[tau1[2]];
     xt[2].ref[ tau0[1]] = 0;


### PR DESCRIPTION
The erroneous tag can be seen by adding checks on mesh consistency (call to `MMG5_chkmesh`) at the beginning of the loadbalancing function of ParMmg (`PMMG_loadBalancing`) and by calling the `ls-CenIn-2` test case of ParMmg:
We try to perform a `swap23` on a tetra with 2 boundary faces. Along the face at interface with the neighbour which with we perform the swap, the edge that doesn't belong to a boundary face has a wrong tag or no tag in the xtetra (due to a previous collapse that has added the xtetra but not updated the edge tag). It is not an issue as, in Mmg, we do not "trust" edge tags for edges not belonging to a boundary face. In the neighbour, the edge has the suitable tag (see attached picture).

![path184](https://github.com/user-attachments/assets/2aa2b87c-789d-4bb1-ba23-c86fb10c8864)

In this picture, the red and green faces belong to boundaries. The blue edge has not tag or errouneous tag (which is not an issue has it doesn't belongs to a boundary face). The grey tetra is the neighbour with which the swap is performed.

Without the fix introduced by this PR, the edge swap creates a tag inconsistency in one of the new tetra (in the sense that now, the edge without tag or with a wrong tag, may belong to a boundary face  but still has an erroneous tag (for example if the grey tetra of the picture has 3 boundary faces for the faces not shared with the other tetra).

The current PR adds the suitable tag update by checking the tag in the edge shell (instead of using the tag of the xtetra 0).