### PR TITLE
Verify that input metric has strictly positive eigenvalues

### DIFF
--- a/src/mmg2d/inout_2d.c
+++ b/src/mmg2d/inout_2d.c
@@ -978,6 +978,21 @@ int MMG2D_loadSol(MMG5_pMesh mesh,MMG5_pSol sol,const char *filename) {
 
   fclose(inm);
 
+  /* For anisotropic metric, check that eigenvalues are stricly positive*/
+  if ( sol->size == 3 ) {
+    for (k=1; k<=sol->np; k++) {
+      double lambda[2],vp[2][2];
+      MMG5_eigensym(sol->m+3*k,lambda,vp);
+
+      if (!(lambda[0] > 0. && lambda[1] > 0.)) {
+        fprintf(stderr, "  ## Error: At least one negative eigenvalue in"
+                        " provided metric file : %lf %lf \n", lambda[0],
+                        lambda[1]);
+        return -1;
+      }
+    }
+  }
+
   /* stats */
   MMG5_printMetStats(mesh,sol);
 
@@ -1091,6 +1106,24 @@ int MMG2D_loadAllSols(MMG5_pMesh mesh,MMG5_pSol *sol, const char *filename) {
     }
   }
   fclose(inm);
+
+  /* For anisotropic metric, check that eigenvalues are stricly positive*/
+  for ( j=0; j<nsols; j++ ) {
+    psl = *sol+j;
+    if ( psl->size == 3 ) {
+      for ( k=1; k<=psl->np; k++ ) {
+        double lambda[2],vp[2][2];
+        MMG5_eigensym(psl->m+3*k,lambda,vp);
+
+        if (!(lambda[0] > 0. && lambda[1] > 0.)) {
+          fprintf(stderr, "  ## Error: At least one negative eigenvalue in"
+                          " provided metric file : %lf %lf \n", lambda[0],
+                          lambda[1]);
+          return -1;
+        }
+      }
+    }
+  }
 
   /* stats */
   MMG5_printSolStats(mesh,sol);

--- a/src/mmg3d/inout_3d.c
+++ b/src/mmg3d/inout_3d.c
@@ -2207,6 +2207,21 @@ int MMG3D_loadSol(MMG5_pMesh mesh,MMG5_pSol met, const char *filename) {
 
   fclose(inm);
 
+  /* For anisotropic metric, check that eigenvalues are stricly positive*/
+  if ( met->size == 3 ) {
+    for (k=1; k<=met->np; k++) {
+      double lambda[3],vp[3][3];
+      MMG5_eigenv3d(1,met->m+6*k,lambda,vp);
+
+      if (!(lambda[0] > 0. && lambda[1] > 0. && lambda[2] > 0.)) {
+        fprintf(stderr, "  ## Error: At least one negative eigenvalue in"
+                        " provided metric file : %lf %lf %lf \n", lambda[0],
+                        lambda[1], lambda[2]);
+        return -1;
+      }
+    }
+  }
+
   /* stats */
   MMG5_printMetStats(mesh,met);
 
@@ -2304,6 +2319,24 @@ int MMG3D_loadAllSols(MMG5_pMesh mesh,MMG5_pSol *sol, const char *filename) {
     }
   }
   fclose(inm);
+
+  /* For anisotropic metric, check that eigenvalues are stricly positive*/
+  for ( j=0; j<nsols; j++) {
+    psl = *sol + j;
+    if ( psl->size == 3 ) {
+      for (k=1; k<=psl->np; k++) {
+        double lambda[3],vp[3][3];
+        MMG5_eigenv3d(1,psl->m+6*k,lambda,vp);
+
+        if (!(lambda[0] > 0. && lambda[1] > 0. && lambda[2] > 0.)) {
+          fprintf(stderr, "  ## Error: At least one negative eigenvalue in"
+                          " provided metric file : %lf %lf %lf \n", lambda[0],
+                          lambda[1], lambda[2]);
+          return -1;
+        }
+      }
+    }
+  }
 
   /* stats */
   MMG5_printSolStats(mesh,sol);

--- a/src/mmg3d/inout_3d.c
+++ b/src/mmg3d/inout_3d.c
@@ -2208,7 +2208,7 @@ int MMG3D_loadSol(MMG5_pMesh mesh,MMG5_pSol met, const char *filename) {
   fclose(inm);
 
   /* For anisotropic metric, check that eigenvalues are stricly positive*/
-  if ( met->size == 3 ) {
+  if ( met->size == 6 ) {
     for (k=1; k<=met->np; k++) {
       double lambda[3],vp[3][3];
       MMG5_eigenv3d(1,met->m+6*k,lambda,vp);
@@ -2323,7 +2323,7 @@ int MMG3D_loadAllSols(MMG5_pMesh mesh,MMG5_pSol *sol, const char *filename) {
   /* For anisotropic metric, check that eigenvalues are stricly positive*/
   for ( j=0; j<nsols; j++) {
     psl = *sol + j;
-    if ( psl->size == 3 ) {
+    if ( psl->size == 6 ) {
       for (k=1; k<=psl->np; k++) {
         double lambda[3],vp[3][3];
         MMG5_eigenv3d(1,psl->m+6*k,lambda,vp);

--- a/src/mmgs/inout_s.c
+++ b/src/mmgs/inout_s.c
@@ -1378,6 +1378,21 @@ int MMGS_loadSol(MMG5_pMesh mesh,MMG5_pSol met,const char* filename) {
 
   fclose(inm);
 
+  /* For anisotropic metric, check that eigenvalues are stricly positive*/
+  if ( met->size == 3 ) {
+    for (k=1; k<=met->np; k++) {
+      double lambda[3],vp[3][3];
+      MMG5_eigenv3d(1,met->m+6*k,lambda,vp);
+
+      if (!(lambda[0] > 0. && lambda[1] > 0. && lambda[2] > 0.)) {
+        fprintf(stderr, "  ## Error: At least one negative eigenvalue in"
+                        " provided metric file : %lf %lf %lf \n", lambda[0],
+                        lambda[1], lambda[2]);
+        return -1;
+      }
+    }
+  }
+
   /* stats */
   MMG5_printMetStats(mesh,met);
 
@@ -1473,6 +1488,24 @@ int MMGS_loadAllSols(MMG5_pMesh mesh,MMG5_pSol *sol, const char *filename) {
     }
   }
   fclose(inm);
+
+  /* For anisotropic metric, check that eigenvalues are stricly positive*/
+  for ( j=0; j<nsols; j++) {
+    psl = *sol + j;
+    if ( psl->size == 3 ) {
+      for (k=1; k<=psl->np; k++) {
+        double lambda[3],vp[3][3];
+        MMG5_eigenv3d(1,psl->m+6*k,lambda,vp);
+
+        if (!(lambda[0] > 0. && lambda[1] > 0. && lambda[2] > 0.)) {
+          fprintf(stderr, "  ## Error: At least one negative eigenvalue in"
+                          " provided metric file : %lf %lf %lf \n", lambda[0],
+                          lambda[1], lambda[2]);
+          return -1;
+        }
+      }
+    }
+  }
 
   /* stats */
   MMG5_printSolStats(mesh,sol);

--- a/src/mmgs/inout_s.c
+++ b/src/mmgs/inout_s.c
@@ -1379,7 +1379,7 @@ int MMGS_loadSol(MMG5_pMesh mesh,MMG5_pSol met,const char* filename) {
   fclose(inm);
 
   /* For anisotropic metric, check that eigenvalues are stricly positive*/
-  if ( met->size == 3 ) {
+  if ( met->size == 6 ) {
     for (k=1; k<=met->np; k++) {
       double lambda[3],vp[3][3];
       MMG5_eigenv3d(1,met->m+6*k,lambda,vp);
@@ -1492,7 +1492,7 @@ int MMGS_loadAllSols(MMG5_pMesh mesh,MMG5_pSol *sol, const char *filename) {
   /* For anisotropic metric, check that eigenvalues are stricly positive*/
   for ( j=0; j<nsols; j++) {
     psl = *sol + j;
-    if ( psl->size == 3 ) {
+    if ( psl->size == 6 ) {
       for (k=1; k<=psl->np; k++) {
         double lambda[3],vp[3][3];
         MMG5_eigenv3d(1,psl->m+6*k,lambda,vp);


### PR DESCRIPTION
This update adds a computation of input metric eigenvalues after loading it to verify that they are strictly positive. If not, exit the code.
This is done for mmg3d, mmg2d and mmgs, for both versions of the API functions:
`MMG[3D/2D/S]_loadSol()`
and
`MMG[3D/2D/S]_loadAllSols()`

Tests have been made to ensure validity of the checks.