### PR TITLE
bug fix in MMG5_split6(): face tags were taken from the wrong, uninitialized variable

### DIFF
--- a/src/mmg3d/split_3d.c
+++ b/src/mmg3d/split_3d.c
@@ -4518,7 +4518,7 @@ int MMG5_split6(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int k,MMG5_int vx[6],int8_t m
 
   /* Store face tags and refs from split tetra*/
   for (i=0; i<4; i++) {
-    ftag[i] = (xt.ftag[i] & ~MG_REF);
+    ftag[i] = (xt0.ftag[i] & ~MG_REF);
   }
 
   /* Modify first tetra */


### PR DESCRIPTION
The MMG5_split6 function was using face tags taken from an uninitialized variable. Since these tags are used to set tags for newly created edges, the bug led to warning messages from MMG5_chkedg() about inconsistency between point and edge tags. With some instrumentation I have seen that only the split6 function had this problem, likely because it is implemented a bit differently than the other split functions. Btw I will propose a reorganization of this function later.