### PR TITLE
correction for MMG5_swapbin_int()

### DIFF
--- a/src/common/inout.c
+++ b/src/common/inout.c
@@ -57,6 +57,13 @@ int MMG5_swapbin(int sbin)
 /**
  * swap bytes if needed (conversion from big/little endian toward little/big
  * endian)
+ *
+ * NOTE this function is probably not useful for i/o because integer sizes
+ * in files are fixed and the size of MMG5_int is configurable; it is meant
+ * only for internal usage. This is perhaps some litter remaining from the
+ * interoduction of a configurable integer size. If it is ever needed, it
+ * should probably be MMG5_swapbin_int64(int64_t sbin).
+ *
  */
 MMG5_int MMG5_swapbin_int(MMG5_int sbin)
 {

--- a/src/common/inout.c
+++ b/src/common/inout.c
@@ -63,11 +63,11 @@ MMG5_int MMG5_swapbin_int(MMG5_int sbin)
   MMG5_int out;
   char     *p_in = (char *) &sbin;
   char     *p_out = (char *) &out;
-  int8_t   i;
+  int      i, Nbytes=sizeof(MMG5_int);
 
-  for(i=0;i<8;i++)
+  for(i=0;i<Nbytes;i++)
   {
-    p_out[i] = p_in[7-i];
+    p_out[i] = p_in[Nbytes-1-i];
   }
 
   return out;


### PR DESCRIPTION
This function can generate a compiler warning because it assumes MMG5_int is an 8-bytes type. The function was meant for i/o but is not used. I made it compile without warning and commented that for i/o purposes a function using MMG5_int (intended for internal use only) is probably not useful.
 