### PR TITLE
Feature/fix vtk install deadlock in ci

### DIFF
--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -33,22 +33,22 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: [macos-12]
-            pattern: [off]
+            os: [ubuntu-20.04,macos-12]
+            pattern: [on,off]
             pointmap: [off]
-            scotch: [off]
+            scotch: [on,off]
             vtk: [off]
             int: [int32_t]
 
             include:
               # test vtk only without scotch and with delaunay insertion (more
               # tests are useless)
-              #- os: ubuntu-20.04
-              #  pattern: off
-              #  pointmap: off
-              #  scotch: off
-              #  vtk: on
-              #  int: int32_t
+              - os: ubuntu-20.04
+                pattern: off
+                pointmap: off
+                scotch: off
+                vtk: on
+                int: int32_t
 
               - os: macos-14
                 pattern: off
@@ -58,93 +58,93 @@ jobs:
                 int: int32_t
 
               # Test pointmap with scotch except on windows
-              #- os: ubuntu-20.04
-              #  pattern: off
-              #  pointmap: on
-              #  scotch: on
-              #  vtk: off
-              #  int: int32_t
+              - os: ubuntu-20.04
+                pattern: off
+                pointmap: on
+                scotch: on
+                vtk: off
+                int: int32_t
 
-              #- os: macos-12
-              #  pattern: off
-              #  pointmap: on
-              #  scotch: on
-              #  vtk: off
-              #  int: int32_t
+              - os: macos-12
+                pattern: off
+                pointmap: on
+                scotch: on
+                vtk: off
+                int: int32_t
 
               # Add windows basic test (matrix is not testable as dependencies
               # don't build with MSVC)
-              #- os: windows-2022
-              #  pattern: off
-              #  pointmap: off
-              #  scotch: off
-              #  vtk: off
-              #  int: int32_t
+              - os: windows-2022
+                pattern: off
+                pointmap: off
+                scotch: off
+                vtk: off
+                int: int32_t
 
-              #- os: windows-2022
-              #  pattern: on
-              #  pointmap: off
-              #  scotch: off
-              #  vtk: off
-              #  int: int32_t
+              - os: windows-2022
+                pattern: on
+                pointmap: off
+                scotch: off
+                vtk: off
+                int: int32_t
 
               # Add test for pointmap only if pattern off
-              #- os: windows-2022
-              #  pattern: off
-              #  pointmap: on
-              #  scotch: off
-              #  vtk: off
-              #  int: int32_t
+              - os: windows-2022
+                pattern: off
+                pointmap: on
+                scotch: off
+                vtk: off
+                int: int32_t
 
               # Test int64_t build on all archi, and try to cover all code
-              #- os: ubuntu-20.04
-              #  pattern: on
-              #  pointmap: on
-              #  scotch: on
-              #  vtk: on
-              #  int: int64_t
-              #
-              #- os: ubuntu-20.04
-              #  pattern: off
-              #  pointmap: off
-              #  scotch: on
-              #  vtk: on
-              #  int: int64_t
-              #
-              #- os: ubuntu-20.04
-              #  pattern: off
-              #  pointmap: off
-              #  scotch: off
-              #  vtk: off
-              #  int: int64_t
-              #
-              #- os: macos-14
-              #  pattern: on
-              #  pointmap: on
-              #  scotch: on
-              #  vtk: on
-              #  int: int64_t
-              #
-              #- os: macos-12
-              #  pattern: off
-              #  pointmap: off
-              #  scotch: off
-              #  vtk: off
-              #  int: int64_t
-              #
-              #- os: windows-2022
-              #  pattern: on
-              #  pointmap: on
-              #  scotch: off
-              #  vtk: off
-              #  int: int64_t
-              #
-              #- os: windows-2022
-              #  pattern: off
-              #  pointmap: off
-              #  scotch: off
-              #  vtk: off
-              #  int: int64_t
+              - os: ubuntu-20.04
+                pattern: on
+                pointmap: on
+                scotch: on
+                vtk: on
+                int: int64_t
+
+              - os: ubuntu-20.04
+                pattern: off
+                pointmap: off
+                scotch: on
+                vtk: on
+                int: int64_t
+
+              - os: ubuntu-20.04
+                pattern: off
+                pointmap: off
+                scotch: off
+                vtk: off
+                int: int64_t
+
+              - os: macos-14
+                pattern: on
+                pointmap: on
+                scotch: on
+                vtk: on
+                int: int64_t
+
+              - os: macos-12
+                pattern: off
+                pointmap: off
+                scotch: off
+                vtk: off
+                int: int64_t
+
+              - os: windows-2022
+                pattern: on
+                pointmap: on
+                scotch: off
+                vtk: off
+                int: int64_t
+
+              - os: windows-2022
+                pattern: off
+                pointmap: off
+                scotch: off
+                vtk: off
+                int: int64_t
 
     steps:
       - name: Set cmake_build_type and export coverage flags

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -37,10 +37,10 @@ jobs:
             pattern: [off]
             pointmap: [off]
             scotch: [off]
-            vtk: [on]
+            vtk: [off]
             int: [int32_t]
 
-            #include:
+            include:
               # test vtk only without scotch and with delaunay insertion (more
               # tests are useless)
               #- os: ubuntu-20.04
@@ -50,12 +50,12 @@ jobs:
               #  vtk: on
               #  int: int32_t
 
-              #- os: macos-12
-              #  pattern: off
-              #  pointmap: off
-              #  scotch: off
-              #  vtk: on
-              #  int: int32_t
+              - os: macos-14
+                pattern: off
+                pointmap: off
+                scotch: off
+                vtk: on
+                int: int32_t
 
               # Test pointmap with scotch except on windows
               #- os: ubuntu-20.04
@@ -118,7 +118,7 @@ jobs:
               #  vtk: off
               #  int: int64_t
               #
-              #- os: macos-12
+              #- os: macos-14
               #  pattern: on
               #  pointmap: on
               #  scotch: on
@@ -342,7 +342,7 @@ jobs:
           cd build
           ctest --timeout 7200 -VV -C ${{ env.BUILD_TYPE }} -j ${{ env.NJOBS }}
 
-      - name: Test Mmg with in64_t integers
+      - name: Test Mmg with int64_t integers
         # Run long tests only on ubuntu with pattern off, scotch on, vtk on and int64_t integers
         if: matrix.os == 'ubuntu-20.04' && matrix.pattern == 'off' && matrix.scotch == 'on' && matrix.vtk == 'on' && matrix.int == 'int64_t'
         run: |

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -33,118 +33,118 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: [ubuntu-20.04,macos-12]
-            pattern: [on,off]
+            os: [macos-12]
+            pattern: [off]
             pointmap: [off]
-            scotch: [on,off]
-            vtk: [off]
+            scotch: [off]
+            vtk: [on]
             int: [int32_t]
 
-            include:
+            #include:
               # test vtk only without scotch and with delaunay insertion (more
               # tests are useless)
-              - os: ubuntu-20.04
-                pattern: off
-                pointmap: off
-                scotch: off
-                vtk: on
-                int: int32_t
+              #- os: ubuntu-20.04
+              #  pattern: off
+              #  pointmap: off
+              #  scotch: off
+              #  vtk: on
+              #  int: int32_t
 
-              - os: macos-12
-                pattern: off
-                pointmap: off
-                scotch: off
-                vtk: on
-                int: int32_t
+              #- os: macos-12
+              #  pattern: off
+              #  pointmap: off
+              #  scotch: off
+              #  vtk: on
+              #  int: int32_t
 
               # Test pointmap with scotch except on windows
-              - os: ubuntu-20.04
-                pattern: off
-                pointmap: on
-                scotch: on
-                vtk: off
-                int: int32_t
+              #- os: ubuntu-20.04
+              #  pattern: off
+              #  pointmap: on
+              #  scotch: on
+              #  vtk: off
+              #  int: int32_t
 
-              - os: macos-12
-                pattern: off
-                pointmap: on
-                scotch: on
-                vtk: off
-                int: int32_t
+              #- os: macos-12
+              #  pattern: off
+              #  pointmap: on
+              #  scotch: on
+              #  vtk: off
+              #  int: int32_t
 
               # Add windows basic test (matrix is not testable as dependencies
               # don't build with MSVC)
-              - os: windows-2022
-                pattern: off
-                pointmap: off
-                scotch: off
-                vtk: off
-                int: int32_t
+              #- os: windows-2022
+              #  pattern: off
+              #  pointmap: off
+              #  scotch: off
+              #  vtk: off
+              #  int: int32_t
 
-              - os: windows-2022
-                pattern: on
-                pointmap: off
-                scotch: off
-                vtk: off
-                int: int32_t
+              #- os: windows-2022
+              #  pattern: on
+              #  pointmap: off
+              #  scotch: off
+              #  vtk: off
+              #  int: int32_t
 
               # Add test for pointmap only if pattern off
-              - os: windows-2022
-                pattern: off
-                pointmap: on
-                scotch: off
-                vtk: off
-                int: int32_t
+              #- os: windows-2022
+              #  pattern: off
+              #  pointmap: on
+              #  scotch: off
+              #  vtk: off
+              #  int: int32_t
 
               # Test int64_t build on all archi, and try to cover all code
-              - os: ubuntu-20.04
-                pattern: on
-                pointmap: on
-                scotch: on
-                vtk: on
-                int: int64_t
-
-              - os: ubuntu-20.04
-                pattern: off
-                pointmap: off
-                scotch: on
-                vtk: on
-                int: int64_t
-
-              - os: ubuntu-20.04
-                pattern: off
-                pointmap: off
-                scotch: off
-                vtk: off
-                int: int64_t
-
-              - os: macos-12
-                pattern: on
-                pointmap: on
-                scotch: on
-                vtk: on
-                int: int64_t
-
-              - os: macos-12
-                pattern: off
-                pointmap: off
-                scotch: off
-                vtk: off
-                int: int64_t
-
-              - os: windows-2022
-                pattern: on
-                pointmap: on
-                scotch: off
-                vtk: off
-                int: int64_t
-
-              - os: windows-2022
-                pattern: off
-                pointmap: off
-                scotch: off
-                vtk: off
-                int: int64_t
+              #- os: ubuntu-20.04
+              #  pattern: on
+              #  pointmap: on
+              #  scotch: on
+              #  vtk: on
+              #  int: int64_t
+              #
+              #- os: ubuntu-20.04
+              #  pattern: off
+              #  pointmap: off
+              #  scotch: on
+              #  vtk: on
+              #  int: int64_t
+              #
+              #- os: ubuntu-20.04
+              #  pattern: off
+              #  pointmap: off
+              #  scotch: off
+              #  vtk: off
+              #  int: int64_t
+              #
+              #- os: macos-12
+              #  pattern: on
+              #  pointmap: on
+              #  scotch: on
+              #  vtk: on
+              #  int: int64_t
+              #
+              #- os: macos-12
+              #  pattern: off
+              #  pointmap: off
+              #  scotch: off
+              #  vtk: off
+              #  int: int64_t
+              #
+              #- os: windows-2022
+              #  pattern: on
+              #  pointmap: on
+              #  scotch: off
+              #  vtk: off
+              #  int: int64_t
+              #
+              #- os: windows-2022
+              #  pattern: off
+              #  pointmap: off
+              #  scotch: off
+              #  vtk: off
+              #  int: int64_t
 
     steps:
       - name: Set cmake_build_type and export coverage flags


### PR DESCRIPTION
This PR replaces the macos-12 runners by macos-14 ones for jobs with VTK enabled.

It fixes a recent deadlock (or very long slowdown) during the installation of VTK using homebrew (see https://github.com/MmgTools/mmg/actions/runs/11384817386/job/31673334951) which is probably due to the removal of the macos-12 runner in a close future.

Integrating this PR should allow to fix the github-actions  of PR #285.