### PR TITLE
Solve issue when inserting a point along a non-manifold edge with 2 singular extremities

### DIFF
--- a/src/mmg3d/tools_3d.c
+++ b/src/mmg3d/tools_3d.c
@@ -595,7 +595,9 @@ inline int MMG5_BezierNom(MMG5_pMesh mesh,MMG5_int ip0,MMG5_int ip1,double s,dou
     /* Coordinates of the new tangent and normal */
     if ( MG_SIN(p0->tag) && MG_SIN(p1->tag) ) {  // function should not be used in that case
         memcpy(to,t0,3*sizeof(double));
-        return 1;
+        /* returning 1 here may create memory error afterward because no (that
+         * is not filled) will be used */
+        return 0;
     }
     else if ( MG_SIN(p0->tag) ) {
         memcpy(n1,&(mesh->xpoint[p1->xp].n1[0]),3*sizeof(double));


### PR DESCRIPTION
Change the return value when BezierNom is called along a non-manifold edge with 2 singular extremities.

If we return 1. The point is inserted along the nom edge but its normals have not been computed (so they can be NaN).

An example of error can be found when running the `ls-DisIn-cubegeom-metric-fields-5` test case of ParMmg.