### PR TITLE
Add Option to deactivate the CPack directives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,4 +341,7 @@ include(doxygen)
 #####         Create Package
 #####
 ###############################################################################
-include(packages)
+SET (MMG5_PACKAGE TRUE CACHE BOOL "add CPack directives")
+IF (MMG5_PACKAGE)
+  include(packages)
+ENDIF ( MMG5_PACKAGE )


### PR DESCRIPTION
Hello, 

Little change to add an option to the cmake files to only install compiled files. In the current cmake files the VisualStudio runtime files are installed. This make it impossible to build a package unsing the conda-force infrastructure on windows (the packages must ship only compiled libs).

MR of the new recipe for mmg for conda-forge. https://github.com/conda-forge/mmgsuite-feedstock/pull/15

Felipe 

