### PR TITLE
Removal of Fortran API variadic functions

### DIFF
--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: [ubuntu-20.04,macos-latest]
+            os: [ubuntu-20.04,macos-13]
             pattern: [on,off]
             pointmap: [off]
             scotch: [on,off]

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: [ubuntu-20.04,macos-12]
+            os: [ubuntu-20.04,macos-latest]
             pattern: [on,off]
             pointmap: [off]
             scotch: [on,off]
@@ -65,7 +65,7 @@ jobs:
                 vtk: off
                 int: int32_t
 
-              - os: macos-12
+              - os: macos-latest
                 pattern: off
                 pointmap: on
                 scotch: on
@@ -125,7 +125,7 @@ jobs:
                 vtk: on
                 int: int64_t
 
-              - os: macos-12
+              - os: macos-latest
                 pattern: off
                 pointmap: off
                 scotch: off

--- a/.github/workflows/main-job.yml
+++ b/.github/workflows/main-job.yml
@@ -383,7 +383,7 @@ jobs:
       if: inputs.code_coverage == true
       uses: codecov/codecov-action@v4
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         root_dir: .
         verbose: true
       env:

--- a/cmake/testing/code/mmg2d_io.F90
+++ b/cmake/testing/code/mmg2d_io.F90
@@ -52,7 +52,8 @@ PROGRAM main
   mmgSol  = 0
   CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   call loadmesh(mmgMesh,trim(filein),by_array)
 
@@ -78,7 +79,8 @@ PROGRAM main
   !> 3) Free the MMG2D structures
   CALL MMG2D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(103)
 
 END PROGRAM main
 

--- a/cmake/testing/code/mmg2d_io.F90
+++ b/cmake/testing/code/mmg2d_io.F90
@@ -16,7 +16,6 @@ PROGRAM main
 
   MMG5_DATA_PTR_T  :: mmgMesh
   MMG5_DATA_PTR_T  :: mmgSol
-  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER          :: ier,argc,by_array
   CHARACTER(len=300) :: exec_name,filein,fileout,option
   !> to cast integers into MMG5F_INT integers
@@ -51,10 +50,9 @@ PROGRAM main
 
   mmgMesh = 0
   mmgSol  = 0
-  meshlist = (/MMG5_ARG_start, &
+  CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/)
-  CALL MMG2D_Init_mesh_F(meshlist)
+       MMG5_ARG_end/))
 
   call loadmesh(mmgMesh,trim(filein),by_array)
 
@@ -78,7 +76,9 @@ PROGRAM main
   call writemesh(mmgMesh,trim(fileout),by_array)
 
   !> 3) Free the MMG2D structures
-  CALL MMG2D_Free_all_F(meshlist)
+  CALL MMG2D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
 END PROGRAM main
 

--- a/cmake/testing/code/mmg2d_io.F90
+++ b/cmake/testing/code/mmg2d_io.F90
@@ -16,6 +16,7 @@ PROGRAM main
 
   MMG5_DATA_PTR_T  :: mmgMesh
   MMG5_DATA_PTR_T  :: mmgSol
+  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER          :: ier,argc,by_array
   CHARACTER(len=300) :: exec_name,filein,fileout,option
   !> to cast integers into MMG5F_INT integers
@@ -50,9 +51,10 @@ PROGRAM main
 
   mmgMesh = 0
   mmgSol  = 0
-  CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  meshlist = (/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/)
+  CALL MMG2D_Init_mesh_F(meshlist)
 
   call loadmesh(mmgMesh,trim(filein),by_array)
 
@@ -76,9 +78,7 @@ PROGRAM main
   call writemesh(mmgMesh,trim(fileout),by_array)
 
   !> 3) Free the MMG2D structures
-  CALL MMG2D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMG2D_Free_all_F(meshlist)
 
 END PROGRAM main
 

--- a/libexamples/mmg/adaptation_example0_fortran/main.F90
+++ b/libexamples/mmg/adaptation_example0_fortran/main.F90
@@ -128,7 +128,8 @@ PROGRAM main
 
   CALL MMGS_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(101)
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMGS_loadMesh function that will read a .mesh(b)
@@ -188,7 +189,8 @@ PROGRAM main
   !> 3) Free the MMGS5 structures
   CALL MMGS_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(106)
 
   !> ================== 3d remeshing using the mmg3d library
 

--- a/libexamples/mmg/adaptation_example0_fortran/main.F90
+++ b/libexamples/mmg/adaptation_example0_fortran/main.F90
@@ -208,7 +208,8 @@ PROGRAM main
 
   CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(101)
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG3D_loadMesh function that will read a .mesh(b)
@@ -268,6 +269,7 @@ PROGRAM main
   !> 3) Free the MMG3D5 structures
   CALL MMG3D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM main

--- a/libexamples/mmg/adaptation_example0_fortran/main.F90
+++ b/libexamples/mmg/adaptation_example0_fortran/main.F90
@@ -51,7 +51,8 @@ PROGRAM main
 
   CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(101)
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG2D_loadMesh function that will read a .mesh(b)
@@ -108,7 +109,8 @@ PROGRAM main
   !> 3) Free the MMG2D5 structures
   CALL MMG2D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
   !> ================== surface remeshing using the mmgs library
 

--- a/libexamples/mmg/adaptation_example0_fortran/main.F90
+++ b/libexamples/mmg/adaptation_example0_fortran/main.F90
@@ -202,9 +202,9 @@ PROGRAM main
   mmgMesh = 0
   mmgSol  = 0
 
-  CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG3D_loadMesh function that will read a .mesh(b)
@@ -262,8 +262,8 @@ PROGRAM main
 
 
   !> 3) Free the MMG3D5 structures
-  CALL MMG3D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMG3D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
 END PROGRAM main

--- a/libexamples/mmg/adaptation_example0_fortran/main.F90
+++ b/libexamples/mmg/adaptation_example0_fortran/main.F90
@@ -124,9 +124,9 @@ PROGRAM main
   mmgMesh = 0
   mmgSol  = 0
 
-  CALL MMGS_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMGS_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMGS_loadMesh function that will read a .mesh(b)
@@ -184,9 +184,9 @@ PROGRAM main
   ENDIF
 
   !> 3) Free the MMGS5 structures
-  CALL MMGS_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMGS_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
   !> ================== 3d remeshing using the mmg3d library
 

--- a/libexamples/mmg/adaptation_example0_fortran/main.F90
+++ b/libexamples/mmg/adaptation_example0_fortran/main.F90
@@ -16,7 +16,6 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgSol
-  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER            :: ier,argc
   CHARACTER(len=350) :: tdfile,tdfileout, bdfile, bdfileout,exec_name,fileout
 
@@ -50,10 +49,9 @@ PROGRAM main
   mmgMesh = 0
   mmgSol  = 0
 
-  meshlist = (/MMG5_ARG_start, &
+  CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/)
-  CALL MMG2D_Init_mesh_F(meshlist)
+       MMG5_ARG_end/))
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG2D_loadMesh function that will read a .mesh(b)
@@ -108,7 +106,9 @@ PROGRAM main
   ENDIF
 
   !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all_F(meshlist)
+  CALL MMG2D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
   !> ================== surface remeshing using the mmgs library
 

--- a/libexamples/mmg/adaptation_example0_fortran/main.F90
+++ b/libexamples/mmg/adaptation_example0_fortran/main.F90
@@ -16,6 +16,7 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgSol
+  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER            :: ier,argc
   CHARACTER(len=350) :: tdfile,tdfileout, bdfile, bdfileout,exec_name,fileout
 
@@ -49,9 +50,10 @@ PROGRAM main
   mmgMesh = 0
   mmgSol  = 0
 
-  CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  meshlist = (/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/)
+  CALL MMG2D_Init_mesh_F(meshlist)
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG2D_loadMesh function that will read a .mesh(b)
@@ -106,9 +108,7 @@ PROGRAM main
   ENDIF
 
   !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMG2D_Free_all_F(meshlist)
 
   !> ================== surface remeshing using the mmgs library
 

--- a/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main.F90
@@ -85,7 +85,8 @@ PROGRAM main
   CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -180,6 +181,7 @@ PROGRAM main
   CALL MMG2D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main.F90
@@ -46,6 +46,7 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgLs,mmgMet
+  MMG5_DATA_PTR_T, dimension(8) :: meshlist
   INTEGER(MMG5F_INT) :: k,np
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,inname,outname,lsname
@@ -82,10 +83,11 @@ PROGRAM main
   mmgLs   = 0
   mmgMet  = 0
 
-  CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  meshlist = (/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/)
+  CALL MMG2D_Init_mesh_F(meshlist)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -177,9 +179,6 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMG2D_Free_all_F(meshlist)
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main.F90
@@ -46,7 +46,6 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgLs,mmgMet
-  MMG5_DATA_PTR_T, dimension(8) :: meshlist
   INTEGER(MMG5F_INT) :: k,np
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,inname,outname,lsname
@@ -83,11 +82,10 @@ PROGRAM main
   mmgLs   = 0
   mmgMet  = 0
 
-  meshlist = (/MMG5_ARG_start, &
+  CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/)
-  CALL MMG2D_Init_mesh_F(meshlist)
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -179,6 +177,9 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all_F(meshlist)
+  CALL MMG2D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
@@ -81,7 +81,8 @@ PROGRAM main
   CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -153,6 +154,7 @@ PROGRAM main
   CALL MMG2D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
@@ -45,7 +45,6 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgLs,mmgMet
-  MMG5_DATA_PTR_T, dimension(8) :: meshlist
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,inname,outname,lsname
   !> to cast integers into MMG5F_INT integers
@@ -79,11 +78,10 @@ PROGRAM main
   mmgLs   = 0
   mmgMet  = 0
 
-  meshlist = (/MMG5_ARG_start, &
+  CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/)
-  CALL MMG2D_Init_mesh_F(meshlist)
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -152,6 +150,9 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all_F(meshlist)
+  CALL MMG2D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
@@ -45,6 +45,7 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgLs,mmgMet
+  MMG5_DATA_PTR_T, dimension(8) :: meshlist
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,inname,outname,lsname
   !> to cast integers into MMG5F_INT integers
@@ -78,10 +79,11 @@ PROGRAM main
   mmgLs   = 0
   mmgMet  = 0
 
-  CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  meshlist = (/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/)
+  CALL MMG2D_Init_mesh_F(meshlist)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -150,9 +152,6 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMG2D_Free_all_F(meshlist)
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main_optim.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main_optim.F90
@@ -45,6 +45,7 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgLs,mmgMet
+  MMG5_DATA_PTR_T, dimension(8) :: meshlist
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,inname,outname,lsname
   !> to cast integers into MMG5F_INT integers
@@ -78,10 +79,11 @@ PROGRAM main
   mmgLs   = 0
   mmgMet  = 0
 
-  CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  meshlist = (/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/)
+  CALL MMG2D_Init_mesh_F(meshlist)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -154,9 +156,6 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMG2D_Free_all_F(meshlist)
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main_optim.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main_optim.F90
@@ -45,7 +45,6 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgLs,mmgMet
-  MMG5_DATA_PTR_T, dimension(8) :: meshlist
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,inname,outname,lsname
   !> to cast integers into MMG5F_INT integers
@@ -79,11 +78,10 @@ PROGRAM main
   mmgLs   = 0
   mmgMet  = 0
 
-  meshlist = (/MMG5_ARG_start, &
+  CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/)
-  CALL MMG2D_Init_mesh_F(meshlist)
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -156,6 +154,9 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all_F(meshlist)
+  CALL MMG2D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main_optim.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsAndMetric/main_optim.F90
@@ -81,7 +81,8 @@ PROGRAM main
   CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -157,6 +158,7 @@ PROGRAM main
   CALL MMG2D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main.F90
@@ -78,7 +78,8 @@ PROGRAM main
 
   CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/) )
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -142,6 +143,7 @@ PROGRAM main
    !> 3) Free the MMG2D5 structures
   CALL MMG2D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/) )
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(107)
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main.F90
@@ -44,7 +44,6 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgLs
-  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,inname,outname,lsname
   !> to cast integers into MMG5F_INT integers
@@ -77,11 +76,9 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
 
-  meshlist = (/MMG5_ARG_start, &
+  CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/) 
-
-  CALL MMG2D_Init_mesh_F(meshlist)
+       MMG5_ARG_end/) )
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -143,6 +140,8 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all_F(meshlist)
+  CALL MMG2D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/) )
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main.F90
@@ -44,6 +44,7 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgLs
+  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,inname,outname,lsname
   !> to cast integers into MMG5F_INT integers
@@ -76,9 +77,11 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
 
-  CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  meshlist = (/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/) 
+
+  CALL MMG2D_Init_mesh_F(meshlist)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -140,8 +143,6 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMG2D_Free_all_F(meshlist)
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main_hsiz.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main_hsiz.F90
@@ -45,7 +45,6 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgLs
-  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,inname,outname,lsname
   !> to cast integers into MMG5F_INT integers
@@ -78,10 +77,9 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
 
-  meshlist = (/MMG5_ARG_start, &
+  CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/)
-  CALL MMG2D_Init_mesh_F(meshlist)
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -146,6 +144,8 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all_F(meshlist)
+  CALL MMG2D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main_hsiz.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main_hsiz.F90
@@ -79,7 +79,8 @@ PROGRAM main
 
   CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -146,6 +147,7 @@ PROGRAM main
    !> 3) Free the MMG2D5 structures
   CALL MMG2D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(107)
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main_hsiz.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main_hsiz.F90
@@ -45,6 +45,7 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgLs
+  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,inname,outname,lsname
   !> to cast integers into MMG5F_INT integers
@@ -77,9 +78,10 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
 
-  CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  meshlist = (/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/)
+  CALL MMG2D_Init_mesh_F(meshlist)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -144,8 +146,6 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMG2D_Free_all_F(meshlist)
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main_optim.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main_optim.F90
@@ -79,7 +79,8 @@ PROGRAM main
 
   CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -150,6 +151,7 @@ PROGRAM main
    !> 3) Free the MMG2D5 structures
   CALL MMG2D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(107)
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main_optim.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main_optim.F90
@@ -45,6 +45,7 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgLs
+  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,inname,outname,lsname
   !> to cast integers into MMG5F_INT integers
@@ -77,9 +78,10 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
 
-  CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  meshlist = (/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/)
+  CALL MMG2D_Init_mesh_F(meshlist)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -148,8 +150,6 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMG2D_Free_all_F(meshlist)
 
 END PROGRAM

--- a/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main_optim.F90
+++ b/libexamples/mmg2d/IsosurfDiscretization_lsOnly/main_optim.F90
@@ -45,7 +45,6 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgLs
-  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,inname,outname,lsname
   !> to cast integers into MMG5F_INT integers
@@ -78,10 +77,9 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
 
-  meshlist = (/MMG5_ARG_start, &
+  CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/)
-  CALL MMG2D_Init_mesh_F(meshlist)
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -150,6 +148,8 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all_F(meshlist)
+  CALL MMG2D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmg2d/adaptation_example0_fortran/example0_a/main.F90
+++ b/libexamples/mmg2d/adaptation_example0_fortran/example0_a/main.F90
@@ -18,7 +18,6 @@ PROGRAM main
   MMG5_DATA_PTR_T    :: mmgSol
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,filename,fileout
-  MMG5_DATA_PTR_T, dimension(6) :: meshlist
 
   PRINT*,"  -- TEST MMG2DLIB"
 
@@ -47,11 +46,9 @@ PROGRAM main
   mmgMesh = 0
   mmgSol  = 0
 
-  meshlist = (/ MMG5_ARG_start, &
+  CALL MMG2D_Init_mesh((/ MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end /)
-
-  CALL MMG2D_Init_mesh_F(meshlist)
+       MMG5_ARG_end /))
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG2D_loadMesh function that will read a .mesh(b)
@@ -105,6 +102,8 @@ PROGRAM main
   IF ( ier /= 1 ) CALL EXIT(107)
 
   !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all_F(meshlist)
+  CALL MMG2D_Free_all((/ MMG5_ARG_start, &
+        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+        MMG5_ARG_end /))
 
 END PROGRAM main

--- a/libexamples/mmg2d/adaptation_example0_fortran/example0_a/main.F90
+++ b/libexamples/mmg2d/adaptation_example0_fortran/example0_a/main.F90
@@ -48,7 +48,8 @@ PROGRAM main
 
   CALL MMG2D_Init_mesh((/ MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end /))
+       MMG5_ARG_end /),ier)
+  IF ( ier == 0 ) CALL EXIT(101)
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG2D_loadMesh function that will read a .mesh(b)
@@ -104,6 +105,7 @@ PROGRAM main
   !> 3) Free the MMG2D5 structures
   CALL MMG2D_Free_all((/ MMG5_ARG_start, &
         MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-        MMG5_ARG_end /))
+        MMG5_ARG_end /),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM main

--- a/libexamples/mmg2d/adaptation_example0_fortran/example0_a/main.F90
+++ b/libexamples/mmg2d/adaptation_example0_fortran/example0_a/main.F90
@@ -18,6 +18,7 @@ PROGRAM main
   MMG5_DATA_PTR_T    :: mmgSol
   INTEGER            :: ier,argc
   CHARACTER(len=300) :: exec_name,filename,fileout
+  MMG5_DATA_PTR_T, dimension(6) :: meshlist
 
   PRINT*,"  -- TEST MMG2DLIB"
 
@@ -46,9 +47,11 @@ PROGRAM main
   mmgMesh = 0
   mmgSol  = 0
 
-  CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  meshlist = (/ MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end /)
+
+  CALL MMG2D_Init_mesh_F(meshlist)
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG2D_loadMesh function that will read a .mesh(b)
@@ -102,8 +105,6 @@ PROGRAM main
   IF ( ier /= 1 ) CALL EXIT(107)
 
   !> 3) Free the MMG2D5 structures
-  CALL MMG2D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMG2D_Free_all_F(meshlist)
 
 END PROGRAM main

--- a/libexamples/mmg2d/adaptation_example0_fortran/example0_b/main.F90
+++ b/libexamples/mmg2d/adaptation_example0_fortran/example0_b/main.F90
@@ -15,7 +15,6 @@ PROGRAM main
 
   MMG5_DATA_PTR_T  :: mmgMesh
   MMG5_DATA_PTR_T  :: mmgSol
-  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER          :: ier,argc
   CHARACTER(len=300) :: exec_name,fileout
 
@@ -55,10 +54,10 @@ PROGRAM main
 
   mmgMesh = 0
   mmgSol  = 0
-  meshlist = (/MMG5_ARG_start, &
+
+  CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/)
-  CALL MMG2D_Init_mesh_F(meshlist)
+       MMG5_ARG_end/))
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG2D_loadMesh function that will read a .mesh(b)
@@ -303,6 +302,8 @@ PROGRAM main
   CLOSE(inm)
 
   !> 3) Free the MMG2D structures
-  CALL MMG2D_Free_all_F(meshlist)
+  CALL MMG2D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
 END PROGRAM main

--- a/libexamples/mmg2d/adaptation_example0_fortran/example0_b/main.F90
+++ b/libexamples/mmg2d/adaptation_example0_fortran/example0_b/main.F90
@@ -57,7 +57,8 @@ PROGRAM main
 
   CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG2D_loadMesh function that will read a .mesh(b)
@@ -304,6 +305,7 @@ PROGRAM main
   !> 3) Free the MMG2D structures
   CALL MMG2D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(116)
 
 END PROGRAM main

--- a/libexamples/mmg2d/adaptation_example0_fortran/example0_b/main.F90
+++ b/libexamples/mmg2d/adaptation_example0_fortran/example0_b/main.F90
@@ -15,6 +15,7 @@ PROGRAM main
 
   MMG5_DATA_PTR_T  :: mmgMesh
   MMG5_DATA_PTR_T  :: mmgSol
+  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER          :: ier,argc
   CHARACTER(len=300) :: exec_name,fileout
 
@@ -54,9 +55,10 @@ PROGRAM main
 
   mmgMesh = 0
   mmgSol  = 0
-  CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  meshlist = (/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/)
+  CALL MMG2D_Init_mesh_F(meshlist)
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG2D_loadMesh function that will read a .mesh(b)
@@ -301,8 +303,6 @@ PROGRAM main
   CLOSE(inm)
 
   !> 3) Free the MMG2D structures
-  CALL MMG2D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMG2D_Free_all_F(meshlist)
 
 END PROGRAM main

--- a/libexamples/mmg2d/io_multisols_example0/main.F90
+++ b/libexamples/mmg2d/io_multisols_example0/main.F90
@@ -15,7 +15,6 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgSol,mmgMet,tmpSol
-  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER            :: ier,argc,i,opt
 
   !! To manually recover the mesh
@@ -60,10 +59,9 @@ PROGRAM main
   mmgMet  = 0
   tmpSol  = 0
 
-  meshlist = (/MMG5_ARG_start, &
+  CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/)
-  CALL MMG2D_Init_mesh_F(meshlist);
+       MMG5_ARG_end/));
 
 
   !!> 2) Build initial mesh and solutions in MMG5 format
@@ -154,6 +152,8 @@ PROGRAM main
   !!> 3) Free the MMG2D structures
   CALL MMG2D_Free_allSols(mmgMesh,mmgSol,ier)
 
-  CALL MMG2D_Free_all_F(meshlist)
+  CALL MMG2D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
 END PROGRAM main

--- a/libexamples/mmg2d/io_multisols_example0/main.F90
+++ b/libexamples/mmg2d/io_multisols_example0/main.F90
@@ -15,6 +15,7 @@ PROGRAM main
 
   MMG5_DATA_PTR_T    :: mmgMesh
   MMG5_DATA_PTR_T    :: mmgSol,mmgMet,tmpSol
+  MMG5_DATA_PTR_T, dimension(6) :: meshlist
   INTEGER            :: ier,argc,i,opt
 
   !! To manually recover the mesh
@@ -59,9 +60,10 @@ PROGRAM main
   mmgMet  = 0
   tmpSol  = 0
 
-  CALL MMG2D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end);
+  meshlist = (/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/)
+  CALL MMG2D_Init_mesh_F(meshlist);
 
 
   !!> 2) Build initial mesh and solutions in MMG5 format
@@ -152,8 +154,6 @@ PROGRAM main
   !!> 3) Free the MMG2D structures
   CALL MMG2D_Free_allSols(mmgMesh,mmgSol,ier)
 
-  CALL MMG2D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppSols,tmpSol, &
-       MMG5_ARG_end)
+  CALL MMG2D_Free_all_F(meshlist)
 
 END PROGRAM main

--- a/libexamples/mmg2d/io_multisols_example0/main.F90
+++ b/libexamples/mmg2d/io_multisols_example0/main.F90
@@ -61,7 +61,8 @@ PROGRAM main
 
   CALL MMG2D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/));
+       MMG5_ARG_end/),ier);
+  IF ( ier == 0 ) CALL EXIT(101)
 
 
   !!> 2) Build initial mesh and solutions in MMG5 format
@@ -154,6 +155,7 @@ PROGRAM main
 
   CALL MMG2D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(112)
 
 END PROGRAM main

--- a/libexamples/mmg3d/IsosurfDiscretization_lsAndMetric/main.F90
+++ b/libexamples/mmg3d/IsosurfDiscretization_lsAndMetric/main.F90
@@ -85,7 +85,8 @@ PROGRAM main
   CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -181,6 +182,7 @@ PROGRAM main
   CALL MMG3D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM

--- a/libexamples/mmg3d/IsosurfDiscretization_lsAndMetric/main.F90
+++ b/libexamples/mmg3d/IsosurfDiscretization_lsAndMetric/main.F90
@@ -82,10 +82,10 @@ PROGRAM main
   mmgLs   = 0
   mmgMet  = 0
 
-  CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -178,9 +178,9 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG3D5 structures
-  CALL MMG3D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMG3D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmg3d/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
+++ b/libexamples/mmg3d/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
@@ -78,10 +78,10 @@ PROGRAM main
   mmgLs   = 0
   mmgMet  = 0
 
-  CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -150,9 +150,9 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG3D5 structures
-  CALL MMG3D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMG3D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmg3d/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
+++ b/libexamples/mmg3d/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
@@ -81,7 +81,8 @@ PROGRAM main
   CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -153,6 +154,7 @@ PROGRAM main
   CALL MMG3D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM

--- a/libexamples/mmg3d/IsosurfDiscretization_lsAndMetric/main_optim.F90
+++ b/libexamples/mmg3d/IsosurfDiscretization_lsAndMetric/main_optim.F90
@@ -81,7 +81,8 @@ PROGRAM main
   CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -157,6 +158,7 @@ PROGRAM main
   CALL MMG3D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM

--- a/libexamples/mmg3d/IsosurfDiscretization_lsAndMetric/main_optim.F90
+++ b/libexamples/mmg3d/IsosurfDiscretization_lsAndMetric/main_optim.F90
@@ -78,10 +78,10 @@ PROGRAM main
   mmgLs   = 0
   mmgMet  = 0
 
-  CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -154,9 +154,9 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG3D5 structures
-  CALL MMG3D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMG3D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmg3d/IsosurfDiscretization_lsOnly/main.F90
+++ b/libexamples/mmg3d/IsosurfDiscretization_lsOnly/main.F90
@@ -79,7 +79,8 @@ PROGRAM main
 
   CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -139,6 +140,7 @@ PROGRAM main
    !> 3) Free the MMG3D5 structures
   CALL MMG3D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(107)
 
 END PROGRAM

--- a/libexamples/mmg3d/IsosurfDiscretization_lsOnly/main.F90
+++ b/libexamples/mmg3d/IsosurfDiscretization_lsOnly/main.F90
@@ -77,9 +77,9 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
 
-  CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -137,8 +137,8 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG3D5 structures
-  CALL MMG3D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMG3D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmg3d/IsosurfDiscretization_lsOnly/main_hsiz.F90
+++ b/libexamples/mmg3d/IsosurfDiscretization_lsOnly/main_hsiz.F90
@@ -79,7 +79,8 @@ PROGRAM main
 
   CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -146,6 +147,7 @@ PROGRAM main
    !> 3) Free the MMG3D5 structures
   CALL MMG3D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(107)
 
 END PROGRAM

--- a/libexamples/mmg3d/IsosurfDiscretization_lsOnly/main_hsiz.F90
+++ b/libexamples/mmg3d/IsosurfDiscretization_lsOnly/main_hsiz.F90
@@ -77,9 +77,9 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
 
-  CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -144,8 +144,8 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMG3D5 structures
-  CALL MMG3D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMG3D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmg3d/IsosurfDiscretization_lsOnly/main_optim.F90
+++ b/libexamples/mmg3d/IsosurfDiscretization_lsOnly/main_optim.F90
@@ -77,9 +77,9 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
 
-  CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -148,8 +148,8 @@ PROGRAM main
   ENDIF
 
   !> 3) Free the MMG3D5 structures
-  CALL MMG3D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMG3D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmg3d/IsosurfDiscretization_lsOnly/main_optim.F90
+++ b/libexamples/mmg3d/IsosurfDiscretization_lsOnly/main_optim.F90
@@ -79,7 +79,8 @@ PROGRAM main
 
   CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -150,6 +151,7 @@ PROGRAM main
   !> 3) Free the MMG3D5 structures
   CALL MMG3D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(107)
 
 END PROGRAM

--- a/libexamples/mmg3d/adaptation_example0_fortran/example0_a/main.F90
+++ b/libexamples/mmg3d/adaptation_example0_fortran/example0_a/main.F90
@@ -47,7 +47,8 @@ PROGRAM main
 
   CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(101)
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG3D_loadMesh function that will read a .mesh(b)
@@ -107,6 +108,7 @@ PROGRAM main
   !> 3) Free the MMG3D5 structures
   CALL MMG3D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM main

--- a/libexamples/mmg3d/adaptation_example0_fortran/example0_a/main.F90
+++ b/libexamples/mmg3d/adaptation_example0_fortran/example0_a/main.F90
@@ -45,9 +45,9 @@ PROGRAM main
   mmgMesh = 0
   mmgSol  = 0
 
-  CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMG3D_loadMesh function that will read a .mesh(b)
@@ -105,8 +105,8 @@ PROGRAM main
   ENDIF
 
   !> 3) Free the MMG3D5 structures
-  CALL MMG3D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMG3D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
 END PROGRAM main

--- a/libexamples/mmg3d/adaptation_example0_fortran/example0_b/main.F90
+++ b/libexamples/mmg3d/adaptation_example0_fortran/example0_b/main.F90
@@ -59,7 +59,8 @@ PROGRAM main
 
   CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
   CALL MMG3D_SET_IPARAMETER(mmgMesh,mmgSol,MMG3D_IPARAM_verbose,5_immg,ier)
 
   !> 2) Build mesh in MMG5 format
@@ -376,5 +377,6 @@ PROGRAM main
   !> 3) Free the MMG3D5 structures
   CALL MMG3D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(101)
 END PROGRAM main

--- a/libexamples/mmg3d/adaptation_example0_fortran/example0_b/main.F90
+++ b/libexamples/mmg3d/adaptation_example0_fortran/example0_b/main.F90
@@ -57,9 +57,9 @@ PROGRAM main
   mmgMesh = 0
   mmgSol  = 0
 
-  CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
   CALL MMG3D_SET_IPARAMETER(mmgMesh,mmgSol,MMG3D_IPARAM_verbose,5_immg,ier)
 
   !> 2) Build mesh in MMG5 format
@@ -374,7 +374,7 @@ PROGRAM main
   CLOSE(inm)
 
   !> 3) Free the MMG3D5 structures
-  CALL MMG3D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMG3D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 END PROGRAM main

--- a/libexamples/mmg3d/io_multisols_example6/main.F90
+++ b/libexamples/mmg3d/io_multisols_example6/main.F90
@@ -62,7 +62,8 @@ PROGRAM main
 
   CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/));
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(101)
 
 
   !!> 2) Build initial mesh and solutions in MMG5 format
@@ -155,6 +156,7 @@ PROGRAM main
 
   CALL MMG3D_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppSols,LOC(tmpSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(112)
 
 END PROGRAM main

--- a/libexamples/mmg3d/io_multisols_example6/main.F90
+++ b/libexamples/mmg3d/io_multisols_example6/main.F90
@@ -60,9 +60,9 @@ PROGRAM main
   mmgMet  = 0
   tmpSol  = 0
 
-  CALL MMG3D_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end);
+  CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/));
 
 
   !!> 2) Build initial mesh and solutions in MMG5 format
@@ -153,8 +153,8 @@ PROGRAM main
   !!> 3) Free the MMG3D structures
   CALL MMG3D_Free_allSols(mmgMesh,mmgSol,ier)
 
-  CALL MMG3D_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppSols,tmpSol, &
-       MMG5_ARG_end)
+  CALL MMG3D_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppSols,LOC(tmpSol), &
+       MMG5_ARG_end/))
 
 END PROGRAM main

--- a/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main.F90
+++ b/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main.F90
@@ -85,7 +85,8 @@ PROGRAM main
   CALL MMGS_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -180,6 +181,7 @@ PROGRAM main
   CALL MMGS_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM

--- a/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main.F90
+++ b/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main.F90
@@ -82,10 +82,10 @@ PROGRAM main
   mmgLs   = 0
   mmgMet  = 0
 
-  CALL MMGS_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMGS_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -177,9 +177,9 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMGS5 structures
-  CALL MMGS_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMGS_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
+++ b/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
@@ -80,7 +80,8 @@ PROGRAM main
   CALL MMGS_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -152,6 +153,7 @@ PROGRAM main
   CALL MMGS_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM

--- a/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
+++ b/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main_hsiz.F90
@@ -77,10 +77,10 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
   mmgMet  = 0
-  CALL MMGS_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMGS_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -149,9 +149,9 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMGS5 structures
-  CALL MMGS_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMGS_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main_optim.F90
+++ b/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main_optim.F90
@@ -77,10 +77,10 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
   mmgMet  = 0
-  CALL MMGS_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMGS_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -153,9 +153,9 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMGS5 structures
-  CALL MMGS_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end)
+  CALL MMGS_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main_optim.F90
+++ b/libexamples/mmgs/IsosurfDiscretization_lsAndMetric/main_optim.F90
@@ -80,7 +80,8 @@ PROGRAM main
   CALL MMGS_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -156,6 +157,7 @@ PROGRAM main
   CALL MMGS_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
        MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM

--- a/libexamples/mmgs/IsosurfDiscretization_lsOnly/main.F90
+++ b/libexamples/mmgs/IsosurfDiscretization_lsOnly/main.F90
@@ -78,9 +78,9 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
 
-  CALL MMGS_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMGS_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -138,8 +138,8 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMGS5 structures
-  CALL MMGS_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMGS_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmgs/IsosurfDiscretization_lsOnly/main.F90
+++ b/libexamples/mmgs/IsosurfDiscretization_lsOnly/main.F90
@@ -80,7 +80,8 @@ PROGRAM main
 
   CALL MMGS_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -140,6 +141,7 @@ PROGRAM main
    !> 3) Free the MMGS5 structures
   CALL MMGS_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(107)
 
 END PROGRAM

--- a/libexamples/mmgs/IsosurfDiscretization_lsOnly/main_hsiz.F90
+++ b/libexamples/mmgs/IsosurfDiscretization_lsOnly/main_hsiz.F90
@@ -80,7 +80,8 @@ PROGRAM main
 
   CALL MMGS_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -147,6 +148,7 @@ PROGRAM main
    !> 3) Free the MMGS5 structures
   CALL MMGS_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(107)
 
 END PROGRAM

--- a/libexamples/mmgs/IsosurfDiscretization_lsOnly/main_hsiz.F90
+++ b/libexamples/mmgs/IsosurfDiscretization_lsOnly/main_hsiz.F90
@@ -78,9 +78,9 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
 
-  CALL MMGS_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMGS_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -145,8 +145,8 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMGS5 structures
-  CALL MMGS_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMGS_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmgs/IsosurfDiscretization_lsOnly/main_optim.F90
+++ b/libexamples/mmgs/IsosurfDiscretization_lsOnly/main_optim.F90
@@ -80,7 +80,8 @@ PROGRAM main
 
   CALL MMGS_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -153,6 +154,7 @@ PROGRAM main
    !> 3) Free the MMGS5 structures
   CALL MMGS_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(107)
 
 END PROGRAM

--- a/libexamples/mmgs/IsosurfDiscretization_lsOnly/main_optim.F90
+++ b/libexamples/mmgs/IsosurfDiscretization_lsOnly/main_optim.F90
@@ -78,9 +78,9 @@ PROGRAM main
   mmgMesh = 0
   mmgLs   = 0
 
-  CALL MMGS_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMGS_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
   !!------------------- Level set discretization option ---------------------
   ! Ask for level set discretization: note that it is important to do this step
@@ -151,8 +151,8 @@ PROGRAM main
   ENDIF
 
    !> 3) Free the MMGS5 structures
-  CALL MMGS_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppLs,mmgLs, &
-       MMG5_ARG_end)
+  CALL MMGS_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppLs,LOC(mmgLs), &
+       MMG5_ARG_end/))
 
 END PROGRAM

--- a/libexamples/mmgs/adaptation_example0_fortran/example0_a/main.F90
+++ b/libexamples/mmgs/adaptation_example0_fortran/example0_a/main.F90
@@ -45,9 +45,9 @@ PROGRAM main
   mmgMesh = 0
   mmgSol  = 0
 
-  CALL MMGS_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMGS_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMGS_loadMesh function that will read a .mesh(b)
@@ -100,8 +100,8 @@ PROGRAM main
   IF ( ier /= 1 ) CALL EXIT(107)
 
   !> 3) Free the MMGS5 structures
-  CALL MMGS_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMGS_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
 END PROGRAM main

--- a/libexamples/mmgs/adaptation_example0_fortran/example0_a/main.F90
+++ b/libexamples/mmgs/adaptation_example0_fortran/example0_a/main.F90
@@ -47,7 +47,8 @@ PROGRAM main
 
   CALL MMGS_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(101)
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMGS_loadMesh function that will read a .mesh(b)
@@ -102,6 +103,7 @@ PROGRAM main
   !> 3) Free the MMGS5 structures
   CALL MMGS_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(108)
 
 END PROGRAM main

--- a/libexamples/mmgs/adaptation_example0_fortran/example0_b/main.F90
+++ b/libexamples/mmgs/adaptation_example0_fortran/example0_b/main.F90
@@ -55,9 +55,9 @@ PROGRAM main
   mmgMesh = 0
   mmgSol  = 0
 
-  CALL MMGS_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMGS_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMGS_loadMesh function that will read a .mesh(b)
@@ -320,7 +320,7 @@ PROGRAM main
   CLOSE(inm)
 
   !> 3) Free the MMGS5 structures
-  CALL MMGS_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMGS_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
+       MMG5_ARG_end/))
 END PROGRAM main

--- a/libexamples/mmgs/adaptation_example0_fortran/example0_b/main.F90
+++ b/libexamples/mmgs/adaptation_example0_fortran/example0_b/main.F90
@@ -57,7 +57,8 @@ PROGRAM main
 
   CALL MMGS_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(100)
 
   !> 2) Build mesh in MMG5 format
   !! Two solutions: just use the MMGS_loadMesh function that will read a .mesh(b)
@@ -322,5 +323,7 @@ PROGRAM main
   !> 3) Free the MMGS5 structures
   CALL MMGS_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(116)
+
 END PROGRAM main

--- a/libexamples/mmgs/io_multisols_example3/main.F90
+++ b/libexamples/mmgs/io_multisols_example3/main.F90
@@ -63,7 +63,8 @@ PROGRAM main
 
   CALL MMGS_Init_mesh((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgMet), &
-       MMG5_ARG_end/));
+       MMG5_ARG_end/),ier);
+  IF ( ier == 0 ) CALL EXIT(101)
 
 
   !!> 2) Build initial mesh and solutions in MMG5 format
@@ -155,6 +156,7 @@ PROGRAM main
   CALL MMGS_Free_all((/MMG5_ARG_start, &
        MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppSols,LOC(tmpSol), &
        MMG5_ARG_ppSols,LOC(mmgSol), &
-       MMG5_ARG_end/))
+       MMG5_ARG_end/),ier)
+  IF ( ier == 0 ) CALL EXIT(112)
 
 END PROGRAM main

--- a/libexamples/mmgs/io_multisols_example3/main.F90
+++ b/libexamples/mmgs/io_multisols_example3/main.F90
@@ -61,9 +61,9 @@ PROGRAM main
   mmgMet  = 0
   tmpSol  = 0
 
-  CALL MMGS_Init_mesh(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppMet,mmgMet, &
-       MMG5_ARG_end);
+  CALL MMGS_Init_mesh((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgMet), &
+       MMG5_ARG_end/));
 
 
   !!> 2) Build initial mesh and solutions in MMG5 format
@@ -152,9 +152,9 @@ PROGRAM main
   IF ( ier /= 1 ) CALL EXIT(111)
 
   !!> 3) Free the MMGS structures
-  CALL MMGS_Free_all(MMG5_ARG_start, &
-       MMG5_ARG_ppMesh,mmgMesh,MMG5_ARG_ppSols,tmpSol, &
-       MMG5_ARG_ppSols,mmgSol, &
-       MMG5_ARG_end)
+  CALL MMGS_Free_all((/MMG5_ARG_start, &
+       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppSols,LOC(tmpSol), &
+       MMG5_ARG_ppSols,LOC(mmgSol), &
+       MMG5_ARG_end/))
 
 END PROGRAM main

--- a/scripts/genfort.pl
+++ b/scripts/genfort.pl
@@ -47,7 +47,6 @@ my $fichier;
 #my $format = "MMG_INTEGER, PARAMETER :: %-30s = %d";
 my $format = "#define %-30s %d";
 my $formatbyval = "#define %-30s \%val(%d)";
-my $definebyval = "#define MMG5_ARG_%-30s \%val(%d)\n";
 my %opts;
 
 ###############################################################################
@@ -131,6 +130,7 @@ sub Convert {
     my $tabcount = 0;
     my $interfaceprinted = 0;
     my $modulename;
+    my $definebyval = "#define MMG5_ARG_%-30s %d_$int\n";
 
     open (APIc, $fichier);
 

--- a/scripts/genheader.c
+++ b/scripts/genheader.c
@@ -108,7 +108,7 @@ int main (int argc, char ** argv)
                                     strlen(libmmg_h)+
                                     strlen(header_f)+128)*sizeof(char))))
     return EXIT_FAILURE;
-  sprintf(cmd, "perl %s -f %s >> %s;",
+  sprintf(cmd, "perl %s -f %s -i 8 >> %s;",
           genfort, libmmg_h, header_f);
   fprintf(stdout, "%s\n", cmd);
   if (-1 == system(cmd))

--- a/scripts/genheader.c
+++ b/scripts/genheader.c
@@ -108,8 +108,8 @@ int main (int argc, char ** argv)
                                     strlen(libmmg_h)+
                                     strlen(header_f)+128)*sizeof(char))))
     return EXIT_FAILURE;
-  sprintf(cmd, "perl %s -f %s -i 8 >> %s;",
-          genfort, libmmg_h, header_f);
+  sprintf(cmd, "perl %s -f %s -i %d >> %s;",
+          genfort, libmmg_h, (int)sizeof(void*), header_f);
   fprintf(stdout, "%s\n", cmd);
   if (-1 == system(cmd))
     return EXIT_FAILURE;

--- a/src/common/anisosiz.c
+++ b/src/common/anisosiz.c
@@ -1631,7 +1631,7 @@ int MMG5_test_simred2d(MMG5_pMesh mesh,double *mex,double *nex,double *dmex,doub
 
   /* Check matrices in norm inf */
   maxerr = MMG5_test_mat_error(3,mex,mnum);
-  if( maxerr > 1.e2*MMG5_EPSOK ) {
+  if( maxerr > 1.e3*MMG5_EPSOK ) {
     fprintf(stderr,"  ## Error first matrix coreduction recomposition: in function %s, max error %e\n",
       __func__,maxerr);
     return 0;

--- a/src/common/mettools.c
+++ b/src/common/mettools.c
@@ -971,7 +971,7 @@ int MMG5_test_intersecmet22(MMG5_pMesh mesh) {
 
   /* Check error in norm inf */
   maxerr = MMG5_test_mat_error(3,intex,intnum);
-  if( maxerr > 1000.*MMG5_EPSOK ) {
+  if( maxerr > 1.e4*MMG5_EPSOK ) {
     fprintf(stderr,"  ## Error metric intersection: in function %s, line %d, max error %e\n",
       __func__,__LINE__,maxerr);
     return 0;
@@ -987,7 +987,7 @@ int MMG5_test_intersecmet22(MMG5_pMesh mesh) {
 
     /* Check error in norm inf */
     maxerr = MMG5_test_mat_error(3,intex,intnum);
-    if( maxerr > 1.e5*MMG5_EPSOK ) {
+    if( maxerr > 1.e6*MMG5_EPSOK ) {
       fprintf(stderr,"  ## Error metric re-intersection: in function %s, line %d, iteration %d, max error %e\n",
         __func__,__LINE__,it,maxerr);
       return 0;
@@ -1000,7 +1000,7 @@ int MMG5_test_intersecmet22(MMG5_pMesh mesh) {
 
     /* Check error in norm inf */
     maxerr = MMG5_test_mat_error(3,intex,intnum);
-    if( maxerr > 1.e5*MMG5_EPSOK ) {
+    if( maxerr > 1.e6*MMG5_EPSOK ) {
       fprintf(stderr,"  ## Error metric re-intersection: in function %s, line %d, iteration %d, max error %e\n",
         __func__,__LINE__,it,maxerr);
       return 0;
@@ -1013,7 +1013,7 @@ int MMG5_test_intersecmet22(MMG5_pMesh mesh) {
 
     /* Check error in norm inf */
     maxerr = MMG5_test_mat_error(3,intex,intnum);
-    if( maxerr > 1.e5*MMG5_EPSOK ) {
+    if( maxerr > 1.e6*MMG5_EPSOK ) {
       fprintf(stderr,"  ## Error metric re-intersection: in function %s, line %d, iteration %d, max error %e\n",
         __func__,__LINE__,it,maxerr);
       return 0;
@@ -1026,7 +1026,7 @@ int MMG5_test_intersecmet22(MMG5_pMesh mesh) {
 
     /* Check error in norm inf */
     maxerr = MMG5_test_mat_error(3,intex,intnum);
-    if( maxerr > 1.e5*MMG5_EPSOK ) {
+    if( maxerr > 1.e6*MMG5_EPSOK ) {
       fprintf(stderr,"  ## Error metric re-intersection: in function %s, line %d, iteration %d, max error %e\n",
         __func__,__LINE__,it,maxerr);
       return 0;

--- a/src/common/mmgcommon_private.h
+++ b/src/common/mmgcommon_private.h
@@ -558,29 +558,6 @@ void MMG5_excfun(int sigid) {
   { nu pc; }                                    \
   void nu pl
 
-/**
- * \def FORTRAN_VARIADIC(nu,nl,pl,body)
- * \brief Adds function definitions.
- * \param nu function name in upper case.
- * \param nl function name in lower case.
- * \param pl type of arguments.
- * \param body body of the function.
- *
- * Adds function definitions with upcase, underscore and double
- * underscore to match any fortran compiler.
- *
- */
-#define FORTRAN_VARIADIC(nu,nl,pl,body)           \
-  void nu pl                                      \
-  { body }                                        \
-  void nl pl                                      \
-  { body }                                        \
-  void nl##_ pl                                   \
-  { body }                                        \
-  void nl##__ pl                                  \
-  { body }                                        \
-
-
 /* Global variables */
   static const uint8_t MMG5_inxt2[6] = {1,2,0,1,2}; /*!< next vertex of triangle: {1,2,0} */
   static const uint8_t MMG5_iprv2[3] = {2,0,1}; /*!< previous vertex of triangle: {2,0,1} */

--- a/src/common/tools.c
+++ b/src/common/tools.c
@@ -446,7 +446,7 @@ inline int MMG5_test_rmtr() {
 
   /* Check error in norm inf */
   maxerr = MMG5_test_mat_error(6,outex,outnum);
-  if( maxerr > 10.*MMG5_EPSOK ) {
+  if( maxerr > 1.E2*MMG5_EPSOK ) {
     fprintf(stderr,"  ## Error linear transformation of symmetric matrix: in function %s, max error %e\n",
       __func__,maxerr);
     return 0;

--- a/src/mmg2d/API_functionsf_2d.c
+++ b/src/mmg2d/API_functionsf_2d.c
@@ -44,7 +44,7 @@
 /**
  * See \ref MMG2D_Init_mesh function in mmg2d/libmmg2d.h file.
  */
-FORTRAN_NAME(MMG2D_INIT_MESH_F, mmg2d_init_mesh_f,(void **arglist),
+FORTRAN_NAME(MMG2D_INIT_MESH, mmg2d_init_mesh,(void **arglist),
              (arglist)) {
   MMG2D_Init_mesh_fortran_var(arglist);
   return;
@@ -722,30 +722,10 @@ FORTRAN_NAME(MMG2D_FREE_ALLSOLS,mmg2d_free_allsols,
   return;
 }
 
-
-/**
- * See \ref MMG2D_Free_all function in \ref mmg2d/libmmg2d.h file.
- */
-FORTRAN_VARIADIC(MMG2D_FREE_ALL,mmg2d_free_all,
-                 (const int starter,...),
-                 va_list argptr;
-                 int     ier;
-
-                 va_start(argptr, starter);
-
-                 ier = MMG2D_Free_all_var(argptr);
-
-                 va_end(argptr);
-
-                 if ( !ier ) exit(EXIT_FAILURE);
-
-                 return;
-  )
-
 /**
  * See \ref MMG2D_Init_mesh function in mmg2d/libmmg2d.h file.
  */
-FORTRAN_NAME(MMG2D_FREE_ALL_F, mmg2d_free_all_f,(void **arglist),
+FORTRAN_NAME(MMG2D_FREE_ALL, mmg2d_free_all,(void **arglist),
              (arglist)) {
   MMG2D_Free_all_fortran_var(arglist);
   return;

--- a/src/mmg2d/API_functionsf_2d.c
+++ b/src/mmg2d/API_functionsf_2d.c
@@ -44,9 +44,9 @@
 /**
  * See \ref MMG2D_Init_mesh function in mmg2d/libmmg2d.h file.
  */
-FORTRAN_NAME(MMG2D_INIT_MESH, mmg2d_init_mesh,(void **arglist),
-             (arglist)) {
-  MMG2D_Init_mesh_fortran_var(arglist);
+FORTRAN_NAME(MMG2D_INIT_MESH, mmg2d_init_mesh,(void **arglist, int* retval),
+             (arglist, retval)) {
+  *retval = MMG2D_Init_mesh_fortran_var(arglist);
   return;
 }
 
@@ -725,9 +725,9 @@ FORTRAN_NAME(MMG2D_FREE_ALLSOLS,mmg2d_free_allsols,
 /**
  * See \ref MMG2D_Init_mesh function in mmg2d/libmmg2d.h file.
  */
-FORTRAN_NAME(MMG2D_FREE_ALL, mmg2d_free_all,(void **arglist),
-             (arglist)) {
-  MMG2D_Free_all_fortran_var(arglist);
+FORTRAN_NAME(MMG2D_FREE_ALL, mmg2d_free_all,(void **arglist, int* retval),
+             (arglist,retval)) {
+  *retval = MMG2D_Free_all_fortran_var(arglist);
   return;
 }
 

--- a/src/mmg2d/API_functionsf_2d.c
+++ b/src/mmg2d/API_functionsf_2d.c
@@ -734,18 +734,18 @@ FORTRAN_NAME(MMG2D_FREE_ALL, mmg2d_free_all,(void **arglist, int* retval),
 /**
  * See \ref MMG2D_Free_structures function in \ref mmg2d/libmmg2d.h file.
  */
-FORTRAN_NAME(MMG2D_FREE_STRUCTURES, mmg2d_free_structures,(void **arglist),
-             (arglist)) {
-  MMG2D_Free_structures_fortran_var(arglist);
+FORTRAN_NAME(MMG2D_FREE_STRUCTURES, mmg2d_free_structures,(void **arglist, int* retval),
+             (arglist,retval)) {
+  *retval = MMG2D_Free_structures_fortran_var(arglist);
   return;
 }
 
 /**
  * See \ref MMG2D_Free_names function in \ref mmg2d/libmmg2d.h file.
  */
-FORTRAN_NAME(MMG2D_FREE_NAMES, mmg2d_free_names,(void **arglist),
-             (arglist)) {
-  MMG2D_Free_names_fortran_var(arglist);
+FORTRAN_NAME(MMG2D_FREE_NAMES, mmg2d_free_names,(void **arglist, int* retval),
+             (arglist,retval)) {
+  *retval = MMG2D_Free_names_fortran_var(arglist);
   return;
 }
 

--- a/src/mmg2d/API_functionsf_2d.c
+++ b/src/mmg2d/API_functionsf_2d.c
@@ -743,6 +743,15 @@ FORTRAN_VARIADIC(MMG2D_FREE_ALL,mmg2d_free_all,
   )
 
 /**
+ * See \ref MMG2D_Init_mesh function in mmg2d/libmmg2d.h file.
+ */
+FORTRAN_NAME(MMG2D_FREE_ALL_F, mmg2d_free_all_f,(void **arglist),
+             (arglist)) {
+  MMG2D_Free_all_fortran_var(arglist);
+  return;
+}
+
+/**
  * See \ref MMG2D_Free_structures function in \ref mmg2d/libmmg2d.h file.
  */
 FORTRAN_VARIADIC(MMG2D_FREE_STRUCTURES,mmg2d_free_structures,

--- a/src/mmg2d/API_functionsf_2d.c
+++ b/src/mmg2d/API_functionsf_2d.c
@@ -734,40 +734,20 @@ FORTRAN_NAME(MMG2D_FREE_ALL, mmg2d_free_all,(void **arglist),
 /**
  * See \ref MMG2D_Free_structures function in \ref mmg2d/libmmg2d.h file.
  */
-FORTRAN_VARIADIC(MMG2D_FREE_STRUCTURES,mmg2d_free_structures,
-                 (const int starter,...),
-                 va_list argptr;
-                 int     ier;
-
-                 va_start(argptr, starter);
-
-                 ier = MMG2D_Free_structures_var(argptr);
-
-                 va_end(argptr);
-
-                 if ( !ier ) exit(EXIT_FAILURE);
-
-                 return;
-  )
+FORTRAN_NAME(MMG2D_FREE_STRUCTURES, mmg2d_free_structures,(void **arglist),
+             (arglist)) {
+  MMG2D_Free_structures_fortran_var(arglist);
+  return;
+}
 
 /**
  * See \ref MMG2D_Free_names function in \ref mmg2d/libmmg2d.h file.
  */
-FORTRAN_VARIADIC(MMG2D_FREE_NAMES,mmg2d_free_names,
-                 (const int starter,...),
-                 va_list argptr;
-                 int     ier;
-
-                 va_start(argptr, starter);
-
-                 ier = MMG2D_Free_names_var(argptr);
-
-                 va_end(argptr);
-
-                 if ( !ier ) exit(EXIT_FAILURE);
-
-                 return;
-  )
+FORTRAN_NAME(MMG2D_FREE_NAMES, mmg2d_free_names,(void **arglist),
+             (arglist)) {
+  MMG2D_Free_names_fortran_var(arglist);
+  return;
+}
 
 /**
  * See \ref MMG2D_loadMesh function in \ref mmg2d/libmmg2d.h file.

--- a/src/mmg2d/API_functionsf_2d.c
+++ b/src/mmg2d/API_functionsf_2d.c
@@ -42,23 +42,13 @@
 #include "libmmg2d_private.h"
 
 /**
- * See \ref MMG2D_Init_mesh function in common/libmmgcommon_private.h file.
+ * See \ref MMG2D_Init_mesh function in mmg2d/libmmg2d.h file.
  */
-FORTRAN_VARIADIC ( MMG2D_INIT_MESH, mmg2d_init_mesh,
-                   (const int starter, ... ),
-                   va_list argptr;
-                   int ier;
-
-                   va_start(argptr, starter);
-
-                   ier = MMG2D_Init_mesh_var(argptr);
-
-                   va_end(argptr);
-
-                   if ( !ier ) exit(EXIT_FAILURE);
-
-                   return;
-  )
+FORTRAN_NAME(MMG2D_INIT_MESH_F, mmg2d_init_mesh_f,(void **arglist),
+             (arglist)) {
+  MMG2D_Init_mesh_fortran_var(arglist);
+  return;
+}
 
 /**
  * See \ref MMG2D_Init_fileNames function in mmg2d/libmmg2d.h file.

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -177,6 +177,18 @@ extern "C" {
   LIBMMG2D_EXPORT int MMG2D_Init_mesh(const int starter,...);
 
 /**
+ * \param arglist
+ *
+ * \brief init mesh
+ *
+ * \remark Fortran interface:
+ * >   SUBROUTINE MMG2D_INIT_MESH_F(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(INOUT) :: arglist\n
+ * >   END SUBROUTINE\n
+ *
+ */
+  LIBMMG2D_EXPORT int MMG2D_Init_mesh_F(void** arglist);
+/**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure.
  *

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -1624,8 +1624,8 @@ LIBMMG2D_EXPORT int  MMG2D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  *
  * \return 0 on failure, 1 on success
  *
- * \remark we pass the structures by reference in order to have argument
- * compatibility between the library call from a Fortran code and a C code.
+ * \remark Fortran users should provide a MMG5_DATA_PTR_T array, where every pointer to 
+ * a MMG structure should be passed by reference (using Fortran LOC function).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG2D_FREE_ALL(arglist,retval)\n
@@ -1661,8 +1661,9 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \return 0 on failure, 1 on success
  *
- * \remark we pass the structures by reference in order to have argument
- * compatibility between the library call from a Fortran code and a C code.
+ * \remark Fortran users should provide a MMG5_DATA_PTR_T array, where every 
+ * pointer to a MMG structure should be passed by reference 
+ * (using Fortran LOC function).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG2D_FREE_STRUCTURES(arglist,retval)\n
@@ -1698,8 +1699,9 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  *
  * \return 0 on failure, 1 otherwise
  *
- * \remark we pass the structures by reference in order to have argument
- * compatibility between the library call from a Fortran code and a C code.
+ * \remark Fortran users should provide a MMG5_DATA_PTR_T array, where every 
+ * pointer to a MMG structure should be passed by reference 
+ * (using Fortran LOC function).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG2D_FREE_NAMES(arglist,retval)\n

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -1662,9 +1662,10 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * \remark we pass the structures by reference in order to have argument
  * compatibility between the library call from a Fortran code and a C code.
  *
- * \remark No fortran interface to allow variadic arguments.
- *
- * \remark no Fortran interface to allow variadic args.
+ * \remark Fortran interface:
+ * >   SUBROUTINE MMG2D_FREE_STRUCTURES(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >   END SUBROUTINE\n
  *
  */
  LIBMMG2D_EXPORT int MMG2D_Free_structures(const int starter,...);
@@ -1697,10 +1698,11 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * \remark we pass the structures by reference in order to have argument
  * compatibility between the library call from a Fortran code and a C code.
  *
- * \remark No fortran interface to allow variadic arguments.
- *
- * \remark no Fortran interface to allow variadic args.
- *
+ * \remark Fortran interface:
+ * >   SUBROUTINE MMG2D_FREE_NAMES(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >   END SUBROUTINE\n
+ * 
  */
   LIBMMG2D_EXPORT int MMG2D_Free_names(const int starter,...);
 

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -1665,8 +1665,9 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * compatibility between the library call from a Fortran code and a C code.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE MMG2D_FREE_STRUCTURES(arglist)\n
+ * >   SUBROUTINE MMG2D_FREE_STRUCTURES(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >     INTEGER, INTENT(OUT)                    :: retval\n
  * >   END SUBROUTINE\n
  *
  */
@@ -1701,8 +1702,9 @@ LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
  * compatibility between the library call from a Fortran code and a C code.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE MMG2D_FREE_NAMES(arglist)\n
+ * >   SUBROUTINE MMG2D_FREE_NAMES(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >     INTEGER, INTENT(OUT)                    :: retval\n
  * >   END SUBROUTINE\n
  * 
  */

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -1640,6 +1640,19 @@ LIBMMG2D_EXPORT int  MMG2D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
 LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
 
 /**
+ * \param arglist
+ *
+ * \brief init mesh
+ *
+ * \remark Fortran interface:
+ * >   SUBROUTINE MMG2D_FREE_ALL_F(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(INOUT) :: arglist\n
+ * >   END SUBROUTINE\n
+ *
+ */
+LIBMMG2D_EXPORT int MMG2D_Free_all_F(void** arglist);
+
+/**
  * \brief Structure deallocations before return.
  *
  * \param starter dummy argument used to initialize the variadic argument

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -171,23 +171,15 @@ extern "C" {
  * Here, \a your_mesh is a \ref MMG5_pMesh, \a your_metric and \a your_level_set
  * are \ref MMG5_pSol.
  *
- * \remark No fortran interface, to allow variadic arguments.
- *
+ * \remark Fortran interface:
+ * Fortran users should provide a MMG5_DATA_PTR_T array, where every pointer to 
+ * a MMG structure should be passed by reference (using Fortran LOC function).
+ * >   SUBROUTINE MMG2D_INIT_MESH(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >   END SUBROUTINE\n
  */
   LIBMMG2D_EXPORT int MMG2D_Init_mesh(const int starter,...);
 
-/**
- * \param arglist
- *
- * \brief init mesh
- *
- * \remark Fortran interface:
- * >   SUBROUTINE MMG2D_INIT_MESH_F(arglist)\n
- * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(INOUT) :: arglist\n
- * >   END SUBROUTINE\n
- *
- */
-  LIBMMG2D_EXPORT int MMG2D_Init_mesh_F(void** arglist);
 /**
  * \param mesh pointer to the mesh structure.
  * \param sol pointer to the sol structure.
@@ -1634,23 +1626,13 @@ LIBMMG2D_EXPORT int  MMG2D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * \remark we pass the structures by reference in order to have argument
  * compatibility between the library call from a Fortran code and a C code.
  *
- * \remark no Fortran interface to allow variadic args.
- *
- */
-LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
-
-/**
- * \param arglist
- *
- * \brief init mesh
- *
  * \remark Fortran interface:
- * >   SUBROUTINE MMG2D_FREE_ALL_F(arglist)\n
- * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(INOUT) :: arglist\n
+ * >   SUBROUTINE MMG2D_FREE_ALL(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
  * >   END SUBROUTINE\n
  *
  */
-LIBMMG2D_EXPORT int MMG2D_Free_all_F(void** arglist);
+LIBMMG2D_EXPORT int MMG2D_Free_all(const int starter,...);
 
 /**
  * \brief Structure deallocations before return.

--- a/src/mmg2d/libmmg2d.h
+++ b/src/mmg2d/libmmg2d.h
@@ -174,8 +174,9 @@ extern "C" {
  * \remark Fortran interface:
  * Fortran users should provide a MMG5_DATA_PTR_T array, where every pointer to 
  * a MMG structure should be passed by reference (using Fortran LOC function).
- * >   SUBROUTINE MMG2D_INIT_MESH(arglist)\n
+ * >   SUBROUTINE MMG2D_INIT_MESH(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >     INTEGER, INTENT(OUT)                    :: retval\n
  * >   END SUBROUTINE\n
  */
   LIBMMG2D_EXPORT int MMG2D_Init_mesh(const int starter,...);
@@ -1627,8 +1628,9 @@ LIBMMG2D_EXPORT int  MMG2D_Set_lsBaseReference(MMG5_pMesh mesh, MMG5_pSol sol,MM
  * compatibility between the library call from a Fortran code and a C code.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE MMG2D_FREE_ALL(arglist)\n
+ * >   SUBROUTINE MMG2D_FREE_ALL(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >     INTEGER, INTENT(OUT)                    :: retval\n
  * >   END SUBROUTINE\n
  *
  */

--- a/src/mmg2d/libmmg2d_private.h
+++ b/src/mmg2d/libmmg2d_private.h
@@ -204,7 +204,9 @@ void MMG2D_Init_mesh_fortran_var(void ** arglist);
 int  MMG2D_Free_all_var( va_list argptr );
 void MMG2D_Free_all_fortran_var(void ** arglist);
 int  MMG2D_Free_structures_var( va_list argptr );
+void  MMG2D_Free_structures_fortran_var( void ** arglist );
 int  MMG2D_Free_names_var( va_list argptr );
+void  MMG2D_Free_names_fortran_var( void ** arglist );
 
 int MMG2D_mmg2d2(MMG5_pMesh , MMG5_pSol);
 int MMG2D_mmg2d6(MMG5_pMesh ,MMG5_pSol,MMG5_pSol );

--- a/src/mmg2d/libmmg2d_private.h
+++ b/src/mmg2d/libmmg2d_private.h
@@ -200,9 +200,9 @@ int MMG2D_outqua(MMG5_pMesh ,MMG5_pSol );
 int MMG2D_mmg2d1(MMG5_pMesh ,MMG5_pSol );
 
 int  MMG2D_Init_mesh_var( va_list argptr );
-void MMG2D_Init_mesh_fortran_var(void ** arglist);
+int MMG2D_Init_mesh_fortran_var(void ** arglist);
 int  MMG2D_Free_all_var( va_list argptr );
-void MMG2D_Free_all_fortran_var(void ** arglist);
+int MMG2D_Free_all_fortran_var(void ** arglist);
 int  MMG2D_Free_structures_var( va_list argptr );
 void  MMG2D_Free_structures_fortran_var( void ** arglist );
 int  MMG2D_Free_names_var( va_list argptr );

--- a/src/mmg2d/libmmg2d_private.h
+++ b/src/mmg2d/libmmg2d_private.h
@@ -204,9 +204,9 @@ int MMG2D_Init_mesh_fortran_var(void ** arglist);
 int  MMG2D_Free_all_var( va_list argptr );
 int MMG2D_Free_all_fortran_var(void ** arglist);
 int  MMG2D_Free_structures_var( va_list argptr );
-void  MMG2D_Free_structures_fortran_var( void ** arglist );
+int  MMG2D_Free_structures_fortran_var( void ** arglist );
 int  MMG2D_Free_names_var( va_list argptr );
-void  MMG2D_Free_names_fortran_var( void ** arglist );
+int  MMG2D_Free_names_fortran_var( void ** arglist );
 
 int MMG2D_mmg2d2(MMG5_pMesh , MMG5_pSol);
 int MMG2D_mmg2d6(MMG5_pMesh ,MMG5_pSol,MMG5_pSol );

--- a/src/mmg2d/libmmg2d_private.h
+++ b/src/mmg2d/libmmg2d_private.h
@@ -200,8 +200,9 @@ int MMG2D_outqua(MMG5_pMesh ,MMG5_pSol );
 int MMG2D_mmg2d1(MMG5_pMesh ,MMG5_pSol );
 
 int  MMG2D_Init_mesh_var( va_list argptr );
-void MMG2d_Init_mesh_fortran_var(void ** arglist);
+void MMG2D_Init_mesh_fortran_var(void ** arglist);
 int  MMG2D_Free_all_var( va_list argptr );
+void MMG2D_Free_all_fortran_var(void ** arglist);
 int  MMG2D_Free_structures_var( va_list argptr );
 int  MMG2D_Free_names_var( va_list argptr );
 

--- a/src/mmg2d/libmmg2d_private.h
+++ b/src/mmg2d/libmmg2d_private.h
@@ -200,6 +200,7 @@ int MMG2D_outqua(MMG5_pMesh ,MMG5_pSol );
 int MMG2D_mmg2d1(MMG5_pMesh ,MMG5_pSol );
 
 int  MMG2D_Init_mesh_var( va_list argptr );
+void MMG2d_Init_mesh_fortran_var(void ** arglist);
 int  MMG2D_Free_all_var( va_list argptr );
 int  MMG2D_Free_structures_var( va_list argptr );
 int  MMG2D_Free_names_var( va_list argptr );

--- a/src/mmg2d/variadic_2d.c
+++ b/src/mmg2d/variadic_2d.c
@@ -254,7 +254,7 @@ int MMG2D_Init_mesh_var( va_list argptr ) {
  * Fortran users should provide a MMG5_DATA_PTR_T array, where every pointer to 
  * a MMG structure should be passed by reference (using Fortran LOC function).
  */
-void MMG2D_Init_mesh_fortran_var(void **arglist) {
+int MMG2D_Init_mesh_fortran_var(void **arglist) {
 
   MMG5_pMesh     *mesh;
   MMG5_pSol      *sol,*disp,*ls;
@@ -289,7 +289,7 @@ void MMG2D_Init_mesh_fortran_var(void **arglist) {
       fprintf(stderr," Argument type must be one of the following"
               " preprocessor variable: MMG5_ARG_ppMesh, MMG5_ARG_ppMet,"
               "  MMG5_ARG_ppLs, MMG5_ARG_ppDisp\n");
-      return;
+      return 0;
     }
     i += 2;
   }
@@ -298,18 +298,17 @@ void MMG2D_Init_mesh_fortran_var(void **arglist) {
     fprintf(stderr,"\n  ## Error: %s: MMG2D_Init_mesh:\n"
             " you need to initialize the mesh structure that"
             " will contain your mesh.\n",__func__);
-    //ier = 0;
-    return;
+    return 0;
   }
 
   /* allocations */
   if ( !MMG2D_Alloc_mesh(mesh,sol,ls,disp) ) {
-    return;
+    return 0;
   }
   
   /* initialisations */
   MMG2D_Init_woalloc_mesh(mesh,sol,ls,disp);
-  return;
+  return 1;
 }
 
 /**
@@ -452,7 +451,7 @@ int MMG2D_Free_all_var(va_list argptr)
  * a MMG structure should be passed by reference (using Fortran LOC function).
  * 
  */
-void MMG2D_Free_all_fortran_var(void **arglist)
+int MMG2D_Free_all_fortran_var(void **arglist)
 {
 
   MMG5_pMesh     *mesh;
@@ -494,7 +493,7 @@ void MMG2D_Free_all_fortran_var(void **arglist)
               " unexpected argument type: %d\n",__func__,typArg);
       fprintf(stderr," Argument type must be one of the following"
               " preprocessor variable: MMG5_ARG_ppMesh or MMG5_ARG_ppMet\n");
-      return;
+      return 0;
     }
     i+=2;
   }
@@ -503,7 +502,7 @@ void MMG2D_Free_all_fortran_var(void **arglist)
     fprintf(stderr,"\n  ## Error: %s: MMG2D_Free_all:\n"
             " you need to provide your mesh structure"
             " to allow to free the associated memory.\n",__func__);
-    return;
+    return 0;
   }
 
   if ( metCount > 1 || lsCount > 1 || dispCount > 1 || fieldsCount > 1 ) {
@@ -534,7 +533,7 @@ void MMG2D_Free_all_fortran_var(void **arglist)
 
   MMG5_SAFE_FREE(*mesh);
 
-  return;
+  return ier;
 }
 
 /**

--- a/src/mmg2d/variadic_2d.c
+++ b/src/mmg2d/variadic_2d.c
@@ -248,7 +248,7 @@ int MMG2D_Init_mesh_var( va_list argptr ) {
  * pointer to a \a MMG5_pSol structure storing the displacement (and
  * identified by the MMG5_ARG_ppDisp keyword).
  *
- * \return void
+ * \return 0 if fail, 1 otherwise
  *
  * Internal function for structure allocations.
  * Fortran users should provide a MMG5_DATA_PTR_T array, where every pointer to 
@@ -444,7 +444,7 @@ int MMG2D_Free_all_var(va_list argptr)
  * pointer to a \a MMG5_pSol structure storing the displacement (and
  * identified by the MMG5_ARG_ppDisp keyword).
  *
- * \return void
+ * \return 0 if fail, 1 if success
  *
  * Internal function for deallocations before return.
  * Fortran users should provide a MMG5_DATA_PTR_T array, where every pointer to 

--- a/src/mmg2d/variadic_2d.c
+++ b/src/mmg2d/variadic_2d.c
@@ -685,7 +685,7 @@ int MMG2D_Free_structures_var(va_list argptr)
  * a MMG structure should be passed by reference (using Fortran LOC function).
  *
  */
-void MMG2D_Free_structures_fortran_var(void **arglist)
+int MMG2D_Free_structures_fortran_var(void **arglist)
 {
 
   MMG5_pMesh     *mesh;
@@ -723,7 +723,7 @@ void MMG2D_Free_structures_fortran_var(void **arglist)
               " unexpected argument type: %d\n",__func__,typArg);
       fprintf(stderr," Argument type must be one of the following"
               " preprocessor variable: MMG5_ARG_ppMesh or MMG5_ARG_ppMet\n");
-      return;
+      return 0;
     }
     i+=2;
   }
@@ -732,7 +732,7 @@ void MMG2D_Free_structures_fortran_var(void **arglist)
     fprintf(stderr,"\n  ## Error: %s: MMG2D_Free_structures:\n"
             " you need to provide your mesh structure"
             " to allow to free the associated memory.\n",__func__);
-    return;
+    return 0;
   }
 
   if ( !MMG2D_Free_names(MMG5_ARG_start,
@@ -740,7 +740,7 @@ void MMG2D_Free_structures_fortran_var(void **arglist)
                          MMG5_ARG_ppLs, ls ,MMG5_ARG_ppDisp, disp,
                          MMG5_ARG_ppSols, sols,
                          MMG5_ARG_end) )
-    return;
+    return 0;
 
   /* mesh */
   assert(mesh && *mesh);
@@ -781,7 +781,7 @@ void MMG2D_Free_structures_fortran_var(void **arglist)
 
   MMG5_Free_structures(*mesh,NULL);
 
-  return;
+  return 1;
 }
 
 /**
@@ -912,7 +912,7 @@ int MMG2D_Free_names_var(va_list argptr)
  * a MMG structure should be passed by reference (using Fortran LOC function).
  *
  */
-void MMG2D_Free_names_fortran_var(void ** arglist)
+int MMG2D_Free_names_fortran_var(void ** arglist)
 {
 
   MMG5_pMesh     *mesh;
@@ -949,7 +949,7 @@ void MMG2D_Free_names_fortran_var(void ** arglist)
               " unexpected argument type: %d\n",__func__,typArg);
       fprintf(stderr," Argument type must be one of the following"
               " preprocessor variable: MMG5_ARG_ppMesh or MMG5_ARG_ppMet\n");
-      return;
+      return 0;
     }
     i+=2;
   }
@@ -958,7 +958,7 @@ void MMG2D_Free_names_fortran_var(void ** arglist)
     fprintf(stderr,"\n  ## Error: %s: MMG2D_Free_names:\n"
             " you need to provide your mesh structure"
             " to allow to free the associated memory.\n",__func__);
-    return;
+    return 0;
   }
 
   /* mesh & met */
@@ -1004,5 +1004,5 @@ void MMG2D_Free_names_fortran_var(void ** arglist)
     }
   }
 
-  return;
+  return 1;
 }

--- a/src/mmg2d/variadic_2d.c
+++ b/src/mmg2d/variadic_2d.c
@@ -465,7 +465,6 @@ void MMG2D_Free_all_fortran_var(void **arglist)
   disp = sol = sols = ls = NULL;
   i = 1;
 
-  //while ( (typArg = va_arg(argptr,int          )) != MMG5_ARG_end )
   while ( (typArg = (intptr_t)arglist[i]) != MMG5_ARG_end )
   {
     switch ( typArg )

--- a/src/mmg3d/API_functionsf_3d.c
+++ b/src/mmg3d/API_functionsf_3d.c
@@ -44,22 +44,11 @@
 /**
  * See \ref MMG3D_Init_mesh function in common/libmmgcommon_private.h file.
  */
-FORTRAN_VARIADIC ( MMG3D_INIT_MESH, mmg3d_init_mesh,
-                   (const int starter, ... ),
-                   va_list argptr;
-                   int     ier;
-
-                   va_start(argptr, starter);
-
-                   ier = MMG3D_Init_mesh_var(argptr);
-
-                   va_end(argptr);
-
-                   if ( !ier ) exit(EXIT_FAILURE);
-
-                   return;
-  )
-
+FORTRAN_NAME(MMG3D_INIT_MESH,mmg3d_init_mesh,(void** arglist),(arglist)) {
+  MMG3D_Init_mesh_fortran_var(arglist);
+  return;
+}
+  
 /**
  * See \ref MMG3D_Init_parameters function in \ref mmg3d/libmmg3d.h file.
  */
@@ -984,57 +973,26 @@ FORTRAN_NAME(MMG3D_FREE_ALLSOLS,mmg3d_free_allsols,
 /**
  * See \ref MMG3D_Free_all function in \ref mmg3d/libmmg3d.h file.
  */
-FORTRAN_VARIADIC(MMG3D_FREE_ALL,mmg3d_free_all,
-                 (const int starter,...),
-                 va_list argptr;
-                 int     ier;
-
-                 va_start(argptr, starter);
-
-                 ier = MMG3D_Free_all_var(argptr);
-
-                 va_end(argptr);
-
-                 if ( !ier ) exit(EXIT_FAILURE);
-                 return;
-  )
+FORTRAN_NAME(MMG3D_FREE_ALL,mmg3d_free_all,(void** arglist),(arglist)) {
+  MMG3D_Free_all_fortran_var(arglist);
+  return;
+}
 
 /**
  * See \ref MMG3D_Free_structures function in \ref mmg3d/libmmg3d.h file.
  */
-FORTRAN_VARIADIC(MMG3D_FREE_STRUCTURES,mmg3d_free_structures,
-                 (const int starter,...),
-                 va_list argptr;
-                 int     ier;
-
-                 va_start(argptr, starter);
-
-                 ier = MMG3D_Free_structures_var(argptr);
-
-                 va_end(argptr);
-
-                 if ( !ier ) exit(EXIT_FAILURE);
-
-                 return;
-  )
+FORTRAN_NAME(MMG3D_FREE_STRUCTURES,mmg3d_free_structures,(void** arglist),(arglist)) {
+  MMG3D_Free_structures_fortran_var(arglist);
+  return;
+}
 
 /**
  * See \ref MMG3D_Free_names function in \ref mmg3d/libmmg3d.h file.
  */
-FORTRAN_VARIADIC(MMG3D_FREE_NAMES,mmg3d_free_names,
-                 (const int starter,...),
-                 va_list argptr;
-                 int     ier;
-
-                 va_start(argptr, starter);
-
-                 ier = MMG3D_Free_names_var(argptr);
-
-                 va_end(argptr);
-
-                 if ( !ier ) exit(EXIT_FAILURE);
-                 return;
-  )
+FORTRAN_NAME(MMG3D_FREE_NAMES,mmg3d_free_names,(void** arglist),(arglist)) {
+  MMG3D_Free_names_fortran_var(arglist);
+  return;
+}
 
 
 /**

--- a/src/mmg3d/API_functionsf_3d.c
+++ b/src/mmg3d/API_functionsf_3d.c
@@ -44,8 +44,8 @@
 /**
  * See \ref MMG3D_Init_mesh function in common/libmmgcommon_private.h file.
  */
-FORTRAN_NAME(MMG3D_INIT_MESH,mmg3d_init_mesh,(void** arglist),(arglist)) {
-  MMG3D_Init_mesh_fortran_var(arglist);
+FORTRAN_NAME(MMG3D_INIT_MESH,mmg3d_init_mesh,(void** arglist, int* retval),(arglist,retval)) {
+  *retval = MMG3D_Init_mesh_fortran_var(arglist);
   return;
 }
   
@@ -973,24 +973,24 @@ FORTRAN_NAME(MMG3D_FREE_ALLSOLS,mmg3d_free_allsols,
 /**
  * See \ref MMG3D_Free_all function in \ref mmg3d/libmmg3d.h file.
  */
-FORTRAN_NAME(MMG3D_FREE_ALL,mmg3d_free_all,(void** arglist),(arglist)) {
-  MMG3D_Free_all_fortran_var(arglist);
+FORTRAN_NAME(MMG3D_FREE_ALL,mmg3d_free_all,(void** arglist,int* retval),(arglist, retval)) {
+  *retval = MMG3D_Free_all_fortran_var(arglist);
   return;
 }
 
 /**
  * See \ref MMG3D_Free_structures function in \ref mmg3d/libmmg3d.h file.
  */
-FORTRAN_NAME(MMG3D_FREE_STRUCTURES,mmg3d_free_structures,(void** arglist),(arglist)) {
-  MMG3D_Free_structures_fortran_var(arglist);
+FORTRAN_NAME(MMG3D_FREE_STRUCTURES,mmg3d_free_structures,(void** arglist,int* retval),(arglist,retval)) {
+  *retval = MMG3D_Free_structures_fortran_var(arglist);
   return;
 }
 
 /**
  * See \ref MMG3D_Free_names function in \ref mmg3d/libmmg3d.h file.
  */
-FORTRAN_NAME(MMG3D_FREE_NAMES,mmg3d_free_names,(void** arglist),(arglist)) {
-  MMG3D_Free_names_fortran_var(arglist);
+FORTRAN_NAME(MMG3D_FREE_NAMES,mmg3d_free_names,(void** arglist,int* retval),(arglist,retval)) {
+  *retval = MMG3D_Free_names_fortran_var(arglist);
   return;
 }
 

--- a/src/mmg3d/libmmg3d.h
+++ b/src/mmg3d/libmmg3d.h
@@ -215,6 +215,10 @@ enum MMG3D_Param {
  * types MMG5_pMesh and MMG5_pSol that will be given as arguments to Mmg
  * functions must be initialized with this function.
  *
+ * \remark Fortran users should provide a MMG5_DATA_PTR_T array, where every 
+ * pointer to a MMG structure should be passed by reference 
+ * (using Fortran LOC function).
+ * 
  * \remark Fortran interface:
  * >   SUBROUTINE MMG3D_INIT_MESH(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
@@ -2802,8 +2806,9 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  *
  * \return 1 if success, 0 if fail
  *
- * \remark we pass the structures by reference in order to have argument
- * compatibility between the library call from a Fortran code and a C code.
+ * \remark Fortran users should provide a MMG5_DATA_PTR_T array, where every 
+ * pointer to a MMG structure should be passed by reference 
+ * (using Fortran LOC function).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG3D_FREE_ALL(arglist,retval)\n
@@ -2839,8 +2844,9 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  *
  * \return 0 if fail, 1 if success
  *
- * \remark we pass the structures by reference in order to have argument
- * compatibility between the library call from a Fortran code and a C code.
+ * \remark Fortran users should provide a MMG5_DATA_PTR_T array, where every 
+ * pointer to a MMG structure should be passed by reference 
+ * (using Fortran LOC function).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG3D_FREE_STRUCTURES(arglist,retval)\n
@@ -2873,8 +2879,12 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  * : MMG3D_Init_mesh(MMG5_ARG_start,MMG5_ARG_ppMesh, &your_mesh,
  *  MMG5_ARG_ppMet,&empty_metric,MMG5_ARG_ppDisp, &your_displacement,
  * MMG5_ARG_end).
- *
+ * 
  * \return 0 if fail, 1 if success
+ * 
+ * \remark Fortran users should provide a MMG5_DATA_PTR_T array, where every 
+ * pointer to a MMG structure should be passed by reference 
+ * (using Fortran LOC function).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMG3D_FREE_NAMES(arglist,retval)\n

--- a/src/mmg3d/libmmg3d.h
+++ b/src/mmg3d/libmmg3d.h
@@ -215,7 +215,10 @@ enum MMG3D_Param {
  * types MMG5_pMesh and MMG5_pSol that will be given as arguments to Mmg
  * functions must be initialized with this function.
  *
- * \remark No fortran interface to allow variadic arguments.
+ * \remark Fortran interface:
+ * >   SUBROUTINE MMG3D_INIT_MESH(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >   END SUBROUTINE\n
  *
  * \warning detected bugs:
  *   - some vertices along open boundaries end up with a normal (while they should not)
@@ -2801,7 +2804,10 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  * \remark we pass the structures by reference in order to have argument
  * compatibility between the library call from a Fortran code and a C code.
  *
- * \remark no Fortran interface to allow variadic args.
+ * \remark Fortran interface:
+ * >   SUBROUTINE MMG3D_FREE_ALL(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >   END SUBROUTINE\n
  *
  */
   LIBMMG3D_EXPORT int MMG3D_Free_all(const int starter,...);
@@ -2834,9 +2840,10 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  * \remark we pass the structures by reference in order to have argument
  * compatibility between the library call from a Fortran code and a C code.
  *
- * \remark No fortran interface to allow variadic arguments.
- *
- * \remark no Fortran interface to allow variadic args.
+ * \remark Fortran interface:
+ * >   SUBROUTINE MMG3D_FREE_STRUCTURES(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >   END SUBROUTINE\n
  *
  */
   LIBMMG3D_EXPORT int MMG3D_Free_structures(const int starter,...);
@@ -2866,10 +2873,10 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  *
  * \return 0 if fail, 1 if success
  *
- * \remark we pass the structures by reference in order to have argument
- * compatibility between the library call from a Fortran code and a C code.
- *
- * \remark No fortran interface to allow variadic arguments.
+ * \remark Fortran interface:
+ * >   SUBROUTINE MMG3D_FREE_NAMES(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >   END SUBROUTINE\n
  *
  */
   LIBMMG3D_EXPORT int MMG3D_Free_names(const int starter,...);

--- a/src/mmg3d/libmmg3d.h
+++ b/src/mmg3d/libmmg3d.h
@@ -216,8 +216,9 @@ enum MMG3D_Param {
  * functions must be initialized with this function.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE MMG3D_INIT_MESH(arglist)\n
+ * >   SUBROUTINE MMG3D_INIT_MESH(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >     INTEGER, INTENT(OUT)                    :: retval\n
  * >   END SUBROUTINE\n
  *
  * \warning detected bugs:
@@ -2805,8 +2806,9 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  * compatibility between the library call from a Fortran code and a C code.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE MMG3D_FREE_ALL(arglist)\n
+ * >   SUBROUTINE MMG3D_FREE_ALL(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >     INTEGER, INTENT(OUT)                    :: retval\n
  * >   END SUBROUTINE\n
  *
  */
@@ -2841,8 +2843,9 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  * compatibility between the library call from a Fortran code and a C code.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE MMG3D_FREE_STRUCTURES(arglist)\n
+ * >   SUBROUTINE MMG3D_FREE_STRUCTURES(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >     INTEGER, INTENT(OUT)                    :: retval\n
  * >   END SUBROUTINE\n
  *
  */
@@ -2874,8 +2877,9 @@ LIBMMG3D_EXPORT int MMG3D_loadVtuMesh_and_allData(MMG5_pMesh mesh,MMG5_pSol *sol
  * \return 0 if fail, 1 if success
  *
  * \remark Fortran interface:
- * >   SUBROUTINE MMG3D_FREE_NAMES(arglist)\n
+ * >   SUBROUTINE MMG3D_FREE_NAMES(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >     INTEGER, INTENT(OUT)                    :: retval\n
  * >   END SUBROUTINE\n
  *
  */

--- a/src/mmg3d/libmmg3d_private.h
+++ b/src/mmg3d/libmmg3d_private.h
@@ -220,13 +220,13 @@ int  MMG3D_tetraQual(MMG5_pMesh mesh, MMG5_pSol met,int8_t metRidTyp);
 extern int MMG5_directsurfball(MMG5_pMesh mesh, MMG5_int ip, MMG5_int *list, int ilist, double n[3]);
 
 int  MMG3D_Init_mesh_var( va_list argptr );
-void MMG3D_Init_mesh_fortran_var(void ** arglist);
+int  MMG3D_Init_mesh_fortran_var(void ** arglist);
 int  MMG3D_Free_all_var( va_list argptr );
-void MMG3D_Free_all_fortran_var(void ** arglist);
+int  MMG3D_Free_all_fortran_var(void ** arglist);
 int  MMG3D_Free_structures_var( va_list argptr );
-void MMG3D_Free_structures_fortran_var(void ** arglist);
+int  MMG3D_Free_structures_fortran_var(void ** arglist);
 int  MMG3D_Free_names_var( va_list argptr );
-void MMG3D_Free_names_fortran_var(void ** arglist);
+int  MMG3D_Free_names_fortran_var(void ** arglist);
 void MMG3D_Free_arrays(MMG5_pMesh*,MMG5_pSol*,MMG5_pSol*,MMG5_pSol*,MMG5_pSol*);
 MMG5_int  MMG3D_newPt(MMG5_pMesh mesh,double c[3],uint16_t tag,MMG5_int src);
 MMG5_int  MMG3D_newElt(MMG5_pMesh mesh);

--- a/src/mmg3d/libmmg3d_private.h
+++ b/src/mmg3d/libmmg3d_private.h
@@ -220,9 +220,13 @@ int  MMG3D_tetraQual(MMG5_pMesh mesh, MMG5_pSol met,int8_t metRidTyp);
 extern int MMG5_directsurfball(MMG5_pMesh mesh, MMG5_int ip, MMG5_int *list, int ilist, double n[3]);
 
 int  MMG3D_Init_mesh_var( va_list argptr );
+void MMG3D_Init_mesh_fortran_var(void ** arglist);
 int  MMG3D_Free_all_var( va_list argptr );
+void MMG3D_Free_all_fortran_var(void ** arglist);
 int  MMG3D_Free_structures_var( va_list argptr );
+void MMG3D_Free_structures_fortran_var(void ** arglist);
 int  MMG3D_Free_names_var( va_list argptr );
+void MMG3D_Free_names_fortran_var(void ** arglist);
 void MMG3D_Free_arrays(MMG5_pMesh*,MMG5_pSol*,MMG5_pSol*,MMG5_pSol*,MMG5_pSol*);
 MMG5_int  MMG3D_newPt(MMG5_pMesh mesh,double c[3],uint16_t tag,MMG5_int src);
 MMG5_int  MMG3D_newElt(MMG5_pMesh mesh);

--- a/src/mmg3d/variadic_3d.c
+++ b/src/mmg3d/variadic_3d.c
@@ -468,6 +468,7 @@ void MMG3D_Free_all_fortran_var(void** arglist)
   meshCount = metCount = lsCount = dispCount = fieldsCount = 0;
   mesh = NULL;
   disp = sol = sols = ls = NULL;
+  i = 1;
 
   while ( (typArg = (intptr_t)arglist[i]) != MMG5_ARG_end )
   {

--- a/src/mmg3d/variadic_3d.c
+++ b/src/mmg3d/variadic_3d.c
@@ -303,7 +303,7 @@ int MMG3D_Init_mesh_fortran_var( void** arglist ) {
   }
 
   /* allocations */
-  if ( !MMG3D_Alloc_mesh(mesh,sol,ls,disp) ) return;
+  if ( !MMG3D_Alloc_mesh(mesh,sol,ls,disp) ) return 0;
 
   /* initialisations */
   MMG3D_Init_woalloc_mesh(*mesh,sol,ls,disp);

--- a/src/mmg3d/variadic_3d.c
+++ b/src/mmg3d/variadic_3d.c
@@ -255,7 +255,7 @@ int MMG3D_Init_mesh_var( va_list argptr ) {
  * Internal function for structure allocations (taking a va_list argument).
  *
  */
-void MMG3D_Init_mesh_fortran_var( void** arglist ) {
+int MMG3D_Init_mesh_fortran_var( void** arglist ) {
   MMG5_pMesh     *mesh;
   MMG5_pSol      *sol,*disp,*ls;
   int            typArg, i;
@@ -290,7 +290,7 @@ void MMG3D_Init_mesh_fortran_var( void** arglist ) {
               " of the MMG5_ARG* preprocessor variable:"
               " MMG5_ARG_ppMesh, MMG5_ARG_ppMet,"
               "  MMG5_ARG_ppLs, MMG5_ARG_ppDisp\n");
-      return;
+      return 0;
     }
     i+=2;
   }
@@ -299,7 +299,7 @@ void MMG3D_Init_mesh_fortran_var( void** arglist ) {
     fprintf(stderr,"\n  ## Error: %s: MMG3D_Init_mesh:\n"
             " you need to initialize the mesh structure that"
             " will contain your mesh.\n",__func__);
-    return;
+    return 0;
   }
 
   /* allocations */
@@ -308,7 +308,7 @@ void MMG3D_Init_mesh_fortran_var( void** arglist ) {
   /* initialisations */
   MMG3D_Init_woalloc_mesh(*mesh,sol,ls,disp);
 
-  return;
+  return 1;
 }
 
 /**
@@ -457,7 +457,7 @@ int MMG3D_Free_all_var(va_list argptr)
  * argument).
  *
  */
-void MMG3D_Free_all_fortran_var(void** arglist)
+int MMG3D_Free_all_fortran_var(void** arglist)
 {
 
   MMG5_pMesh     *mesh;
@@ -501,7 +501,7 @@ void MMG3D_Free_all_fortran_var(void** arglist)
               " variable:"
               " MMG5_ARG_ppMesh, MMG5_ARG_ppMet,"
               " MMG5_ARG_ppLs, MMG5_ARG_ppDisp\n");
-      return;
+      return 0;
     }
     i+=2;
   }
@@ -510,7 +510,7 @@ void MMG3D_Free_all_fortran_var(void** arglist)
     fprintf(stderr,"\n  ## Error: %s: MMG3D_Free_all:\n"
             " you need to provide your mesh structure"
             " to allow to free the associated memory.\n",__func__);
-    return;
+    return 0;
   }
 
   if ( metCount > 1 || lsCount > 1 || dispCount > 1 || fieldsCount > 1 ) {
@@ -525,7 +525,7 @@ void MMG3D_Free_all_fortran_var(void** arglist)
                               MMG5_ARG_ppLs, ls,MMG5_ARG_ppDisp, disp,
                               MMG5_ARG_ppSols, sols,
                               MMG5_ARG_end) ) {
-    return;
+    return 0;
   }
 
   if ( sol ) {
@@ -546,7 +546,7 @@ void MMG3D_Free_all_fortran_var(void** arglist)
 
   MMG5_SAFE_FREE(*mesh);
 
-  return;
+  return 1;
 }
 
 /**
@@ -745,7 +745,7 @@ int MMG3D_Free_structures_var(va_list argptr)
  * compatibility between the library call from a Fortran code and a C code.
  *
  */
-void MMG3D_Free_structures_fortran_var(void** arglist)
+int MMG3D_Free_structures_fortran_var(void** arglist)
 {
 
   MMG5_pMesh     *mesh;
@@ -785,7 +785,7 @@ void MMG3D_Free_structures_fortran_var(void** arglist)
               " variable:"
               " MMG5_ARG_ppMesh, MMG5_ARG_ppMet,"
               " MMG5_ARG_ppLs, MMG5_ARG_ppDisp\n");
-      return;
+      return 0;
     }
     i+=2;
   }
@@ -794,7 +794,7 @@ void MMG3D_Free_structures_fortran_var(void** arglist)
     fprintf(stderr,"\n  ## Error: %s: MMG3D_Free_structures:\n"
             " you need to provide your mesh structure"
             " to allow to free the associated memory.\n",__func__);
-    return;
+    return 0;
   }
 
   if ( !MMG3D_Free_names(MMG5_ARG_start,
@@ -803,7 +803,7 @@ void MMG3D_Free_structures_fortran_var(void** arglist)
                          MMG5_ARG_ppDisp, disp,
                          MMG5_ARG_ppSols, sols,
                          MMG5_ARG_end) ) {
-    return;
+    return 0;
   }
 
   /* mesh */
@@ -812,7 +812,7 @@ void MMG3D_Free_structures_fortran_var(void** arglist)
 
   MMG3D_Free_arrays(mesh,sol,ls,disp,sols);
 
-  return;
+  return 1;
 }
 
 /**
@@ -968,7 +968,7 @@ int MMG3D_Free_names_var(va_list argptr)
  * compatibility between the library call from a Fortran code and a C code.
  *
  */
-void MMG3D_Free_names_fortran_var(void** arglist)
+int MMG3D_Free_names_fortran_var(void** arglist)
 {
 
   MMG5_pMesh     *mesh;
@@ -1007,7 +1007,7 @@ void MMG3D_Free_names_fortran_var(void** arglist)
               " variable:"
               " MMG5_ARG_ppMesh, MMG5_ARG_ppMet,"
               " MMG5_ARG_ppLs, MMG5_ARG_ppDisp\n");
-      return;
+      return 0;
     }
     i+=2;
   }
@@ -1016,7 +1016,7 @@ void MMG3D_Free_names_fortran_var(void** arglist)
     fprintf(stderr,"\n  ## Error: %s: MMG3D_Free_names:\n"
             " you need to provide your mesh structure"
             " to allow to free the associated memory.\n",__func__);
-    return;
+    return 0;
   }
 
   /* mesh & met */
@@ -1060,5 +1060,5 @@ void MMG3D_Free_names_fortran_var(void** arglist)
     }
   }
 
-  return;
+  return 1;
 }

--- a/src/mmg3d/variadic_3d.c
+++ b/src/mmg3d/variadic_3d.c
@@ -230,6 +230,88 @@ int MMG3D_Init_mesh_var( va_list argptr ) {
 }
 
 /**
+ * \param arglist list of the mmg structures that must be initialized. Each
+ * structure must follow one of the MMG5_ARG* preprocessor variable that allow
+ * to identify it.
+ *
+ * \a arglist contains at least a pointer to a \a MMG5_pMesh structure
+ * (that will contain the mesh and identified by the MMG5_ARG_ppMesh keyword)
+ *
+ *  To call the \a MMG3D_mmg3dlib function, you must also provide
+ * a pointer to a \a MMG5_pSol structure (that will contain the ouput
+ * metric (and the input one, if provided) and identified by the MMG5_ARG_ppMet
+ * keyword).
+ *
+ *  To call the \a MMG3D_mmg3dls function, you must also provide a pointer
+ * toward a \a MMG5_pSol structure (that will contain the level-set function and
+ * identified by the MMG5_ARG_ppLs keyword).
+ *
+ *  To call the \a MMG3D_mmg3dmov library, you must also provide a
+ * pointer to a \a MMG5_pSol structure storing the displacement (and
+ * identified by the MMG5_ARG_ppDisp keyword).
+ *
+ * \return 1 if success, 0 if fail
+ *
+ * Internal function for structure allocations (taking a va_list argument).
+ *
+ */
+void MMG3D_Init_mesh_fortran_var( void** arglist ) {
+  MMG5_pMesh     *mesh;
+  MMG5_pSol      *sol,*disp,*ls;
+  int            typArg, i;
+  int            meshCount;
+
+  meshCount = 0;
+  mesh = NULL;
+  disp = sol = ls = NULL;
+  i = 1;
+
+  while ( (typArg = (intptr_t)arglist[i]) != MMG5_ARG_end )
+  {
+    switch ( typArg )
+    {
+    case(MMG5_ARG_ppMesh):
+      mesh = (MMG5_pMesh*)arglist[i+1];
+      ++meshCount;
+      break;
+    case(MMG5_ARG_ppMet):
+      sol = (MMG5_pSol*)arglist[i+1];
+      break;
+    case(MMG5_ARG_ppLs):
+      ls = (MMG5_pSol*)arglist[i+1];
+      break;
+    case(MMG5_ARG_ppDisp):
+      disp = (MMG5_pSol*)arglist[i+1];
+      break;
+    default:
+      fprintf(stderr,"\n  ## Error: %s: MMG3D_Init_mesh:\n"
+              " unexpected argument type: %d\n",__func__,typArg);
+      fprintf(stderr," Argument type must be one"
+              " of the MMG5_ARG* preprocessor variable:"
+              " MMG5_ARG_ppMesh, MMG5_ARG_ppMet,"
+              "  MMG5_ARG_ppLs, MMG5_ARG_ppDisp\n");
+      return;
+    }
+    i+=2;
+  }
+
+  if ( meshCount !=1 ) {
+    fprintf(stderr,"\n  ## Error: %s: MMG3D_Init_mesh:\n"
+            " you need to initialize the mesh structure that"
+            " will contain your mesh.\n",__func__);
+    return;
+  }
+
+  /* allocations */
+  if ( !MMG3D_Alloc_mesh(mesh,sol,ls,disp) ) return;
+
+  /* initialisations */
+  MMG3D_Init_woalloc_mesh(*mesh,sol,ls,disp);
+
+  return;
+}
+
+/**
  * \param argptr list of the mmg structures that must be deallocated. Each
  * structure must follow one of the MMG5_ARG* preprocessor variable that allow
  * to identify it.
@@ -346,6 +428,124 @@ int MMG3D_Free_all_var(va_list argptr)
   MMG5_SAFE_FREE(*mesh);
 
   return 1;
+}
+
+/**
+ * \param arglist list of the mmg structures that must be deallocated. Each
+ * structure must follow one of the MMG5_ARG* preprocessor variable that allow
+ * to identify it.
+ *
+ * \a arglist contains at least a pointer to a \a MMG5_pMesh structure
+ * (that will contain the mesh and identified by the MMG5_ARG_ppMesh keyword)
+ *
+ *  To call the \a MMG3D_mmg3dlib function, you must also provide
+ * a pointer to a \a MMG5_pSol structure (that will contain the ouput
+ * metric (and the input one, if provided) and identified by the MMG5_ARG_ppMet
+ * keyword).
+ *
+ *  To call the \a MMG3D_mmg3dls function, you must also provide a pointer
+ * toward a \a MMG5_pSol structure (that will contain the level-set function and
+ * identified by the MMG5_ARG_ppLs keyword).
+ *
+ *  To call the \a MMG3D_mmg3dmov library, you must also provide a
+ * pointer to a \a MMG5_pSol structure storing the displacement (and
+ * identified by the MMG5_ARG_ppDisp keyword).
+ *
+ * \return 0 if fail, 1 if success
+ *
+ * Internal function for deallocations before return (taking a va_list as
+ * argument).
+ *
+ */
+void MMG3D_Free_all_fortran_var(void** arglist)
+{
+
+  MMG5_pMesh     *mesh;
+  MMG5_pSol      *sol,*disp,*sols,*ls;
+  int            typArg,i;
+  int            meshCount,metCount,lsCount,dispCount,fieldsCount;
+
+  meshCount = metCount = lsCount = dispCount = fieldsCount = 0;
+  mesh = NULL;
+  disp = sol = sols = ls = NULL;
+
+  while ( (typArg = (intptr_t)arglist[i]) != MMG5_ARG_end )
+  {
+    switch ( typArg )
+    {
+    case(MMG5_ARG_ppMesh):
+      mesh = (MMG5_pMesh*)arglist[i+1];
+      ++meshCount;
+      break;
+    case(MMG5_ARG_ppMet):
+      ++metCount;
+      sol = (MMG5_pSol*)arglist[i+1];
+      break;
+   case(MMG5_ARG_ppLs):
+     ++lsCount;
+      ls = (MMG5_pSol*)arglist[i+1];
+      break;
+    case(MMG5_ARG_ppDisp):
+      ++dispCount;
+      disp = (MMG5_pSol*)arglist[i+1];
+      break;
+    case(MMG5_ARG_ppSols):
+      ++fieldsCount;
+      sols = (MMG5_pSol*)arglist[i+1];
+      break;
+    default:
+      fprintf(stderr,"\n  ## Error: %s: MMG3D_Free_all:\n"
+              " unexpected argument type: %d\n",__func__,typArg);
+      fprintf(stderr," Argument type must be one of the following preprocessor"
+              " variable:"
+              " MMG5_ARG_ppMesh, MMG5_ARG_ppMet,"
+              " MMG5_ARG_ppLs, MMG5_ARG_ppDisp\n");
+      return;
+    }
+    i+=2;
+  }
+
+  if ( meshCount !=1 ) {
+    fprintf(stderr,"\n  ## Error: %s: MMG3D_Free_all:\n"
+            " you need to provide your mesh structure"
+            " to allow to free the associated memory.\n",__func__);
+    return;
+  }
+
+  if ( metCount > 1 || lsCount > 1 || dispCount > 1 || fieldsCount > 1 ) {
+    fprintf(stdout,"\n  ## Warning: %s: MMG3D_Free_all:\n"
+            " This function can free only one structure of each type.\n"
+            " Probable memory leak.\n",
+            __func__);
+  }
+
+  if ( !MMG3D_Free_structures(MMG5_ARG_start,
+                              MMG5_ARG_ppMesh, mesh, MMG5_ARG_ppMet, sol,
+                              MMG5_ARG_ppLs, ls,MMG5_ARG_ppDisp, disp,
+                              MMG5_ARG_ppSols, sols,
+                              MMG5_ARG_end) ) {
+    return;
+  }
+
+  if ( sol ) {
+    MMG5_SAFE_FREE(*sol);
+  }
+
+  if ( disp ) {
+    MMG5_SAFE_FREE(*disp);
+  }
+
+  if ( ls ) {
+    MMG5_SAFE_FREE(*ls);
+  }
+
+  if ( sols ) {
+    MMG5_DEL_MEM(*mesh,*sols);
+  }
+
+  MMG5_SAFE_FREE(*mesh);
+
+  return;
 }
 
 /**
@@ -515,6 +715,106 @@ int MMG3D_Free_structures_var(va_list argptr)
 }
 
 /**
+ * \param argptr list of the mmg structures that must be deallocated. Each
+ * structure must follow one of the MMG5_ARG* preprocessor variable that allow
+ * to identify it.
+ *
+ * \a argptr contains at least a pointer to a \a MMG5_pMesh structure
+ * (that will contain the mesh and identified by the MMG5_ARG_ppMesh keyword)
+ *
+ *  To call the \a MMG3D_mmg3dlib function, you must also provide
+ * a pointer to a \a MMG5_pSol structure (that will contain the ouput
+ * metric (and the input one, if provided) and identified by the MMG5_ARG_ppMet
+ * keyword).
+ *
+ *  To call the \a MMG3D_mmg3dls function, you must also provide a pointer
+ * toward a \a MMG5_pSol structure (that will contain the level-set function and
+ * identified by the MMG5_ARG_ppLs keyword).
+ *
+ *  To call the \a MMG3D_mmg3dmov library, you must also provide a
+ * pointer to a \a MMG5_pSol structure storing the displacement (and
+ * identified by the MMG5_ARG_ppDisp keyword).
+ *
+ * \return 0 if fail, 1 if success
+ *
+ * Internal function for structures deallocations before return (taking a
+ * va_list as argument).
+ *
+ * \remark we pass the structures by reference in order to have argument
+ * compatibility between the library call from a Fortran code and a C code.
+ *
+ */
+void MMG3D_Free_structures_fortran_var(void** arglist)
+{
+
+  MMG5_pMesh     *mesh;
+  MMG5_pSol      *sol,*ls,*disp,*sols;
+  int            typArg,i;
+  int            meshCount;
+
+  meshCount = 0;
+  mesh = NULL;
+  disp = sol = ls = sols = NULL;
+  i = 1;
+
+  while ( (typArg = (intptr_t)arglist[i]) != MMG5_ARG_end )
+  {
+    switch ( typArg )
+    {
+    case(MMG5_ARG_ppMesh):
+      mesh = (MMG5_pMesh*)arglist[i+1];
+      ++meshCount;
+      break;
+    case(MMG5_ARG_ppMet):
+      sol = (MMG5_pSol*)arglist[i+1];
+      break;
+    case(MMG5_ARG_ppLs):
+      ls = (MMG5_pSol*)arglist[i+1];
+      break;
+    case(MMG5_ARG_ppDisp):
+      disp = (MMG5_pSol*)arglist[i+1];
+      break;
+    case(MMG5_ARG_ppSols):
+      sols = (MMG5_pSol*)arglist[i+1];
+      break;
+    default:
+      fprintf(stderr,"\n  ## Error: %s: MMG3D_Free_structures:\n"
+              " unexpected argument type: %d\n",__func__,typArg);
+      fprintf(stderr," Argument type must be one of the following preprocessor"
+              " variable:"
+              " MMG5_ARG_ppMesh, MMG5_ARG_ppMet,"
+              " MMG5_ARG_ppLs, MMG5_ARG_ppDisp\n");
+      return;
+    }
+    i+=2;
+  }
+
+  if ( meshCount !=1 ) {
+    fprintf(stderr,"\n  ## Error: %s: MMG3D_Free_structures:\n"
+            " you need to provide your mesh structure"
+            " to allow to free the associated memory.\n",__func__);
+    return;
+  }
+
+  if ( !MMG3D_Free_names(MMG5_ARG_start,
+                         MMG5_ARG_ppMesh, mesh, MMG5_ARG_ppMet, sol,
+                         MMG5_ARG_ppLs, ls,
+                         MMG5_ARG_ppDisp, disp,
+                         MMG5_ARG_ppSols, sols,
+                         MMG5_ARG_end) ) {
+    return;
+  }
+
+  /* mesh */
+  assert(mesh && *mesh);
+
+
+  MMG3D_Free_arrays(mesh,sol,ls,disp,sols);
+
+  return;
+}
+
+/**
  * \param argptr list of the mmg structures for whose we want to deallocate the
  * name. Each structure must follow one of the \a MMG5_ARG* preprocessor
  * variable that allow to identify it.
@@ -635,4 +935,129 @@ int MMG3D_Free_names_var(va_list argptr)
   }
 
   return 1;
+}
+
+/**
+ * \param argptr list of the mmg structures for whose we want to deallocate the
+ * name. Each structure must follow one of the \a MMG5_ARG* preprocessor
+ * variable that allow to identify it.
+ *
+ * \a argptr contains at least a pointer to a \a MMG5_pMesh structure
+ * (that will contain the mesh and identified by the MMG5_ARG_ppMesh keyword)
+ *
+ *  To call the \a MMG3D_mmg3dlib function, you must also provide
+ * a pointer to a \a MMG5_pSol structure (that will contain the ouput
+ * metric (and the input one, if provided) and identified by the MMG5_ARG_ppMet
+ * keyword).
+ *
+ *  To call the \a MMG3D_mmg3dls function, you must also provide a pointer
+ * toward a \a MMG5_pSol structure (that will contain the level-set function and
+ * identified by the MMG5_ARG_ppLs keyword).
+ *
+ *  To call the \a MMG3D_mmg3dmov library, you must also provide a
+ * pointer to a \a MMG5_pSol structure storing the displacement (and
+ * identified by the MMG5_ARG_ppDisp keyword).
+ *
+ * \return 0 if fail, 1 if success
+ *
+ * Internal function for name deallocations before return (taking a va_list as
+ * argument).
+ *
+ * \remark we pass the structures by reference in order to have argument
+ * compatibility between the library call from a Fortran code and a C code.
+ *
+ */
+void MMG3D_Free_names_fortran_var(void** arglist)
+{
+
+  MMG5_pMesh     *mesh;
+  MMG5_pSol      psl,*sol,*disp,*ls,*sols;
+  int            typArg,i;
+  int            meshCount;
+
+  meshCount = 0;
+  disp = sol = ls = sols = NULL;
+  i = 1;
+
+  while ( (typArg = (intptr_t)arglist[i]) != MMG5_ARG_end )
+  {
+    switch ( typArg )
+    {
+    case(MMG5_ARG_ppMesh):
+      mesh = (MMG5_pMesh*)arglist[i+1];
+      ++meshCount;
+      break;
+    case(MMG5_ARG_ppMet):
+      sol = (MMG5_pSol*)arglist[i+1];
+      break;
+    case(MMG5_ARG_ppLs):
+      ls = (MMG5_pSol*)arglist[i+1];
+      break;
+    case(MMG5_ARG_ppDisp):
+      disp = (MMG5_pSol*)arglist[i+1];
+      break;
+    case(MMG5_ARG_ppSols):
+      sols = (MMG5_pSol*)arglist[i+1];
+      break;
+    default:
+      fprintf(stderr,"\n  ## Error: %s: MMG3D_Free_names:\n"
+              " unexpected argument type: %d\n",__func__,typArg);
+      fprintf(stderr," Argument type must be one of the following preprocessor"
+              " variable:"
+              " MMG5_ARG_ppMesh, MMG5_ARG_ppMet,"
+              " MMG5_ARG_ppLs, MMG5_ARG_ppDisp\n");
+      return;
+    }
+    i+=2;
+  }
+
+  if ( meshCount !=1 ) {
+    fprintf(stderr,"\n  ## Error: %s: MMG3D_Free_names:\n"
+            " you need to provide your mesh structure"
+            " to allow to free the associated memory.\n",__func__);
+    return;
+  }
+
+  /* mesh & met */
+  if (!sol)
+    MMG5_mmgFree_names(*mesh,NULL);
+  else
+    MMG5_mmgFree_names(*mesh,*sol);
+
+  /* disp */
+  if ( disp && *disp ) {
+    if ( (*disp)->namein ) {
+      MMG5_DEL_MEM(*mesh,(*disp)->namein);
+    }
+
+    if ( (*disp)->nameout ) {
+      MMG5_DEL_MEM(*mesh,(*disp)->nameout);
+    }
+  }
+
+  /* ls */
+  if ( ls && *ls ) {
+    if ( (*ls)->namein ) {
+      MMG5_DEL_MEM(*mesh,(*ls)->namein);
+    }
+
+    if ( (*ls)->nameout ) {
+      MMG5_DEL_MEM(*mesh,(*ls)->nameout);
+    }
+  }
+
+  /* Fields */
+  if ( sols ) {
+    for ( i=0; i<(*mesh)->nsols; ++i ) {
+      psl = (*sols) + i;
+      if ( psl->namein ) {
+        MMG5_DEL_MEM(*mesh,psl->namein);
+      }
+      if ( psl->nameout ) {
+        MMG5_DEL_MEM(*mesh,psl->nameout);
+      }
+    }
+  }
+
+  return;
 }

--- a/src/mmg3d/variadic_3d.c
+++ b/src/mmg3d/variadic_3d.c
@@ -716,11 +716,11 @@ int MMG3D_Free_structures_var(va_list argptr)
 }
 
 /**
- * \param argptr list of the mmg structures that must be deallocated. Each
+ * \param arglist list of the mmg structures that must be deallocated. Each
  * structure must follow one of the MMG5_ARG* preprocessor variable that allow
  * to identify it.
  *
- * \a argptr contains at least a pointer to a \a MMG5_pMesh structure
+ * \a arglist contains at least a pointer to a \a MMG5_pMesh structure
  * (that will contain the mesh and identified by the MMG5_ARG_ppMesh keyword)
  *
  *  To call the \a MMG3D_mmg3dlib function, you must also provide
@@ -939,11 +939,11 @@ int MMG3D_Free_names_var(va_list argptr)
 }
 
 /**
- * \param argptr list of the mmg structures for whose we want to deallocate the
+ * \param arglist list of the mmg structures for whose we want to deallocate the
  * name. Each structure must follow one of the \a MMG5_ARG* preprocessor
  * variable that allow to identify it.
  *
- * \a argptr contains at least a pointer to a \a MMG5_pMesh structure
+ * \a arglist contains at least a pointer to a \a MMG5_pMesh structure
  * (that will contain the mesh and identified by the MMG5_ARG_ppMesh keyword)
  *
  *  To call the \a MMG3D_mmg3dlib function, you must also provide

--- a/src/mmgs/API_functionsf_s.c
+++ b/src/mmgs/API_functionsf_s.c
@@ -728,18 +728,18 @@ FORTRAN_NAME(MMGS_FREE_ALL, mmgs_free_all,(void **arglist, int* retval),
 /**
  * See \ref MMGS_Free_structures function in \ref mmgs/libmmgs.h file.
  */
-FORTRAN_NAME(MMGS_FREE_STRUCTURES, mmgs_free_structures,(void **arglist),
-             (arglist)) {
-  MMGS_Free_structures_fortran_var(arglist);
+FORTRAN_NAME(MMGS_FREE_STRUCTURES, mmgs_free_structures,(void **arglist, int* retval),
+             (arglist,retval)) {
+  *retval = MMGS_Free_structures_fortran_var(arglist);
   return;
 }
 
 /**
  * See \ref MMGS_Free_names function in \ref mmgs/libmmgs.h file.
  */
-FORTRAN_NAME(MMGS_FREE_NAMES, mmgs_free_names,(void **arglist),
-             (arglist)) {
-  MMGS_Free_names_fortran_var(arglist);
+FORTRAN_NAME(MMGS_FREE_NAMES, mmgs_free_names,(void **arglist, int* retval),
+             (arglist,retval)) {
+  *retval = MMGS_Free_names_fortran_var(arglist);
   return;
 }
 

--- a/src/mmgs/API_functionsf_s.c
+++ b/src/mmgs/API_functionsf_s.c
@@ -43,20 +43,11 @@
 /**
  * See \ref MMGS_Init_mesh function in common/libmmgcommon_private.h file.
  */
-FORTRAN_VARIADIC ( MMGS_INIT_MESH, mmgs_init_mesh,
-                   (const int starter, ... ),
-                   va_list argptr;
-                   int     ier;
-
-                   va_start(argptr, starter);
-
-                   ier = MMGS_Init_mesh_var(argptr);
-
-                   va_end(argptr);
-
-                   if ( !ier ) exit(EXIT_FAILURE);
-                   return;
-  )
+FORTRAN_NAME(MMGS_INIT_MESH, mmgs_init_mesh,(void **arglist),
+             (arglist)) {
+  MMGS_Init_mesh_fortran_var(arglist);
+  return;
+}
 
 /**
  * See \ref MMGS_Init_parameters function in \ref mmgs/libmmgs.h file.
@@ -728,60 +719,29 @@ FORTRAN_NAME(MMGS_FREE_ALLSOLS,mmgs_free_allsols,
 /**
  * See \ref MMGS_Free_all function in \ref mmgs/libmmgs.h file.
  */
-FORTRAN_VARIADIC(MMGS_FREE_ALL,mmgs_free_all,
-                 (const int starter,...),
-                 va_list argptr;
-
-                 int ier;
-
-                 va_start(argptr, starter);
-
-                 ier = MMGS_Free_all_var(argptr);
-
-                 va_end(argptr);
-
-                 if ( !ier ) exit(EXIT_FAILURE);
-
-                 return;
-  )
+FORTRAN_NAME(MMGS_FREE_ALL, mmgs_free_all,(void **arglist),
+             (arglist)) {
+  MMGS_Free_all_fortran_var(arglist);
+  return;
+}
 
 /**
  * See \ref MMGS_Free_structures function in \ref mmgs/libmmgs.h file.
  */
-FORTRAN_VARIADIC(MMGS_FREE_STRUCTURES,mmgs_free_structures,
-                 (const int starter,...),
-                 va_list argptr;
-                 int     ier;
-
-                 va_start(argptr, starter);
-
-                 ier = MMGS_Free_structures_var(argptr);
-
-                 va_end(argptr);
-
-                 if ( !ier ) exit(EXIT_FAILURE);
-
-                 return;
-  )
+FORTRAN_NAME(MMGS_FREE_STRUCTURES, mmgs_free_structures,(void **arglist),
+             (arglist)) {
+  MMGS_Free_structures_fortran_var(arglist);
+  return;
+}
 
 /**
  * See \ref MMGS_Free_names function in \ref mmgs/libmmgs.h file.
  */
-FORTRAN_VARIADIC(MMGS_FREE_NAMES,mmgs_free_names,
-                 (const int starter,...),
-                 va_list argptr;
-                 int     ier;
-
-                 va_start(argptr, starter);
-
-                 ier = MMGS_Free_names_var(argptr);
-
-                 va_end(argptr);
-
-                 if ( !ier  ) exit(EXIT_FAILURE);
-
-                 return;
-  )
+FORTRAN_NAME(MMGS_FREE_NAMES, mmgs_free_names,(void **arglist),
+             (arglist)) {
+  MMGS_Free_names_fortran_var(arglist);
+  return;
+}
 
 /**
  * See \ref MMGS_loadMesh function in \ref mmgs/libmmgs.h file.

--- a/src/mmgs/API_functionsf_s.c
+++ b/src/mmgs/API_functionsf_s.c
@@ -43,9 +43,9 @@
 /**
  * See \ref MMGS_Init_mesh function in common/libmmgcommon_private.h file.
  */
-FORTRAN_NAME(MMGS_INIT_MESH, mmgs_init_mesh,(void **arglist),
-             (arglist)) {
-  MMGS_Init_mesh_fortran_var(arglist);
+FORTRAN_NAME(MMGS_INIT_MESH, mmgs_init_mesh,(void **arglist, int* retval),
+             (arglist,retval)) {
+  *retval = MMGS_Init_mesh_fortran_var(arglist);
   return;
 }
 
@@ -719,9 +719,9 @@ FORTRAN_NAME(MMGS_FREE_ALLSOLS,mmgs_free_allsols,
 /**
  * See \ref MMGS_Free_all function in \ref mmgs/libmmgs.h file.
  */
-FORTRAN_NAME(MMGS_FREE_ALL, mmgs_free_all,(void **arglist),
-             (arglist)) {
-  MMGS_Free_all_fortran_var(arglist);
+FORTRAN_NAME(MMGS_FREE_ALL, mmgs_free_all,(void **arglist, int* retval),
+             (arglist,retval)) {
+  *retval = MMGS_Free_all_fortran_var(arglist);
   return;
 }
 

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -2187,8 +2187,9 @@ LIBMMGS_EXPORT int MMGS_Free_all(const int starter,...);
  * compatibility between the library call from a Fortran code and a C code.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE MMGS_FREE_STRUCTURES(arglist)\n
+ * >   SUBROUTINE MMGS_FREE_STRUCTURES(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >     INTEGER, INTENT(OUT)                    :: retval\n
  * >   END SUBROUTINE\n
  *
  */
@@ -2219,8 +2220,9 @@ LIBMMGS_EXPORT int MMGS_Free_structures(const int starter,...);
  * compatibility between the library call from a Fortran code and a C code.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE MMGS_FREE_NAMES(arglist)\n
+ * >   SUBROUTINE MMGS_FREE_NAMES(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >     INTEGER, INTENT(OUT)                    :: retval\n
  * >   END SUBROUTINE\n
  *
  */

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -166,6 +166,10 @@ enum MMGS_Param {
  *
  * \return 1 on success, 0 on failure
  *
+ * \remark Fortran users should provide a MMG5_DATA_PTR_T array, where every 
+ * pointer to a MMG structure should be passed by reference 
+ * (using Fortran LOC function).
+ * 
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_INIT_MESH(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
@@ -2150,8 +2154,9 @@ LIBMMGS_EXPORT int MMGS_Free_allSols(MMG5_pMesh mesh,MMG5_pSol *sol);
  *
  * \return 0 on failure, 1 on success
  *
- * \remark we pass the structures by reference in order to have argument
- * compatibility between the library call from a Fortran code and a C code.
+ * \remark Fortran users should provide a MMG5_DATA_PTR_T array, where every 
+ * pointer to a MMG structure should be passed by reference 
+ * (using Fortran LOC function).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_FREE_ALL(arglist,retval)\n
@@ -2183,8 +2188,9 @@ LIBMMGS_EXPORT int MMGS_Free_all(const int starter,...);
  *
  * \return 0 on failure, 1 on success
  *
- * \remark we pass the structures by reference in order to have argument
- * compatibility between the library call from a Fortran code and a C code.
+ * \remark Fortran users should provide a MMG5_DATA_PTR_T array, where every 
+ * pointer to a MMG structure should be passed by reference 
+ * (using Fortran LOC function).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_FREE_STRUCTURES(arglist,retval)\n
@@ -2216,8 +2222,9 @@ LIBMMGS_EXPORT int MMGS_Free_structures(const int starter,...);
  *
  * \return 0 on failure, 1 on success
  *
- * \remark we pass the structures by reference in order to have argument
- * compatibility between the library call from a Fortran code and a C code.
+ * \remark Fortran users should provide a MMG5_DATA_PTR_T array, where every 
+ * pointer to a MMG structure should be passed by reference 
+ * (using Fortran LOC function).
  *
  * \remark Fortran interface:
  * >   SUBROUTINE MMGS_FREE_NAMES(arglist,retval)\n

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -166,7 +166,10 @@ enum MMGS_Param {
  *
  * \return 1 on success, 0 on failure
  *
- * \remark No fortran interface, to allow variadic arguments.
+* \remark Fortran interface:
+ * >   SUBROUTINE MMGS_INIT_MESH(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >   END SUBROUTINE\n
  *
  */
 LIBMMGS_EXPORT int MMGS_Init_mesh(const int starter,...);
@@ -2149,7 +2152,10 @@ LIBMMGS_EXPORT int MMGS_Free_allSols(MMG5_pMesh mesh,MMG5_pSol *sol);
  * \remark we pass the structures by reference in order to have argument
  * compatibility between the library call from a Fortran code and a C code.
  *
- * \remark no Fortran interface to allow variadic args.
+ * \remark Fortran interface:
+ * >   SUBROUTINE MMGS_FREE_ALL(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >   END SUBROUTINE\n
  *
  */
 LIBMMGS_EXPORT int MMGS_Free_all(const int starter,...);
@@ -2178,7 +2184,10 @@ LIBMMGS_EXPORT int MMGS_Free_all(const int starter,...);
  * \remark we pass the structures by reference in order to have argument
  * compatibility between the library call from a Fortran code and a C code.
  *
- * \remark no Fortran interface to allow variadic args.
+ * \remark Fortran interface:
+ * >   SUBROUTINE MMGS_FREE_STRUCTURES(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >   END SUBROUTINE\n
  *
  */
 LIBMMGS_EXPORT int MMGS_Free_structures(const int starter,...);
@@ -2207,7 +2216,10 @@ LIBMMGS_EXPORT int MMGS_Free_structures(const int starter,...);
  * \remark we pass the structures by reference in order to have argument
  * compatibility between the library call from a Fortran code and a C code.
  *
- * \remark no Fortran interface to allow variadic args.
+ * \remark Fortran interface:
+ * >   SUBROUTINE MMGS_FREE_NAMES(arglist)\n
+ * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >   END SUBROUTINE\n
  *
  */
 LIBMMGS_EXPORT int MMGS_Free_names(const int starter,...);

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -167,8 +167,9 @@ enum MMGS_Param {
  * \return 1 on success, 0 on failure
  *
  * \remark Fortran interface:
- * >   SUBROUTINE MMGS_INIT_MESH(arglist)\n
+ * >   SUBROUTINE MMGS_INIT_MESH(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >     INTEGER, INTENT(OUT)                    :: retval\n
  * >   END SUBROUTINE\n
  *
  */
@@ -2153,8 +2154,9 @@ LIBMMGS_EXPORT int MMGS_Free_allSols(MMG5_pMesh mesh,MMG5_pSol *sol);
  * compatibility between the library call from a Fortran code and a C code.
  *
  * \remark Fortran interface:
- * >   SUBROUTINE MMGS_FREE_ALL(arglist)\n
+ * >   SUBROUTINE MMGS_FREE_ALL(arglist,retval)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
+ * >     INTEGER, INTENT(OUT)                    :: retval\n
  * >   END SUBROUTINE\n
  *
  */

--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -166,7 +166,7 @@ enum MMGS_Param {
  *
  * \return 1 on success, 0 on failure
  *
-* \remark Fortran interface:
+ * \remark Fortran interface:
  * >   SUBROUTINE MMGS_INIT_MESH(arglist)\n
  * >     MMG5_DATA_PTR_T,DIMENSION(*),INTENT(IN) :: arglist\n
  * >   END SUBROUTINE\n

--- a/src/mmgs/libmmgs_private.h
+++ b/src/mmgs/libmmgs_private.h
@@ -127,8 +127,8 @@ int  MMGS_Free_names_var( va_list argptr );
 
 int  MMGS_Init_mesh_fortran_var( void ** arglist );
 int  MMGS_Free_all_fortran_var( void ** arglist );
-void  MMGS_Free_structures_fortran_var( void ** arglist );
-void  MMGS_Free_names_fortran_var( void ** arglist );
+int  MMGS_Free_structures_fortran_var( void ** arglist );
+int  MMGS_Free_names_fortran_var( void ** arglist );
 
 int  MMGS_zaldy(MMG5_pMesh mesh);
 int  MMGS_assignEdge(MMG5_pMesh mesh);

--- a/src/mmgs/libmmgs_private.h
+++ b/src/mmgs/libmmgs_private.h
@@ -125,8 +125,8 @@ int  MMGS_Free_all_var( va_list argptr );
 int  MMGS_Free_structures_var( va_list argptr );
 int  MMGS_Free_names_var( va_list argptr );
 
-void  MMGS_Init_mesh_fortran_var( void ** arglist );
-void  MMGS_Free_all_fortran_var( void ** arglist );
+int  MMGS_Init_mesh_fortran_var( void ** arglist );
+int  MMGS_Free_all_fortran_var( void ** arglist );
 void  MMGS_Free_structures_fortran_var( void ** arglist );
 void  MMGS_Free_names_fortran_var( void ** arglist );
 

--- a/src/mmgs/libmmgs_private.h
+++ b/src/mmgs/libmmgs_private.h
@@ -125,6 +125,11 @@ int  MMGS_Free_all_var( va_list argptr );
 int  MMGS_Free_structures_var( va_list argptr );
 int  MMGS_Free_names_var( va_list argptr );
 
+void  MMGS_Init_mesh_fortran_var( void ** arglist );
+void  MMGS_Free_all_fortran_var( void ** arglist );
+void  MMGS_Free_structures_fortran_var( void ** arglist );
+void  MMGS_Free_names_fortran_var( void ** arglist );
+
 int  MMGS_zaldy(MMG5_pMesh mesh);
 int  MMGS_assignEdge(MMG5_pMesh mesh);
 int  MMGS_analys_for_norver(MMG5_pMesh mesh);

--- a/src/mmgs/variadic_s.c
+++ b/src/mmgs/variadic_s.c
@@ -592,7 +592,7 @@ int MMGS_Free_structures_var(va_list argptr)
  * compatibility between the library call from a Fortran code and a C code.
  *
  */
-void MMGS_Free_structures_fortran_var(void** arglist)
+int MMGS_Free_structures_fortran_var(void** arglist)
 {
 
   MMG5_pMesh     *mesh;
@@ -627,7 +627,7 @@ void MMGS_Free_structures_fortran_var(void** arglist)
       fprintf(stderr," Argument type must be one of the following"
               " preprocessor variable: MMG5_ARG_ppMesh, MMG5_ARG_ppMet or"
               " MMG5_ARG_ppLs.\n");
-      return;
+      return 0;
     }
     i+=2;
   }
@@ -636,7 +636,7 @@ void MMGS_Free_structures_fortran_var(void** arglist)
     fprintf(stderr,"\n  ## Error: %s: MMGS_Free_structures:\n"
             " you need to provide your mesh structure"
             " to allow to free the associated memory.\n",__func__);
-    return;
+    return 0;
   }
 
   MMGS_Free_names(MMG5_ARG_start,
@@ -666,7 +666,7 @@ void MMGS_Free_structures_fortran_var(void** arglist)
 
   MMG5_Free_structures(*mesh,NULL);
 
-  return;
+  return 1;
 }
 
 /**
@@ -804,7 +804,7 @@ int MMGS_Free_names_var(va_list argptr)
  * compatibility between the library call from a Fortran code and a C code.
  *
  */
-void MMGS_Free_names_fortran_var(void** arglist)
+int MMGS_Free_names_fortran_var(void** arglist)
 {
 
   MMG5_pMesh     *mesh;
@@ -839,7 +839,7 @@ void MMGS_Free_names_fortran_var(void** arglist)
       fprintf(stderr," Argument type must be one of the following"
               " preprocessor variable: MMG5_ARG_ppMesh, MMG5_ARG_ppMet "
               " or MMG5_ARG_ppLs\n");
-      return;
+      return 0;
     }
     i+=2;
   }
@@ -848,7 +848,7 @@ void MMGS_Free_names_fortran_var(void** arglist)
     fprintf(stderr,"\n  ## Error: %s: MMGS_Free_names:\n"
             " you need to provide your mesh structure"
             " to allow to free the associated memory.\n",__func__);
-    return;
+    return 0;
   }
 
   /* mesh & met */
@@ -883,6 +883,5 @@ void MMGS_Free_names_fortran_var(void** arglist)
     }
   }
 
-
-  return;
+  return 1;
 }

--- a/src/mmgs/variadic_s.c
+++ b/src/mmgs/variadic_s.c
@@ -841,6 +841,7 @@ void MMGS_Free_names_fortran_var(void** arglist)
               " or MMG5_ARG_ppLs\n");
       return;
     }
+    i+=2;
   }
 
   if ( meshCount !=1 ) {

--- a/src/mmgs/variadic_s.c
+++ b/src/mmgs/variadic_s.c
@@ -218,7 +218,7 @@ int MMGS_Init_mesh_var( va_list argptr ) {
  *
  *
  */
-void MMGS_Init_mesh_fortran_var( void** arglist ) {
+int MMGS_Init_mesh_fortran_var( void** arglist ) {
   MMG5_pMesh     *mesh;
   MMG5_pSol      *sol,*ls;
   int            typArg,i;
@@ -249,7 +249,7 @@ void MMGS_Init_mesh_fortran_var( void** arglist ) {
       fprintf(stderr," Argument type must be one of the following"
               " preprocessor variable: MMG5_ARG_ppMesh, MMG5_ARG_ppMet,"
               " MMG5_ARG_ppLs.\n");
-      return;
+      return 0;
     }
     i+=2;
   }
@@ -258,16 +258,16 @@ void MMGS_Init_mesh_fortran_var( void** arglist ) {
     fprintf(stderr,"\n  ## Error: %s: MMGS_Init_mesh:\n"
             " you need to initialize the mesh structure that"
             " will contain your mesh.\n",__func__);
-    return;
+    return 0;
   }
 
   /* allocations */
-  if ( !MMGS_Alloc_mesh(mesh,sol,ls) )  return;
+  if ( !MMGS_Alloc_mesh(mesh,sol,ls) )  return 0;
 
   /* initialisations */
   MMGS_Init_woalloc_mesh(*mesh,sol,ls);
 
-  return;
+  return 1;
 }
 
 /**
@@ -390,7 +390,7 @@ int MMGS_Free_all_var(va_list argptr)
  * Internal function for deallocations before return (taking a va_list as
  * argument).
  */
-void MMGS_Free_all_fortran_var(void** arglist)
+int MMGS_Free_all_fortran_var(void** arglist)
 {
 
   MMG5_pMesh     *mesh;
@@ -428,7 +428,7 @@ void MMGS_Free_all_fortran_var(void** arglist)
       fprintf(stderr," Argument type must be one of the following"
               " preprocessor variable: MMG5_ARG_ppMesh, MMG5_ARG_ppMet or "
               "MMG5_ARG_ppLs.\n");
-      return;
+      return 0;
     }
     i+=2;
   }
@@ -437,7 +437,7 @@ void MMGS_Free_all_fortran_var(void** arglist)
     fprintf(stderr,"\n  ## Error: %s: MMGS_Free_all:\n"
             " you need to provide your mesh structure"
             " to allow to free the associated memory.\n",__func__);
-    return;
+    return 0;
   }
 
   if ( metCount > 1 || lsCount > 1 || fieldsCount > 1 ) {
@@ -451,7 +451,7 @@ void MMGS_Free_all_fortran_var(void** arglist)
                              MMG5_ARG_ppMesh, mesh, MMG5_ARG_ppMet, sol,
                              MMG5_ARG_ppLs, ls,MMG5_ARG_ppSols, sols,
                              MMG5_ARG_end) )
-    return;
+    return 0;
 
   if ( sol )
     MMG5_SAFE_FREE(*sol);
@@ -462,7 +462,7 @@ void MMGS_Free_all_fortran_var(void** arglist)
 
   MMG5_SAFE_FREE(*mesh);
 
-  return;
+  return 1;
 }
 
 /**

--- a/src/mmgs/variadic_s.c
+++ b/src/mmgs/variadic_s.c
@@ -369,11 +369,11 @@ int MMGS_Free_all_var(va_list argptr)
 }
 
 /**
- * \param argptr list of the mmg structures that must be deallocated. Each
+ * \param arglist list of the mmg structures that must be deallocated. Each
  * structure must follow one of the \a MMG5_ARG preprocessor variable that allow to
  * identify it.
  *
- * \a argptr contains at least a pointer to a \a MMG5_pMesh structure
+ * \a arglist contains at least a pointer to a \a MMG5_pMesh structure
  * (that will contain the mesh and identified by the MMG5_ARG_ppMesh keyword).
  *
  *  To call the \a MMGS_mmgslib function, you must also provide
@@ -567,11 +567,11 @@ int MMGS_Free_structures_var(va_list argptr)
 }
 
 /**
- * \param argptr list of the mmg structures that must be deallocated. Each
+ * \param arglist list of the mmg structures that must be deallocated. Each
  * structure must follow one of the \a MMG5_ARG* preprocessor variable that allow
  * to identify it.
  *
- * \a argptr contains at least a pointer to a \a MMG5_pMesh structure
+ * \a arglist contains at least a pointer to a \a MMG5_pMesh structure
  * (that will contain the mesh and identified by the MMG5_ARG_ppMesh keyword).
  *
  *  To call the \a MMGS_mmgslib function, you must also provide
@@ -778,11 +778,11 @@ int MMGS_Free_names_var(va_list argptr)
 }
 
 /**
- * \param argptr list of the mmg structures for whose we want to deallocate the
+ * \param arglist list of the mmg structures for whose we want to deallocate the
  * name. Each structure must follow one of the \a MMG5_ARG preprocessor variable
  * that allow to identify it.
  *
- * \a argptr contains at least a pointer to a \a MMG5_pMesh
+ * \a arglist contains at least a pointer to a \a MMG5_pMesh
  * structure (that will contain the mesh and identified by the MMG5_ARG_ppMesh
  * keyword).
  *


### PR DESCRIPTION
This update is motivated by problems encountered when using variadic functions, such as `MMG3D_Init_mesh()` in Fortran on a ARM processor.
Up to now, the Fortran API did not provide interfaces for variadic functions, as such functions do not exist in Fortran.
In this update, variadic functions from the Fortran API have been removed. They have been replaced by functions holding the same name with a different prototype, using arrays of pointer of unknown length, allowing to mimic the behaviour of C variadic functions.
As a consequence, the typical use of these functions in Fortran as been modifed. As illustrated in the `libexamples`, functions should be called using the following syntax:
```
  CALL MMG3D_Init_mesh((/MMG5_ARG_start, &
       MMG5_ARG_ppMesh,LOC(mmgMesh),MMG5_ARG_ppMet,LOC(mmgSol), &
       MMG5_ARG_end/),ier)
```
where variadic arguments are passed through an array of `MMG5_DATA_PTR_T` elements. The `LOC()` function must be used to pass data by reference.
The perl script generating the Fortran interface has been modified in order to have consistency between both types of elements in the array: indicators such as `MMG5_ARG_start` should be interpreted as `INTEGER(kind=N)`, which correspond to the type `MMG5_DATA_PTR_T`.