### PR TITLE
fix(mmgs): add LIBMMGS_EXPORT to MMGS_Get_triangleQuality declaration

### DIFF
--- a/src/mmgs/libmmgs.h
+++ b/src/mmgs/libmmgs.h
@@ -777,7 +777,7 @@ LIBMMGS_EXPORT int  MMGS_Set_normalAtVertex(MMG5_pMesh mesh, MMG5_int k, double 
  * >   END SUBROUTINE\n
  *
  */
-  double MMGS_Get_triangleQuality(MMG5_pMesh mesh, MMG5_pSol met, MMG5_int k);
+LIBMMGS_EXPORT double MMGS_Get_triangleQuality(MMG5_pMesh mesh, MMG5_pSol met, MMG5_int k);
 
 /**
  * \brief Set a single element of a scalar solution structure.


### PR DESCRIPTION
`MMGS_Get_triangleQuality` is missing `LIBMMGS_EXPORT` in `src/mmgs/libmmgs.h`. Every other API function in the header has it. Without it the symbol is not exported from `libMmgs.dll` on Windows, so downstream consumers of a prebuilt DLL (e.g. conda-forge `mmgsuite`) hit an unresolved external symbol.