### PR TITLE
Allow the 3d swapper to create tetrahedra with 4 boundary vertices when not in FEM mode

### DIFF
--- a/src/mmg3d/swapgen_3d.c
+++ b/src/mmg3d/swapgen_3d.c
@@ -207,7 +207,8 @@ MMG5_int MMG5_chkswpgen(MMG5_pMesh mesh,MMG5_pSol met,MMG5_int start,int ia,
       }
 
       /* Prevent from creating a tetra with 4 bdy vertices */
-      if ( mesh->point[np].tag & MG_BDY ) {
+      /* when the mesh is in FEM mode */
+      if ( mesh->info.fem && (mesh->point[np].tag & MG_BDY) ) {
         if ( ( mesh->point[pt->v[MMG5_ifar[i][0]]].tag & MG_BDY ) &&
              ( mesh->point[pt->v[MMG5_ifar[i][1]]].tag & MG_BDY ) ) {
           if ( ( mesh->point[pt->v[MMG5_iare[i][0]]].tag & MG_BDY ) ||


### PR DESCRIPTION
MMG5_chkswpgen() does not allow the creation of tetrahedra with 4 boundary vertices. I think this restriction should only  be made in FEM mode, just like the restriction on creating edges between boundary points is only made in FEM mode (further up in the same function) and anatet4() is only called in FEM mode.
I made this modification because we need it for the meshes we create for the MICROCARD project. These meshes have lots of internal boundaries, often with only one layer of tetrahedra between them, and we don't want to have more layers because the space is very thin. Thus it is perfectly normal to have tetrahedra with all of their vertices on either of two boundaries. The refusal of these swaps costs me a factor 5 in quality for the worst 10% of tetrahedra.
I wrote the change such that it makes minimal changes to the blame.
