### PR TITLE
fixed bug in MMG5_split6 that caused MMG5_chkedg warnings

### DIFF
--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -4523,6 +4523,12 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
     yt[0].ftag[0] = 0;      // face tag
     MG_SET(yt[0].ori, 0);   // triangle orientation flags
     for(i=0;i<4;i++ ) {
+      // An xTetra is only created if any face has a reference or a tag.
+      // This means that edge references and tags are lost for edges that
+      // do not border a tetrahedron with a tagged or referenced face.
+      // This appears to be so by design because it is done everywhere.
+      // Orientation information is also lost most of the time. Maybe
+      // this is not important when there is no surface?
       if ( (yt[0].ref[i]) || yt[0].ftag[i] ) need_xt[0] = 1;
     }
     if ( need_xt[0] ) {

--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -4652,24 +4652,25 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
     if ( (yt[7].ref[0]) || yt[7].ftag[0]) need_xt[7] = 1;
   }
 
+  /* make sure there is room in the xtetra table for all of them */
+  if ( mesh->xt > mesh->xtmax - 7 ) {
+    MMG5_TAB_RECALLOC(mesh,mesh->xtetra,mesh->xtmax,MMG5_GAP,MMG5_xTetra,
+                      "larger xtetra table",
+                      mesh->xt--;
+                      fprintf(stderr,"  Exit program.\n");
+                      return 0);
+  }
+
   /* assign xTetra to the new tets that need them */
   for(int t=1; t<8; t++){
     pt[t]->xt = 0;
     if ( need_xt[t] ) {
       if ( !isxt0 ) {
         isxt0 = 1;
-        pt[t]->xt = nxt0;
+        pt[t]->xt = nxt0;  /* re-use the initial xtetra */
       }
       else {
         mesh->xt++;
-        if ( mesh->xt > mesh->xtmax ) {
-          /* realloc of xtetras table */
-          MMG5_TAB_RECALLOC(mesh,mesh->xtetra,mesh->xtmax,MMG5_GAP,MMG5_xTetra,
-                             "larger xtetra table",
-                             mesh->xt--;
-                             fprintf(stderr,"  Exit program.\n");
-                             return 0);
-        }
         pt[t]->xt = mesh->xt;
       }
       memcpy(&mesh->xtetra[pt[t]->xt],&yt[t],sizeof(MMG5_xTetra));

--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -4501,14 +4501,14 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   nxt0 = pt[0]->xt;
   pxt0 = &mesh->xtetra[nxt0];
 
+  /* Store face tags and refs from split tetra (before modifying pxt) */
+  for (i=0; i<4; i++) {
+    ftag[i] = (pxt0->ftag[i] & ~MG_REF);
+  }
+
   /* create 7 new tetras and initialize as copies of the original */
   if ( !MMG3D_crea_newTetra(mesh,ne,newtet,pt,yt,&pxt0) ) {
     return 0;
-  }
-
-  /* Store face tags and refs from split tetra*/
-  for (i=0; i<4; i++) {
-    ftag[i] = (pxt0->ftag[i] & ~MG_REF);
   }
 
   /* Modify first tetra */

--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -4484,7 +4484,7 @@ int MMG3D_split6_sim(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6]) {
  */
 int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t metRidTyp) {
   MMG5_pTetra    pt[8];
-  MMG5_xTetra    xt0,yt[8];
+  MMG5_xTetra    yt[8];
   MMG5_pxTetra   pxt;
   int            i,j;
   MMG5_int       iel,newtet[8],nxt0;
@@ -4498,7 +4498,6 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
 
   nxt0 = pt[0]->xt;
   pxt = &mesh->xtetra[nxt0];
-  memcpy(&xt0,pxt,sizeof(MMG5_xTetra));
 
   /* create 7 new tetras */
   if ( !MMG3D_crea_newTetra(mesh,ne,newtet,pt,yt,&pxt) ) {
@@ -4507,7 +4506,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
 
   /* Store face tags and refs from split tetra*/
   for (i=0; i<4; i++) {
-    ftag[i] = (xt0.ftag[i] & ~MG_REF);
+    ftag[i] = (pxt->ftag[i] & ~MG_REF);
   }
 
   /* Modify first tetra */

--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -4486,7 +4486,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   MMG5_pxTetra   pxt;
   int            i,j;
   MMG5_int       iel,newtet[8],nxt0;
-  int8_t         isxt0,isxt;
+  int8_t         isxt0,need_xt[8] = {0,0,0,0,0,0,0,0};
   int16_t        ftag[4];
   const int8_t   ne=8;
 
@@ -4536,35 +4536,8 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
     yt[1].tag[5] = ftag[0];  yt[1].edg[1] = 0;
     yt[1].edg[2] = 0;  yt[1].edg[5] = 0;
     yt[1].ref[1] = 0;  yt[1].ftag[1] = 0; MG_SET(yt[1].ori, 1);
-
-    isxt = 0;
-
     for (i=0; i<4; i++) {
-      if ( (yt[1].ref[i]) || yt[1].ftag[i]) isxt = 1;
-    }
-
-    pt[1]->xt = 0;
-    if ( isxt ) {
-      if ( !isxt0 ) {
-        isxt0 = 1;
-        pt[1]->xt = nxt0;
-        pxt = &mesh->xtetra[pt[1]->xt];
-        memcpy(pxt,&yt[1],sizeof(MMG5_xTetra));
-      }
-      else {
-        mesh->xt++;
-        if ( mesh->xt > mesh->xtmax ) {
-          /* realloc of xtetras table */
-          MMG5_TAB_RECALLOC(mesh,mesh->xtetra,mesh->xtmax,MMG5_GAP,MMG5_xTetra,
-                             "larger xtetra table",
-                             mesh->xt--;
-                             fprintf(stderr,"  Exit program.\n");
-                             return 0);
-        }
-        pt[1]->xt = mesh->xt;
-        pxt = &mesh->xtetra[pt[1]->xt];
-        memcpy(pxt,&yt[1],sizeof(MMG5_xTetra));
-      }
+      if ( (yt[1].ref[i]) || yt[1].ftag[i]) need_xt[1] = 1;
     }
   }
 
@@ -4576,34 +4549,8 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
     yt[2].tag[4] = ftag[0];  yt[2].edg[0] = 0;
     yt[2].edg[2] = 0;  yt[2].edg[4] = 0;
     yt[2].ref[2] = 0;  yt[2].ftag[2] = 0;  MG_SET(yt[2].ori, 2);
-    isxt = 0;
-
     for (i=0; i<4;i++) {
-      if ( (yt[2].ref[i]) || yt[2].ftag[i]) isxt = 1;
-    }
-
-    pt[2]->xt = 0;
-    if ( isxt ) {
-      if ( !isxt0 ) {
-        isxt0 = 1;
-        pt[2]->xt = nxt0;
-        pxt = &mesh->xtetra[pt[2]->xt];
-        memcpy(pxt,&yt[2],sizeof(MMG5_xTetra));
-      }
-      else {
-        mesh->xt++;
-        if ( mesh->xt > mesh->xtmax ) {
-          /* realloc of xtetras table */
-          MMG5_TAB_RECALLOC(mesh,mesh->xtetra,mesh->xtmax,MMG5_GAP,MMG5_xTetra,
-                             "larger xtetra table",
-                             mesh->xt--;
-                             fprintf(stderr,"  Exit program.\n");
-                             return 0);
-        }
-        pt[2]->xt = mesh->xt;
-        pxt = &mesh->xtetra[pt[2]->xt];
-        memcpy(pxt,&yt[2],sizeof(MMG5_xTetra));
-      }
+      if ( (yt[2].ref[i]) || yt[2].ftag[i]) need_xt[2] = 1;
     }
   }
 
@@ -4615,35 +4562,8 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
     yt[3].tag[3] = ftag[0];  yt[3].edg[0] = 0;
     yt[3].edg[1] = 0;  yt[3].edg[3] = 0;
     yt[3].ref[3] = 0;  yt[3].ftag[3] = 0;  MG_SET(yt[3].ori, 3);
-
-    isxt = 0;
-
     for (i=0; i<4; i++) {
-      if ( (yt[3].ref[i]) || yt[3].ftag[i]) isxt = 1;
-    }
-
-    pt[3]->xt = 0;
-    if ( isxt ) {
-      if ( !isxt0 ) {
-        isxt0 = 1;
-        pt[3]->xt = nxt0;
-        pxt = &mesh->xtetra[pt[3]->xt];
-        memcpy(pxt,&yt[3],sizeof(MMG5_xTetra));
-      }
-      else {
-        mesh->xt++;
-        if ( mesh->xt > mesh->xtmax ) {
-          /* realloc of xtetras table */
-          MMG5_TAB_RECALLOC(mesh,mesh->xtetra,mesh->xtmax,MMG5_GAP,MMG5_xTetra,
-                             "larger xtetra table",
-                             mesh->xt--;
-                             fprintf(stderr,"  Exit program.\n");
-                             return 0);
-        }
-        pt[3]->xt = mesh->xt;
-        pxt = &mesh->xtetra[pt[3]->xt];
-        memcpy(pxt,&yt[3],sizeof(MMG5_xTetra));
-      }
+      if ( (yt[3].ref[i]) || yt[3].ftag[i]) need_xt[3] = 1;
     }
   }
 
@@ -4661,33 +4581,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
     yt[4].ftag[0] = 0 ; yt[4].ftag[1] = 0 ; yt[4].ftag[2] = 0;
     MG_SET(yt[4].ori, 0); MG_SET(yt[4].ori, 1); MG_SET(yt[4].ori, 2);
 
-    isxt = 0;
-
-    if ( (yt[4].ref[3]) || yt[4].ftag[3]) isxt = 1;
-
-    pt[4]->xt = 0;
-    if ( isxt ) {
-      if ( !isxt0 ) {
-        isxt0 = 1;
-        pt[4]->xt = nxt0;
-        pxt = &mesh->xtetra[(pt[4])->xt];
-        memcpy(pxt,&yt[4],sizeof(MMG5_xTetra));
-      }
-      else {
-        mesh->xt++;
-        if ( mesh->xt > mesh->xtmax ) {
-          /* realloc of xtetras table */
-          MMG5_TAB_RECALLOC(mesh,mesh->xtetra,mesh->xtmax,MMG5_GAP,MMG5_xTetra,
-                             "larger xtetra table",
-                             mesh->xt--;
-                             fprintf(stderr,"  Exit program.\n");
-                             return 0);
-        }
-        pt[4]->xt = mesh->xt;
-        pxt = &mesh->xtetra[pt[4]->xt];
-        memcpy(pxt,&yt[4],sizeof(MMG5_xTetra));
-      }
-    }
+    if ( (yt[4].ref[3]) || yt[4].ftag[3]) need_xt[4] = 1;
   }
 
   /* Modify 6th tetra */
@@ -4703,34 +4597,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
     yt[5].ref [0] = 0 ; yt[5].ref [1] = 0 ; yt[5].ref [3] = 0;
     yt[5].ftag[0] = 0 ; yt[5].ftag[1] = 0 ; yt[5].ftag[3] = 0;
     MG_SET(yt[5].ori, 0); MG_SET(yt[5].ori, 1); MG_SET(yt[5].ori, 3);
-
-    isxt = 0;
-
-    if ( (yt[5].ref[2]) || yt[5].ftag[2]) isxt = 1;
-
-    pt[5]->xt = 0;
-    if ( isxt ) {
-      if ( !isxt0 ) {
-        isxt0 = 1;
-        pt[5]->xt = nxt0;
-        pxt = &mesh->xtetra[pt[5]->xt];
-        memcpy(pxt,&yt[5],sizeof(MMG5_xTetra));
-      }
-      else {
-        mesh->xt++;
-        if ( mesh->xt > mesh->xtmax ) {
-          /* realloc of xtetras table */
-          MMG5_TAB_RECALLOC(mesh,mesh->xtetra,mesh->xtmax,MMG5_GAP,MMG5_xTetra,
-                             "larger xtetra table",
-                             mesh->xt--;
-                             fprintf(stderr,"  Exit program.\n");
-                             return 0);
-        }
-        pt[5]->xt = mesh->xt;
-        pxt = &mesh->xtetra[pt[5]->xt];
-        memcpy(pxt,&yt[5],sizeof(MMG5_xTetra));
-      }
-    }
+    if ( (yt[5].ref[2]) || yt[5].ftag[2]) need_xt[5] = 1;
   }
 
   /* Modify 7th tetra */
@@ -4746,34 +4613,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
     yt[6].ref [0] = 0 ; yt[6].ref [2] = 0 ; yt[6].ref [3] = 0;
     yt[6].ftag[0] = 0 ; yt[6].ftag[2] = 0 ; yt[6].ftag[3] = 0;
     MG_SET(yt[6].ori, 0); MG_SET(yt[6].ori, 2); MG_SET(yt[6].ori, 3);
-
-    isxt = 0;
-
-    if ( (yt[6].ref[1]) || yt[6].ftag[1]) isxt = 1;
-
-    pt[6]->xt = 0;
-    if ( isxt ) {
-      if ( !isxt0 ) {
-        isxt0 = 1;
-        pt[6]->xt = nxt0;
-        pxt = &mesh->xtetra[pt[6]->xt];
-        memcpy(pxt,&yt[6],sizeof(MMG5_xTetra));
-      }
-      else {
-        mesh->xt++;
-        if ( mesh->xt > mesh->xtmax ) {
-          /* realloc of xtetras table */
-          MMG5_TAB_RECALLOC(mesh,mesh->xtetra,mesh->xtmax,MMG5_GAP,MMG5_xTetra,
-                             "larger xtetra table",
-                             mesh->xt--;
-                             fprintf(stderr,"  Exit program.\n");
-                             return 0);
-        }
-        pt[6]->xt = mesh->xt;
-        pxt = &mesh->xtetra[pt[6]->xt];
-        memcpy(pxt,&yt[6],sizeof(MMG5_xTetra));
-      }
-    }
+    if( yt[6].ref[1] || yt[6].ftag[1] ) need_xt[6] = 1;
   }
 
   /* Modify last tetra */
@@ -4789,17 +4629,16 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
     yt[7].ref [1] = 0 ; yt[7].ref [2] = 0 ; yt[7].ref [3] = 0;
     yt[7].ftag[1] = 0 ; yt[7].ftag[2] = 0 ; yt[7].ftag[3] = 0;
     MG_SET(yt[7].ori, 1); MG_SET(yt[7].ori, 2); MG_SET(yt[7].ori, 3);
+    if ( (yt[7].ref[0]) || yt[7].ftag[0]) need_xt[7] = 1;
+  }
 
-    isxt = 0;
-
-    if ( (yt[7].ref[0]) || yt[7].ftag[0]) isxt = 1;
-
-    pt[7]->xt = 0;
-    if ( isxt ) {
+  /* assign xTetra to the new tets that need them */
+  for(int t=1; t<8; t++){
+    pt[t]->xt = 0;
+    if ( need_xt[t] ) {
       if ( !isxt0 ) {
-        pt[7]->xt = nxt0;
-        pxt = &mesh->xtetra[pt[7]->xt];
-        memcpy(pxt,&yt[7],sizeof(MMG5_xTetra));
+        isxt0 = 1;
+        pt[t]->xt = nxt0;
       }
       else {
         mesh->xt++;
@@ -4811,10 +4650,9 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
                              fprintf(stderr,"  Exit program.\n");
                              return 0);
         }
-        pt[7]->xt = mesh->xt;
-        pxt = &mesh->xtetra[pt[7]->xt];
-        memcpy(pxt,&yt[7],sizeof(MMG5_xTetra));
+        pt[t]->xt = mesh->xt;
       }
+      memcpy(&mesh->xtetra[pt[t]->xt],&yt[t],sizeof(MMG5_xTetra));
     }
   }
 

--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -1153,13 +1153,15 @@ int MMG3D_split2sf_sim(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6]){
  * \param mesh pointer to the mesh structure.
  * \param newtet list of indices of the new tetra.
  * \param ne number of tetra in the list.
- * \param pt list of tetra.
- * \param xt list of xtetra.
+ * \param pt list of tetra, the first of which already exists and is the one to be split
+ * \param xt list of xtetra, none of which need to exist
  * \param pxt0 xtetra associated to the first tetra of the list
  *
  * \return 0 if fail, 1 otherwise
  *
- * Create a list of new tetra whose indices are passed in \a newtet.
+ * Create a list of new tetrahedra whose indices are returned in \a newtet.
+ * The new tetrahedra will be copies of pt[0].
+ * A list of xtetra is returned as well; these are copies of *pxt0.
  *
  */
 static inline
@@ -4509,17 +4511,20 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   }
 
   /* Modify first tetra */
-  pt[0]->v[1] = vx[0] ; pt[0]->v[2] = vx[1]; pt[0]->v[3] = vx[2];
+  pt[0]->v[1] = vx[0];
+  pt[0]->v[2] = vx[1];
+  pt[0]->v[3] = vx[2];
   if ( nxt0 ) {
-    yt[0].tag[3] = ftag[3];  yt[0].tag[4] = ftag[2];
-    yt[0].tag[5] = ftag[1];  yt[0].edg[3] = 0;
-    yt[0].edg[4] = 0;  yt[0].edg[5] = 0;
-    yt[0].ref[0] = 0;  yt[0].ftag[0] = 0; MG_SET(yt[0].ori, 0);
+    yt[0].tag[3] = ftag[3];    yt[0].edg[3] = 0;
+    yt[0].tag[4] = ftag[2];    yt[0].edg[4] = 0;
+    yt[0].tag[5] = ftag[1];    yt[0].edg[5] = 0;
+    yt[0].ref[0] = 0;
+    yt[0].ftag[0] = 0;
+    MG_SET(yt[0].ori, 0);
     isxt0 = 0;
     for(i=0;i<4;i++ ) {
       if ( (yt[0].ref[i]) || yt[0].ftag[i] ) isxt0 = 1;
     }
-
     if ( isxt0 ) {
       memcpy(pxt,&yt[0],sizeof(MMG5_xTetra));
     }
@@ -4529,71 +4534,83 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   }
 
   /* Modify second tetra */
-  pt[1]->v[0] = vx[0] ; pt[1]->v[2] = vx[3]; pt[1]->v[3] = vx[4];
-
+  pt[1]->v[0] = vx[0];
+  pt[1]->v[2] = vx[3];
+  pt[1]->v[3] = vx[4];
   if ( nxt0 ) {
-    yt[1].tag[1] = ftag[3];  yt[1].tag[2] = ftag[2];
-    yt[1].tag[5] = ftag[0];  yt[1].edg[1] = 0;
-    yt[1].edg[2] = 0;  yt[1].edg[5] = 0;
-    yt[1].ref[1] = 0;  yt[1].ftag[1] = 0; MG_SET(yt[1].ori, 1);
+    yt[1].tag[1] = ftag[3];    yt[1].edg[1] = 0;
+    yt[1].tag[2] = ftag[2];    yt[1].edg[2] = 0;
+    yt[1].tag[5] = ftag[0];    yt[1].edg[5] = 0;
+    yt[1].ref[1] = 0;
+    yt[1].ftag[1] = 0;
+    MG_SET(yt[1].ori, 1);
     for (i=0; i<4; i++) {
       if ( (yt[1].ref[i]) || yt[1].ftag[i]) need_xt[1] = 1;
     }
   }
 
   /* Modify 3rd tetra */
-  pt[2]->v[0] = vx[1] ; pt[2]->v[1] = vx[3]; pt[2]->v[3] = vx[5];
-
+  pt[2]->v[0] = vx[1];
+  pt[2]->v[1] = vx[3];
+  pt[2]->v[3] = vx[5];
   if ( nxt0 ) {
-    yt[2].tag[0] = ftag[3];  yt[2].tag[2] = ftag[1];
-    yt[2].tag[4] = ftag[0];  yt[2].edg[0] = 0;
-    yt[2].edg[2] = 0;  yt[2].edg[4] = 0;
-    yt[2].ref[2] = 0;  yt[2].ftag[2] = 0;  MG_SET(yt[2].ori, 2);
+    yt[2].tag[0] = ftag[3];    yt[2].edg[0] = 0;
+    yt[2].tag[2] = ftag[1];    yt[2].edg[2] = 0;
+    yt[2].tag[4] = ftag[0];    yt[2].edg[4] = 0;
+    yt[2].ref[2] = 0;
+    yt[2].ftag[2] = 0;
+    MG_SET(yt[2].ori, 2);
     for (i=0; i<4;i++) {
       if ( (yt[2].ref[i]) || yt[2].ftag[i]) need_xt[2] = 1;
     }
   }
 
   /* Modify 4th tetra */
-  pt[3]->v[0] = vx[2] ; pt[3]->v[1] = vx[4]; pt[3]->v[2] = vx[5];
-
+  pt[3]->v[0] = vx[2] ;
+  pt[3]->v[1] = vx[4];
+  pt[3]->v[2] = vx[5];
   if ( nxt0 ) {
-    yt[3].tag[0] = ftag[2];  yt[3].tag[1] = ftag[1];
-    yt[3].tag[3] = ftag[0];  yt[3].edg[0] = 0;
-    yt[3].edg[1] = 0;  yt[3].edg[3] = 0;
-    yt[3].ref[3] = 0;  yt[3].ftag[3] = 0;  MG_SET(yt[3].ori, 3);
+    yt[3].tag[0] = ftag[2];    yt[3].edg[0] = 0;
+    yt[3].tag[1] = ftag[1];    yt[3].edg[1] = 0;
+    yt[3].tag[3] = ftag[0];    yt[3].edg[3] = 0;
+    yt[3].ref[3] = 0;
+    yt[3].ftag[3] = 0;
+    MG_SET(yt[3].ori, 3);
     for (i=0; i<4; i++) {
       if ( (yt[3].ref[i]) || yt[3].ftag[i]) need_xt[3] = 1;
     }
   }
 
   /* Modify 5th tetra */
-  pt[4]->v[0] = vx[0] ; pt[4]->v[1] = vx[3]; pt[4]->v[2] = vx[1] ; pt[4]->v[3] = vx[2];
-
+  pt[4]->v[0] = vx[0];
+  pt[4]->v[1] = vx[3];
+  pt[4]->v[2] = vx[1];
+  pt[4]->v[3] = vx[2];
   if ( nxt0 ) {
-    yt[4].tag[0] = ftag[3];  yt[4].tag[1] = ftag[3];
-    yt[4].tag[2] = ftag[2];  yt[4].tag[3] = ftag[3];
-    yt[4].edg[0] = 0;  yt[4].edg[1] = 0;
-    yt[4].edg[2] = 0;  yt[4].edg[3] = 0;
-    yt[4].tag[4] = 0;  yt[4].edg[4] = 0;
-    yt[4].tag[5] = ftag[1];  yt[4].edg[5] = 0;
-    yt[4].ref [0] = 0 ; yt[4].ref [1] = 0 ; yt[4].ref [2] = 0;
-    yt[4].ftag[0] = 0 ; yt[4].ftag[1] = 0 ; yt[4].ftag[2] = 0;
+    yt[4].tag[0] = ftag[3];    yt[4].edg[0] = 0;
+    yt[4].tag[1] = ftag[3];    yt[4].edg[1] = 0;
+    yt[4].tag[2] = ftag[2];    yt[4].edg[2] = 0;
+    yt[4].tag[3] = ftag[3];    yt[4].edg[3] = 0;
+    yt[4].tag[4] = 0;          yt[4].edg[4] = 0;
+    yt[4].tag[5] = ftag[1];    yt[4].edg[5] = 0;
+    yt[4].ref [0] = 0;  yt[4].ref [1] = 0;  yt[4].ref [2] = 0;
+    yt[4].ftag[0] = 0;  yt[4].ftag[1] = 0;  yt[4].ftag[2] = 0;
     MG_SET(yt[4].ori, 0); MG_SET(yt[4].ori, 1); MG_SET(yt[4].ori, 2);
-
     if ( (yt[4].ref[3]) || yt[4].ftag[3]) need_xt[4] = 1;
   }
 
   /* Modify 6th tetra */
-  pt[5]->v[0] = vx[2] ; pt[5]->v[1] = vx[0]; pt[5]->v[2] = vx[3] ; pt[5]->v[3] = vx[4];
-
+  pt[5]->v[0] = vx[2];
+  pt[5]->v[1] = vx[0];
+  pt[5]->v[2] = vx[3];
+  pt[5]->v[3] = vx[4];
   if ( nxt0 ) {
-    yt[5].tag[0] = ftag[2];  yt[5].tag[1] = 0;
-    yt[5].tag[2] = ftag[2];  yt[5].tag[3] = ftag[3];
-    yt[5].tag[4] = ftag[2];  yt[5].tag[5] = ftag[0];
-    yt[5].edg[0] = 0;  yt[5].edg[1] = 0;
-    yt[5].edg[2] = 0;  yt[5].edg[3] = 0;
-    yt[5].edg[4] = 0;  yt[5].edg[5] = 0;
+    yt[5].tag[0] = ftag[2];    yt[5].edg[0] = 0;
+    yt[5].tag[1] = 0;          yt[5].edg[1] = 0;
+    yt[5].tag[2] = ftag[2];    yt[5].edg[2] = 0;
+    yt[5].tag[3] = ftag[3];    yt[5].edg[3] = 0;
+    yt[5].tag[4] = ftag[2];    yt[5].edg[4] = 0;
+    yt[5].tag[5] = ftag[0];    yt[5].edg[5] = 0;
     yt[5].ref [0] = 0 ; yt[5].ref [1] = 0 ; yt[5].ref [3] = 0;
     yt[5].ftag[0] = 0 ; yt[5].ftag[1] = 0 ; yt[5].ftag[3] = 0;
     MG_SET(yt[5].ori, 0); MG_SET(yt[5].ori, 1); MG_SET(yt[5].ori, 3);
@@ -4601,15 +4618,17 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   }
 
   /* Modify 7th tetra */
-  pt[6]->v[0] = vx[2] ; pt[6]->v[1] = vx[3]; pt[6]->v[2] = vx[1] ; pt[6]->v[3] = vx[5];
-
+  pt[6]->v[0] = vx[2];
+  pt[6]->v[1] = vx[3];
+  pt[6]->v[2] = vx[1];
+  pt[6]->v[3] = vx[5];
   if ( nxt0 ) {
-    yt[6].tag[0] = 0;  yt[6].edg[0] = 0;
-    yt[6].tag[1] = ftag[1];  yt[6].tag[2] = ftag[1];
-    yt[6].tag[3] = ftag[3];  yt[6].tag[4] = ftag[0];
-    yt[6].edg[1] = 0;  yt[6].edg[2] = 0;
-    yt[6].edg[3] = 0;  yt[6].edg[4] = 0;
-    yt[6].tag[5] = ftag[3];  yt[6].edg[5] = 0;
+    yt[6].tag[0] = 0;          yt[6].edg[0] = 0;
+    yt[6].tag[1] = ftag[1];    yt[6].edg[1] = 0;
+    yt[6].tag[2] = ftag[1];    yt[6].edg[2] = 0;
+    yt[6].tag[3] = ftag[3];    yt[6].edg[3] = 0;
+    yt[6].tag[4] = ftag[0];    yt[6].edg[4] = 0;
+    yt[6].tag[5] = ftag[3];    yt[6].edg[5] = 0;
     yt[6].ref [0] = 0 ; yt[6].ref [2] = 0 ; yt[6].ref [3] = 0;
     yt[6].ftag[0] = 0 ; yt[6].ftag[2] = 0 ; yt[6].ftag[3] = 0;
     MG_SET(yt[6].ori, 0); MG_SET(yt[6].ori, 2); MG_SET(yt[6].ori, 3);
@@ -4617,15 +4636,17 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   }
 
   /* Modify last tetra */
-  pt[7]->v[0] = vx[2] ; pt[7]->v[1] = vx[3]; pt[7]->v[2] = vx[5] ; pt[7]->v[3] = vx[4];
-
+  pt[7]->v[0] = vx[2];
+  pt[7]->v[1] = vx[3];
+  pt[7]->v[2] = vx[5];
+  pt[7]->v[3] = vx[4];
   if ( nxt0 ) {
-    yt[7].tag[0] = 0;  yt[7].tag[1] = ftag[1];
-    yt[7].tag[2] = ftag[2];  yt[7].tag[3] = ftag[0];
-    yt[7].tag[4] = ftag[0];  yt[7].tag[5] = ftag[0];
-    yt[7].edg[0] = 0;  yt[7].edg[1] = 0;
-    yt[7].edg[2] = 0;  yt[7].edg[3] = 0;
-    yt[7].edg[4] = 0;  yt[7].edg[5] = 0;
+    yt[7].tag[0] = 0;           yt[7].edg[0] = 0;
+    yt[7].tag[1] = ftag[1];     yt[7].edg[1] = 0;
+    yt[7].tag[2] = ftag[2];     yt[7].edg[2] = 0;
+    yt[7].tag[3] = ftag[0];     yt[7].edg[3] = 0;
+    yt[7].tag[4] = ftag[0];     yt[7].edg[4] = 0;
+    yt[7].tag[5] = ftag[0];     yt[7].edg[5] = 0;
     yt[7].ref [1] = 0 ; yt[7].ref [2] = 0 ; yt[7].ref [3] = 0;
     yt[7].ftag[1] = 0 ; yt[7].ftag[2] = 0 ; yt[7].ftag[3] = 0;
     MG_SET(yt[7].ori, 1); MG_SET(yt[7].ori, 2); MG_SET(yt[7].ori, 3);

--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -4518,7 +4518,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
 
   /* Store face tags and refs from split tetra*/
   for (i=0; i<4; i++) {
-    ftag[i] = (xt.ftag[i] & ~MG_REF);
+    ftag[i] = (xt0.ftag[i] & ~MG_REF);
   }
 
   /* Modify first tetra */

--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -4482,7 +4482,7 @@ int MMG3D_split6_sim(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6]) {
  */
 int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t metRidTyp) {
   MMG5_pTetra    pt[8];
-  MMG5_xTetra    xt0,xt,yt[8]; /* yt is a dummy variable for the time being */
+  MMG5_xTetra    xt0,yt[8];
   MMG5_pxTetra   pxt;
   int            i,j;
   MMG5_int       iel,newtet[8],nxt0;
@@ -4511,18 +4511,17 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   /* Modify first tetra */
   pt[0]->v[1] = vx[0] ; pt[0]->v[2] = vx[1]; pt[0]->v[3] = vx[2];
   if ( nxt0 ) {
-    memcpy(&xt,&xt0,sizeof(MMG5_xTetra));
-    xt.tag[3] = ftag[3];  xt.tag[4] = ftag[2];
-    xt.tag[5] = ftag[1];  xt.edg[3] = 0;
-    xt.edg[4] = 0;  xt.edg[5] = 0;
-    xt.ref[0] = 0;  xt.ftag[0] = 0; MG_SET(xt.ori, 0);
+    yt[0].tag[3] = ftag[3];  yt[0].tag[4] = ftag[2];
+    yt[0].tag[5] = ftag[1];  yt[0].edg[3] = 0;
+    yt[0].edg[4] = 0;  yt[0].edg[5] = 0;
+    yt[0].ref[0] = 0;  yt[0].ftag[0] = 0; MG_SET(yt[0].ori, 0);
     isxt0 = 0;
     for(i=0;i<4;i++ ) {
-      if ( (xt.ref[i]) || xt.ftag[i] ) isxt0 = 1;
+      if ( (yt[0].ref[i]) || yt[0].ftag[i] ) isxt0 = 1;
     }
 
     if ( isxt0 ) {
-      memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+      memcpy(pxt,&yt[0],sizeof(MMG5_xTetra));
     }
     else {
       pt[0]->xt = 0;
@@ -4533,16 +4532,15 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   pt[1]->v[0] = vx[0] ; pt[1]->v[2] = vx[3]; pt[1]->v[3] = vx[4];
 
   if ( nxt0 ) {
-    memcpy(&xt,&xt0,sizeof(MMG5_xTetra));
-    xt.tag[1] = ftag[3];  xt.tag[2] = ftag[2];
-    xt.tag[5] = ftag[0];  xt.edg[1] = 0;
-    xt.edg[2] = 0;  xt.edg[5] = 0;
-    xt.ref[1] = 0;  xt.ftag[1] = 0; MG_SET(xt.ori, 1);
+    yt[1].tag[1] = ftag[3];  yt[1].tag[2] = ftag[2];
+    yt[1].tag[5] = ftag[0];  yt[1].edg[1] = 0;
+    yt[1].edg[2] = 0;  yt[1].edg[5] = 0;
+    yt[1].ref[1] = 0;  yt[1].ftag[1] = 0; MG_SET(yt[1].ori, 1);
 
     isxt = 0;
 
     for (i=0; i<4; i++) {
-      if ( (xt.ref[i]) || xt.ftag[i]) isxt = 1;
+      if ( (yt[1].ref[i]) || yt[1].ftag[i]) isxt = 1;
     }
 
     pt[1]->xt = 0;
@@ -4551,7 +4549,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         isxt0 = 1;
         pt[1]->xt = nxt0;
         pxt = &mesh->xtetra[pt[1]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[1],sizeof(MMG5_xTetra));
       }
       else {
         mesh->xt++;
@@ -4565,7 +4563,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         }
         pt[1]->xt = mesh->xt;
         pxt = &mesh->xtetra[pt[1]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[1],sizeof(MMG5_xTetra));
       }
     }
   }
@@ -4574,15 +4572,14 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   pt[2]->v[0] = vx[1] ; pt[2]->v[1] = vx[3]; pt[2]->v[3] = vx[5];
 
   if ( nxt0 ) {
-    memcpy(&xt,&xt0,sizeof(MMG5_xTetra));
-    xt.tag[0] = ftag[3];  xt.tag[2] = ftag[1];
-    xt.tag[4] = ftag[0];  xt.edg[0] = 0;
-    xt.edg[2] = 0;  xt.edg[4] = 0;
-    xt.ref[2] = 0;  xt.ftag[2] = 0;  MG_SET(xt.ori, 2);
+    yt[2].tag[0] = ftag[3];  yt[2].tag[2] = ftag[1];
+    yt[2].tag[4] = ftag[0];  yt[2].edg[0] = 0;
+    yt[2].edg[2] = 0;  yt[2].edg[4] = 0;
+    yt[2].ref[2] = 0;  yt[2].ftag[2] = 0;  MG_SET(yt[2].ori, 2);
     isxt = 0;
 
     for (i=0; i<4;i++) {
-      if ( (xt.ref[i]) || xt.ftag[i]) isxt = 1;
+      if ( (yt[2].ref[i]) || yt[2].ftag[i]) isxt = 1;
     }
 
     pt[2]->xt = 0;
@@ -4591,7 +4588,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         isxt0 = 1;
         pt[2]->xt = nxt0;
         pxt = &mesh->xtetra[pt[2]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[2],sizeof(MMG5_xTetra));
       }
       else {
         mesh->xt++;
@@ -4605,7 +4602,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         }
         pt[2]->xt = mesh->xt;
         pxt = &mesh->xtetra[pt[2]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[2],sizeof(MMG5_xTetra));
       }
     }
   }
@@ -4614,16 +4611,15 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   pt[3]->v[0] = vx[2] ; pt[3]->v[1] = vx[4]; pt[3]->v[2] = vx[5];
 
   if ( nxt0 ) {
-    memcpy(&xt,&xt0,sizeof(MMG5_xTetra));
-    xt.tag[0] = ftag[2];  xt.tag[1] = ftag[1];
-    xt.tag[3] = ftag[0];  xt.edg[0] = 0;
-    xt.edg[1] = 0;  xt.edg[3] = 0;
-    xt.ref[3] = 0;  xt.ftag[3] = 0;  MG_SET(xt.ori, 3);
+    yt[3].tag[0] = ftag[2];  yt[3].tag[1] = ftag[1];
+    yt[3].tag[3] = ftag[0];  yt[3].edg[0] = 0;
+    yt[3].edg[1] = 0;  yt[3].edg[3] = 0;
+    yt[3].ref[3] = 0;  yt[3].ftag[3] = 0;  MG_SET(yt[3].ori, 3);
 
     isxt = 0;
 
     for (i=0; i<4; i++) {
-      if ( (xt.ref[i]) || xt.ftag[i]) isxt = 1;
+      if ( (yt[3].ref[i]) || yt[3].ftag[i]) isxt = 1;
     }
 
     pt[3]->xt = 0;
@@ -4632,7 +4628,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         isxt0 = 1;
         pt[3]->xt = nxt0;
         pxt = &mesh->xtetra[pt[3]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[3],sizeof(MMG5_xTetra));
       }
       else {
         mesh->xt++;
@@ -4646,7 +4642,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         }
         pt[3]->xt = mesh->xt;
         pxt = &mesh->xtetra[pt[3]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[3],sizeof(MMG5_xTetra));
       }
     }
   }
@@ -4655,20 +4651,19 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   pt[4]->v[0] = vx[0] ; pt[4]->v[1] = vx[3]; pt[4]->v[2] = vx[1] ; pt[4]->v[3] = vx[2];
 
   if ( nxt0 ) {
-    memcpy(&xt,&xt0,sizeof(MMG5_xTetra));
-    xt.tag[0] = ftag[3];  xt.tag[1] = ftag[3];
-    xt.tag[2] = ftag[2];  xt.tag[3] = ftag[3];
-    xt.edg[0] = 0;  xt.edg[1] = 0;
-    xt.edg[2] = 0;  xt.edg[3] = 0;
-    xt.tag[4] = 0;  xt.edg[4] = 0;
-    xt.tag[5] = ftag[1];  xt.edg[5] = 0;
-    xt.ref [0] = 0 ; xt.ref [1] = 0 ; xt.ref [2] = 0;
-    xt.ftag[0] = 0 ; xt.ftag[1] = 0 ; xt.ftag[2] = 0;
-    MG_SET(xt.ori, 0); MG_SET(xt.ori, 1); MG_SET(xt.ori, 2);
+    yt[4].tag[0] = ftag[3];  yt[4].tag[1] = ftag[3];
+    yt[4].tag[2] = ftag[2];  yt[4].tag[3] = ftag[3];
+    yt[4].edg[0] = 0;  yt[4].edg[1] = 0;
+    yt[4].edg[2] = 0;  yt[4].edg[3] = 0;
+    yt[4].tag[4] = 0;  yt[4].edg[4] = 0;
+    yt[4].tag[5] = ftag[1];  yt[4].edg[5] = 0;
+    yt[4].ref [0] = 0 ; yt[4].ref [1] = 0 ; yt[4].ref [2] = 0;
+    yt[4].ftag[0] = 0 ; yt[4].ftag[1] = 0 ; yt[4].ftag[2] = 0;
+    MG_SET(yt[4].ori, 0); MG_SET(yt[4].ori, 1); MG_SET(yt[4].ori, 2);
 
     isxt = 0;
 
-    if ( (xt.ref[3]) || xt.ftag[3]) isxt = 1;
+    if ( (yt[4].ref[3]) || yt[4].ftag[3]) isxt = 1;
 
     pt[4]->xt = 0;
     if ( isxt ) {
@@ -4676,7 +4671,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         isxt0 = 1;
         pt[4]->xt = nxt0;
         pxt = &mesh->xtetra[(pt[4])->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[4],sizeof(MMG5_xTetra));
       }
       else {
         mesh->xt++;
@@ -4690,7 +4685,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         }
         pt[4]->xt = mesh->xt;
         pxt = &mesh->xtetra[pt[4]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[4],sizeof(MMG5_xTetra));
       }
     }
   }
@@ -4699,20 +4694,19 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   pt[5]->v[0] = vx[2] ; pt[5]->v[1] = vx[0]; pt[5]->v[2] = vx[3] ; pt[5]->v[3] = vx[4];
 
   if ( nxt0 ) {
-    memcpy(&xt,&xt0,sizeof(MMG5_xTetra));
-    xt.tag[0] = ftag[2];  xt.tag[1] = 0;
-    xt.tag[2] = ftag[2];  xt.tag[3] = ftag[3];
-    xt.tag[4] = ftag[2];  xt.tag[5] = ftag[0];
-    xt.edg[0] = 0;  xt.edg[1] = 0;
-    xt.edg[2] = 0;  xt.edg[3] = 0;
-    xt.edg[4] = 0;  xt.edg[5] = 0;
-    xt.ref [0] = 0 ; xt.ref [1] = 0 ; xt.ref [3] = 0;
-    xt.ftag[0] = 0 ; xt.ftag[1] = 0 ; xt.ftag[3] = 0;
-    MG_SET(xt.ori, 0); MG_SET(xt.ori, 1); MG_SET(xt.ori, 3);
+    yt[5].tag[0] = ftag[2];  yt[5].tag[1] = 0;
+    yt[5].tag[2] = ftag[2];  yt[5].tag[3] = ftag[3];
+    yt[5].tag[4] = ftag[2];  yt[5].tag[5] = ftag[0];
+    yt[5].edg[0] = 0;  yt[5].edg[1] = 0;
+    yt[5].edg[2] = 0;  yt[5].edg[3] = 0;
+    yt[5].edg[4] = 0;  yt[5].edg[5] = 0;
+    yt[5].ref [0] = 0 ; yt[5].ref [1] = 0 ; yt[5].ref [3] = 0;
+    yt[5].ftag[0] = 0 ; yt[5].ftag[1] = 0 ; yt[5].ftag[3] = 0;
+    MG_SET(yt[5].ori, 0); MG_SET(yt[5].ori, 1); MG_SET(yt[5].ori, 3);
 
     isxt = 0;
 
-    if ( (xt.ref[2]) || xt.ftag[2]) isxt = 1;
+    if ( (yt[5].ref[2]) || yt[5].ftag[2]) isxt = 1;
 
     pt[5]->xt = 0;
     if ( isxt ) {
@@ -4720,7 +4714,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         isxt0 = 1;
         pt[5]->xt = nxt0;
         pxt = &mesh->xtetra[pt[5]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[5],sizeof(MMG5_xTetra));
       }
       else {
         mesh->xt++;
@@ -4734,7 +4728,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         }
         pt[5]->xt = mesh->xt;
         pxt = &mesh->xtetra[pt[5]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[5],sizeof(MMG5_xTetra));
       }
     }
   }
@@ -4743,20 +4737,19 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   pt[6]->v[0] = vx[2] ; pt[6]->v[1] = vx[3]; pt[6]->v[2] = vx[1] ; pt[6]->v[3] = vx[5];
 
   if ( nxt0 ) {
-    memcpy(&xt,&xt0,sizeof(MMG5_xTetra));
-    xt.tag[0] = 0;  xt.edg[0] = 0;
-    xt.tag[1] = ftag[1];  xt.tag[2] = ftag[1];
-    xt.tag[3] = ftag[3];  xt.tag[4] = ftag[0];
-    xt.edg[1] = 0;  xt.edg[2] = 0;
-    xt.edg[3] = 0;  xt.edg[4] = 0;
-    xt.tag[5] = ftag[3];  xt.edg[5] = 0;
-    xt.ref [0] = 0 ; xt.ref [2] = 0 ; xt.ref [3] = 0;
-    xt.ftag[0] = 0 ; xt.ftag[2] = 0 ; xt.ftag[3] = 0;
-    MG_SET(xt.ori, 0); MG_SET(xt.ori, 2); MG_SET(xt.ori, 3);
+    yt[6].tag[0] = 0;  yt[6].edg[0] = 0;
+    yt[6].tag[1] = ftag[1];  yt[6].tag[2] = ftag[1];
+    yt[6].tag[3] = ftag[3];  yt[6].tag[4] = ftag[0];
+    yt[6].edg[1] = 0;  yt[6].edg[2] = 0;
+    yt[6].edg[3] = 0;  yt[6].edg[4] = 0;
+    yt[6].tag[5] = ftag[3];  yt[6].edg[5] = 0;
+    yt[6].ref [0] = 0 ; yt[6].ref [2] = 0 ; yt[6].ref [3] = 0;
+    yt[6].ftag[0] = 0 ; yt[6].ftag[2] = 0 ; yt[6].ftag[3] = 0;
+    MG_SET(yt[6].ori, 0); MG_SET(yt[6].ori, 2); MG_SET(yt[6].ori, 3);
 
     isxt = 0;
 
-    if ( (xt.ref[1]) || xt.ftag[1]) isxt = 1;
+    if ( (yt[6].ref[1]) || yt[6].ftag[1]) isxt = 1;
 
     pt[6]->xt = 0;
     if ( isxt ) {
@@ -4764,7 +4757,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         isxt0 = 1;
         pt[6]->xt = nxt0;
         pxt = &mesh->xtetra[pt[6]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[6],sizeof(MMG5_xTetra));
       }
       else {
         mesh->xt++;
@@ -4778,7 +4771,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         }
         pt[6]->xt = mesh->xt;
         pxt = &mesh->xtetra[pt[6]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[6],sizeof(MMG5_xTetra));
       }
     }
   }
@@ -4787,27 +4780,26 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   pt[7]->v[0] = vx[2] ; pt[7]->v[1] = vx[3]; pt[7]->v[2] = vx[5] ; pt[7]->v[3] = vx[4];
 
   if ( nxt0 ) {
-    memcpy(&xt,&xt0,sizeof(MMG5_xTetra));
-    xt.tag[0] = 0;  xt.tag[1] = ftag[1];
-    xt.tag[2] = ftag[2];  xt.tag[3] = ftag[0];
-    xt.tag[4] = ftag[0];  xt.tag[5] = ftag[0];
-    xt.edg[0] = 0;  xt.edg[1] = 0;
-    xt.edg[2] = 0;  xt.edg[3] = 0;
-    xt.edg[4] = 0;  xt.edg[5] = 0;
-    xt.ref [1] = 0 ; xt.ref [2] = 0 ; xt.ref [3] = 0;
-    xt.ftag[1] = 0 ; xt.ftag[2] = 0 ; xt.ftag[3] = 0;
-    MG_SET(xt.ori, 1); MG_SET(xt.ori, 2); MG_SET(xt.ori, 3);
+    yt[7].tag[0] = 0;  yt[7].tag[1] = ftag[1];
+    yt[7].tag[2] = ftag[2];  yt[7].tag[3] = ftag[0];
+    yt[7].tag[4] = ftag[0];  yt[7].tag[5] = ftag[0];
+    yt[7].edg[0] = 0;  yt[7].edg[1] = 0;
+    yt[7].edg[2] = 0;  yt[7].edg[3] = 0;
+    yt[7].edg[4] = 0;  yt[7].edg[5] = 0;
+    yt[7].ref [1] = 0 ; yt[7].ref [2] = 0 ; yt[7].ref [3] = 0;
+    yt[7].ftag[1] = 0 ; yt[7].ftag[2] = 0 ; yt[7].ftag[3] = 0;
+    MG_SET(yt[7].ori, 1); MG_SET(yt[7].ori, 2); MG_SET(yt[7].ori, 3);
 
     isxt = 0;
 
-    if ( (xt.ref[0]) || xt.ftag[0]) isxt = 1;
+    if ( (yt[7].ref[0]) || yt[7].ftag[0]) isxt = 1;
 
     pt[7]->xt = 0;
     if ( isxt ) {
       if ( !isxt0 ) {
         pt[7]->xt = nxt0;
         pxt = &mesh->xtetra[pt[7]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[7],sizeof(MMG5_xTetra));
       }
       else {
         mesh->xt++;
@@ -4821,7 +4813,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
         }
         pt[7]->xt = mesh->xt;
         pxt = &mesh->xtetra[pt[7]->xt];
-        memcpy(pxt,&xt,sizeof(MMG5_xTetra));
+        memcpy(pxt,&yt[7],sizeof(MMG5_xTetra));
       }
     }
   }

--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -4482,7 +4482,7 @@ int MMG3D_split6_sim(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6]) {
  */
 int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t metRidTyp) {
   MMG5_pTetra    pt[8];
-  MMG5_xTetra    xt0,xt;
+  MMG5_xTetra    xt0,xt,yt[8]; /* yt is a dummy variable for the time being */
   MMG5_pxTetra   pxt;
   int            i,j;
   MMG5_int       iel,newtet[8],nxt0;
@@ -4499,21 +4499,8 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
   memcpy(&xt0,pxt,sizeof(MMG5_xTetra));
 
   /* create 7 new tetras */
-  for (i=1; i<ne; i++) {
-    iel = MMG3D_newElt(mesh);
-    if ( !iel ) {
-      MMG3D_TETRA_REALLOC(mesh,iel,mesh->gap,
-                          fprintf(stderr,"\n  ## Error: %s: unable to allocate"
-                                  " a new element.\n",__func__);
-                          MMG5_INCREASE_MEM_MESSAGE();
-                          fprintf(stderr,"  Exit program.\n");
-                          return 0);
-      for ( j=0; j<i; j++ )
-        pt[j] = &mesh->tetra[newtet[j]];
-    }
-    pt[i] = &mesh->tetra[iel];
-    pt[i] = memcpy(pt[i],pt[0],sizeof(MMG5_Tetra));
-    newtet[i]=iel;
+  if ( !MMG3D_crea_newTetra(mesh,ne,newtet,pt,yt,&pxt) ) {
+    return 0;
   }
 
   /* Store face tags and refs from split tetra*/


### PR DESCRIPTION
Face tags were taken from the wrong, uninitialized variable. Since these tags are used to set tags for newly created edges, the bug led to warning messages from MMG5_chkedg() about inconsistency between point and edge tags.